### PR TITLE
Fix correctness, safety, and portability bugs in AntHocNet module

### DIFF
--- a/ns-allinone-2.34/ns-2.34/anthocnet/ahn_ant_nest.cc
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ahn_ant_nest.cc
@@ -210,6 +210,11 @@ Packet* AntNest::createAntHelloPacket()
 	struct hdr_ip* ih = HDR_IP(p); // ip header
 	AntHelloPacket* ah = HDR_AHN_HELLO(p); // ant header
 
+	// header memory is reused by NS-2 without running constructors: reset the
+	// list pointers before they are used so the NULL guards work correctly
+	ah->resetNodes();
+	ah->resetDestinations();
+
 #ifdef DEBUG
 	//fprintf(stderr, "sending Hello from %d at %.2f\n", index, Scheduler::instance().clock());
 #endif // DEBUG
@@ -227,7 +232,7 @@ Packet* AntNest::createAntHelloPacket()
 	for (; it != dest_table.end(); it++) {
 		double random = rand() / (RAND_MAX * 1.0);
 
-		if (dest_table.size() <= 10 || (random > 0.5 && ah->sizeNodes() < 10)) {
+		if (dest_table.size() <= 10 || (random > 0.5 && ah->sizeDests() < 10)) {
 			nsaddr_t dest = *it;
 			ah->addDestination(ANT_NODE(dest, 1.000));
 		}
@@ -269,6 +274,10 @@ Packet* AntNest::createAntBackPacket(Packet *pfw)
 	struct hdr_ip* ih = HDR_IP(pbk);
 	struct hdr_cmn* ch = HDR_CMN(pbk);
 	AntBackPacket* ah = (AntBackPacket*) AntBackPacket::access(pbk);
+
+	// reset header-resident list pointers before they are populated below
+	ah->resetNodes();
+	ah->resetHist();
 
 	ah->setAntType(ahfw->getAntType()); // set ant type as  Ant
 	ah->setAntDirection(ANT_DOWN); // set ant direction
@@ -320,6 +329,9 @@ Packet* AntNest::createAntForwardPacket(u_int8_t antType, nsaddr_t destination)
 	struct hdr_cmn* ch = HDR_CMN(p); // common header
 	struct hdr_ip* ih = HDR_IP(p); // ip header
 	AntForwardPacket* ah = (AntForwardPacket*) AntForwardPacket::access(p); // ant header
+
+	// reset header-resident list pointer before addToNodes() uses it
+	ah->resetNodes();
 
 	ah->setAntType(antType); // ant type
 	ah->setAntDirection(ANT_UP); // set ant direction

--- a/ns-allinone-2.34/ns-2.34/anthocnet/ahn_pheromone_table.cc
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ahn_pheromone_table.cc
@@ -9,8 +9,8 @@
 #include <math.h>
 
 #include "anthocnet/ant_types.h"
-#include "anthocnet/ahn_pheromone_table.h";
-#include "anthocnet/ahn_protocol_utils.h";
+#include "anthocnet/ahn_pheromone_table.h"
+#include "anthocnet/ahn_protocol_utils.h"
 
 /**
  * Method to add an entry in neighbor table.
@@ -121,10 +121,10 @@ double PheromoneTable::getPheromoneRegular(nsaddr_t destination, nsaddr_t neighb
  */
 double PheromoneTable::getPheromoneVirtual(nsaddr_t destination, nsaddr_t neighbor)
 {
-	MapNodePheromone_it iter = this->pheromone_regular.find(ANT_ENTRY(neighbor, destination));
+	MapNodePheromone_it iter = this->pheromone_virtual.find(ANT_ENTRY(neighbor, destination));
 
 	// destination entry exist in pheromone_table
-	if (iter != this->pheromone_regular.end()) {
+	if (iter != this->pheromone_virtual.end()) {
 		return (iter->second);
 	} else {
 		return 0;
@@ -282,11 +282,13 @@ nsaddr_t PheromoneTable::randomDestination() {
 	nsaddr_t dest = -1;
 
 	AntDestinations_it it;
-	int count = 1;
+	// uniform draw over the destination set: each entry has weight 1/size.
+	// (the previous code used integer division `count/size`, which is 0 for
+	// every entry except the last, so it never selected at random.)
+	const double step = 1.0 / size;
 
 	for (it = this->dest_table_regular.begin(); it != this->dest_table_regular.end(); it++) {
-		double value = (count++) / size;
-		random -= value;
+		random -= step;
 
 		dest = *it;
 

--- a/ns-allinone-2.34/ns-2.34/anthocnet/ahn_pheromone_table.h
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ahn_pheromone_table.h
@@ -115,7 +115,7 @@ class PheromoneTable
 		// Author Daniel Henrique Joppi 06/01/2009
 		inline bool hasNeighbor()
 		{
-			return (this->neighbor_table.empty() || this->neighbor_table.size()<=0);
+			return !this->neighbor_table.empty();
 		}
 
 		// Author Daniel Henrique Joppi 04/10/2011

--- a/ns-allinone-2.34/ns-2.34/anthocnet/ahn_protocol_utils.h
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ahn_protocol_utils.h
@@ -13,17 +13,20 @@
 class AntHocNetUtils
 {
 	public:
-		const static float ALFA = 0.7;
-		const static int BETA = 1;
-		const static float GAMA = 0.7;
+		// constexpr is required for in-class initialization of non-integral
+		// static members; plain `const static float` is ill-formed and is
+		// rejected as a hard error by modern compilers (g++ >= ~6).
+		static constexpr float ALFA = 0.7;
+		static constexpr int BETA = 1;
+		static constexpr float GAMA = 0.7;
 
-		const static int HOP_TIME = 50; //millisecond
+		static constexpr int HOP_TIME = 50; //millisecond
 
-		const static int PROACTIVE = 1;
-		const static int REACTIVE = 2;
-		const static int REPAIR = 3;
+		static constexpr int PROACTIVE = 1;
+		static constexpr int REACTIVE = 2;
+		static constexpr int REPAIR = 3;
 
-		const static double MIN_PHEROMONE = 0.00001;
+		static constexpr double MIN_PHEROMONE = 0.00001;
 };
 
 #endif /* _ahn_protocol_utils_ */

--- a/ns-allinone-2.34/ns-2.34/anthocnet/ahn_router.cc
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ahn_router.cc
@@ -213,9 +213,10 @@ void AntHocNet::recv(Packet *p, Handler *h)
 	// recieved packet is an Ant packet
 	if (ch->ptype() == PT_ANT)
 	{
-		// call method to handle ant packet
+		// call method to handle ant packet. TTL was already decremented above
+		// for forwarded packets; recvAHN() may forward/free p, so do not touch
+		// the (possibly in-flight) header here again.
 		recvAHN(p);
-		ih->ttl_ -= 1;
 	}
 	// if not Ant packet, forward
 	else
@@ -268,7 +269,7 @@ void AntHocNet::recvAHN(Packet *p)
 		if (nb_timer_list.find(node) != nb_timer_list.end()) {
 			nb_timer_list.erase(node);
 		}
-		nb_timer_list.insert(std::make_pair<nsaddr_t, double>(node, CURRENT_TIME));
+		nb_timer_list.insert(std::make_pair(node, (double) CURRENT_TIME));
 
 
 		// initialize equal pheromone value to all neighbor links
@@ -842,7 +843,7 @@ void AntHocNet::sendPRFA()
 void AntHocNet::sendPRFA(nsaddr_t destination) {
 #ifndef ANT_LINK_LAYER_DETECTION
 	// generate next hop as per AntHocNet algorithm
-	nsaddr_t next = this->ant_nest_->pheromoneTable()->nextNeighborNode(next, true);
+	nsaddr_t next = this->ant_nest_->pheromoneTable()->nextNeighborNode(destination, true);
 #endif
 
 	Packet* p = this->ant_nest_->createAntForwardPacket(ANTTYPEPROACTIVE, destination);
@@ -1211,12 +1212,13 @@ void AntHocNet::printNeighbors()
 	//fprintf(stdout, "node id: %d\tnode address: %d\n", n->nodeid(), n->address());
 	//fprintf(stdout, "Neighbors:\n");
 	neighbor_list_node* nb = n->neighbor_list_;
-	do
+	// guard against an empty neighbor list (do/while dereferenced nb first)
+	while (nb != NULL)
 	{
 		int neigh = nb->nodeid;
 		//printf("%d\n", neigh);
 		nb = nb->next;
-	} while (nb != NULL);
+	}
 }
 
 /*
@@ -1266,7 +1268,7 @@ void AntHocNet::recvAntHello(Packet *p)
 	if (nb_timer_list.find(node) != nb_timer_list.end()) {
 		nb_timer_list.erase(node);
 	}
-	nb_timer_list.insert(std::make_pair<nsaddr_t, double>(node, CURRENT_TIME));
+	nb_timer_list.insert(std::make_pair(node, (double) CURRENT_TIME));
 
 
 	// initialize equal pheromone value to all neighbor links

--- a/ns-allinone-2.34/ns-2.34/anthocnet/ant_packet.cc
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ant_packet.cc
@@ -55,7 +55,8 @@ AntTimeEntry* AntBasicPacket::pop_back() {
 		return NULL;
 	}
 
-	AntTimeEntry* entry = visitedNodes[sizeNodes_--];
+	// valid indices are 0 .. sizeNodes_-1, so decrement first
+	AntTimeEntry* entry = visitedNodes[--sizeNodes_];
 	return entry;
 }
 
@@ -66,7 +67,10 @@ int AntBasicPacket::size()
 	sz += sizeof(u_int8_t);
 	sz += sizeof(u_int8_t);
 
-	sz += sizeof(visitedNodes);
+	// the ant carries its visited-node stack over the air: each entry is a
+	// node address plus a timestamp, so model the size from the entry count
+	// (not sizeof(pointer), which was a fixed 8 bytes regardless of path length)
+	sz += sizeNodes_ * (sizeof(nsaddr_t) + sizeof(double));
 
 	sz += sizeof(nsaddr_t);
 	sz += sizeof(nsaddr_t);
@@ -153,7 +157,8 @@ int AntBackPacket::size()
 {
 	int sz = AntBasicPacket::size();
 	sz += sizeof(nsaddr_t);
-	sz += sizeof(visitedNodesHist);
+	// history stack, same per-entry cost as the visited-node stack above
+	sz += sizeNodesHist_ * (sizeof(nsaddr_t) + sizeof(double));
 	sz += sizeof(int);
 	sz += sizeof(int);
 	sz += sizeof(double);

--- a/ns-allinone-2.34/ns-2.34/anthocnet/ant_packet.h
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ant_packet.h
@@ -106,6 +106,16 @@ class AntBasicPacket
 			sizeNodes_ = size;
 		}
 
+		// Initialize the (header-resident) visited-node list. NS-2 pools and
+		// reuses packet header memory without running C++ constructors, so the
+		// list pointer holds garbage until it is explicitly reset. Every factory
+		// method must call this before the list is used, otherwise the
+		// "visitedNodes == NULL" guards in ant_packet.cc test stale bytes.
+		void resetNodes() {
+			visitedNodes = NULL;
+			sizeNodes_ = 0;
+		}
+
 		void addToNodes(AntTimeEntry* entry);
 
 		AntTimeEntry* pop_back();
@@ -222,6 +232,13 @@ class AntHelloPacket:
 			sizeDests_ = size;
 		}
 
+		// See AntBasicPacket::resetNodes(): the destinations list pointer is also
+		// header-resident and must be reset before use.
+		void resetDestinations() {
+			destinations = NULL;
+			sizeDests_ = 0;
+		}
+
 		void addDestination(AntNode* destination);
 
 		/**
@@ -311,6 +328,13 @@ class AntBackPacket:
 		// cycleNode Lists
 		int sizeNodesHist() {
 			return sizeNodesHist_;
+		}
+
+		// See AntBasicPacket::resetNodes(): the history list pointer is also
+		// header-resident and must be reset before use.
+		void resetHist() {
+			visitedNodesHist = NULL;
+			sizeNodesHist_ = 0;
 		}
 
 		// Method to find next neighbor visited by ant forward

--- a/ns-allinone-2.34/ns-2.34/anthocnet/ant_types.h
+++ b/ns-allinone-2.34/ns-2.34/anthocnet/ant_types.h
@@ -21,7 +21,9 @@ class Packet;
 
 struct ant_node_less_adapter
 {
-	bool operator() (const nsaddr_t lhs, const nsaddr_t rhs)
+	// must be const: std::set comparators are invoked through a const
+	// reference, which modern libstdc++ enforces with a static_assert.
+	bool operator() (const nsaddr_t lhs, const nsaddr_t rhs) const
 	{
 	   return lhs < rhs;
 	}
@@ -29,7 +31,7 @@ struct ant_node_less_adapter
 
 struct ant_dest_less_adapter
 {
-	bool operator() (const nsaddr_t lhs, const nsaddr_t rhs)
+	bool operator() (const nsaddr_t lhs, const nsaddr_t rhs) const
 	{
 	   return lhs < rhs;
 	}


### PR DESCRIPTION
Reviewed the legacy AntHocNet (NS-2.34) implementation and fixed a set of
bugs. The module now compiles cleanly on a modern toolchain (g++ 13), which
it did not before.

Portability (previously hard compile errors on modern g++):
- ant_types.h: make set comparators' operator() const (libstdc++ requires
  comparators to be invocable as const).
- ahn_protocol_utils.h: use `static constexpr` for non-integral static
  constants; in-class init of `const static float/double` is ill-formed.

Memory-safety / data corruption:
- ant_packet.{h,cc}, ahn_ant_nest.cc: reset header-resident list pointers
  (visitedNodes / visitedNodesHist / destinations) in every packet factory.
  NS-2 reuses header memory without running constructors, so the NULL guards
  were testing stale bytes (undefined behavior). Added resetNodes/resetHist/
  resetDestinations and call them when creating forward/back/hello ants.
- ant_packet.cc: pop_back() read one element past the end of the stack;
  decrement before indexing.

Correctness:
- ahn_pheromone_table.cc: getPheromoneVirtual() queried the regular table
  instead of the virtual table.
- ahn_pheromone_table.cc: randomDestination() used integer division
  (count/size == 0 for all but the last entry), so it never selected at
  random; use a uniform 1/size step.
- ahn_pheromone_table.h: hasNeighbor() returned true when the table was
  empty (inverted).
- ahn_ant_nest.cc: hello-ant destination cap checked sizeNodes() instead of
  sizeDests().
- ahn_router.cc: recv() decremented an ant packet's TTL twice (once in the
  shared path, once again after recvAHN); removed the second, which also
  mutated an already-forwarded header.
- ahn_router.cc: sendPRFA(dest) passed an uninitialized `next` to
  nextNeighborNode() instead of the destination.

Modeling / robustness / portability cleanups:
- ant_packet.cc: model ant packet size from the visited/history entry counts
  instead of sizeof(pointer).
- ahn_router.cc: printNeighbors() used a do/while that dereferenced a possibly
  NULL neighbor list; guard with while.
- ahn_router.cc: drop explicit template args from std::make_pair (breaks on
  modern compilers).
- ahn_pheromone_table.cc: remove stray semicolons after #include directives.

Note: scenarios still require integration wiring (ns-lib.tcl routing-agent
case and ns-default.tcl binding defaults) that lives in the full ns-allinone
tree, not in this partial repo snapshot.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LYatkKbPeHGb9inrZ7TmTh