### PR TITLE
Portable, patch-only refactor: shared core + NS-2 and NS-3 adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,25 +25,24 @@ jobs:
         run: bash ns2/patch/selftest.sh
 
   ns3-build:
-    name: NS-3 module build (optional)
+    name: NS-3 module build + test
     runs-on: ubuntu-latest
-    # Heavy (fetches + builds ns-3). Run manually via the Actions tab.
-    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - name: Install toolchain
         run: sudo apt-get update && sudo apt-get install -y cmake g++ python3 ninja-build
-      - name: Fetch ns-3
+      - name: Fetch ns-3 (pinned release)
         run: |
-          git clone --depth 1 https://gitlab.com/nsnam/ns-3-dev.git ns-3-dev
+          git clone --depth 1 --branch ns-3.42 https://gitlab.com/nsnam/ns-3-dev.git ns-3
       - name: Install AntHocNet module
-        run: make install-ns3 NS3DIR="$PWD/ns-3-dev"
-      - name: Configure and build
+        run: make install-ns3 NS3DIR="$PWD/ns-3"
+      - name: Configure (minimal module set)
         run: |
-          cd ns-3-dev
-          ./ns3 configure --enable-examples --enable-tests
-          ./ns3 build anthocnet
-      - name: Run module tests
-        run: |
-          cd ns-3-dev
-          ./test.py -s anthocnet || true
+          cd ns-3
+          ./ns3 configure --enable-modules='anthocnet;wifi;mobility;applications' --enable-examples --enable-tests
+      - name: Build
+        run: cd ns-3 && ./ns3 build
+      - name: Run module test suite
+        run: cd ns-3 && ./test.py -s anthocnet
+      - name: Smoke-run the example
+        run: cd ns-3 && ./ns3 run anthocnet-example

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(ANTHOCNET_TESTS
   test_ant_history
   test_codec
   test_router_logic
+  test_network_integration
 )
 
 foreach(test ${ANTHOCNET_TESTS})

--- a/core/tests/test_network_integration.cpp
+++ b/core/tests/test_network_integration.cpp
@@ -1,0 +1,108 @@
+/*
+ * End-to-end integration test: drive AntRouterLogic through a real multi-hop
+ * route discovery using a tiny in-memory "network", with no simulator.
+ *
+ * Topology is a line  0 - 1 - 2 - 3.  Node 0 wants to reach node 3 and has no
+ * route, so it floods a reactive forward ant; the ant reaches 3, a backward
+ * ant retraces and reinforces the path, and afterwards every node on the path
+ * has a unicast route toward 3. This exercises the forward-ant flooding,
+ * (src,seq) dedup, neighbour learning, back-ant construction/advance, and
+ * pheromone reinforcement all working together.
+ */
+#include <deque>
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "anthocnet/core/ant_router_logic.h"
+#include "test_support.h"
+
+using namespace anthocnet::core;
+using anthocnet::test::FakeClock;
+using anthocnet::test::ScriptedRng;
+
+namespace {
+
+struct Network {
+    FakeClock clock;
+    std::vector<std::unique_ptr<ScriptedRng>> rngs;
+    std::vector<std::unique_ptr<AntRouterLogic>> nodes;
+    std::map<int, std::set<int>> adj;  // physical adjacency
+
+    struct Event {
+        int to;
+        AntMessage msg;
+        int prevHop;
+    };
+    std::deque<Event> queue;
+    bool delivered = false;  // a back ant reached its origin
+
+    void addNode(int addr, const Config& cfg) {
+        rngs.push_back(std::unique_ptr<ScriptedRng>(new ScriptedRng({0.5})));
+        nodes.push_back(std::unique_ptr<AntRouterLogic>(
+            new AntRouterLogic(addr, cfg, clock, *rngs.back())));
+    }
+
+    void link(int a, int b) { adj[a].insert(b); adj[b].insert(a); }
+
+    void dispatch(int from, const std::vector<RouteDecision>& decisions) {
+        for (const RouteDecision& d : decisions) {
+            switch (d.action) {
+                case RouteAction::Unicast:
+                    queue.push_back({d.nextHop, d.message, from});
+                    break;
+                case RouteAction::Broadcast:
+                    for (int nb : adj[from]) queue.push_back({nb, d.message, from});
+                    break;
+                case RouteAction::Deliver:
+                    delivered = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    void run(int maxSteps = 1000) {
+        int steps = 0;
+        while (!queue.empty() && steps++ < maxSteps) {
+            Event e = queue.front();
+            queue.pop_front();
+            dispatch(e.to, nodes[e.to]->onReceiveAnt(e.msg, e.prevHop));
+        }
+    }
+};
+
+} // namespace
+
+int main() {
+    Config cfg;
+    Network net;
+    for (int i = 0; i < 4; ++i) net.addNode(i, cfg);
+    net.link(0, 1);
+    net.link(1, 2);
+    net.link(2, 3);
+
+    // Node 0 has data for node 3 but no route: it queues and floods a REFA.
+    net.dispatch(0, net.nodes[0]->onDataPacket(/*dest*/ 3));
+    net.run();
+
+    // A backward ant made it home.
+    CHECK(net.delivered);
+
+    // Every node on the path now has a unicast route toward 3.
+    CHECK_EQ(net.nodes[0]->selectNextHop(3, /*proactive=*/false), 1);
+    CHECK_EQ(net.nodes[1]->selectNextHop(3, /*proactive=*/false), 2);
+    CHECK_EQ(net.nodes[2]->selectNextHop(3, /*proactive=*/false), 3);
+
+    // A second data packet at node 0 is now routed immediately (no flood).
+    {
+        auto decisions = net.nodes[0]->onDataPacket(3);
+        CHECK_EQ(decisions.size(), static_cast<std::size_t>(1));
+        CHECK(decisions[0].action == RouteAction::Unicast);
+        CHECK_EQ(decisions[0].nextHop, 1);
+    }
+
+    return RUN_TESTS();
+}

--- a/ns2/patch/apply-patch.sh
+++ b/ns2/patch/apply-patch.sh
@@ -42,6 +42,15 @@ require_anchor() {
     grep -qE "$2" "$1" || die "anchor not found in $1 : /$2/"
 }
 
+# Translate a POSIX [[:space:]] class to [ \t] for awk. GNU grep/sed accept
+# [[:space:]], but the mawk shipped on some systems (e.g. older Ubuntu) does
+# not and silently fails to match -- so every pattern handed to awk goes
+# through this first. awk natively reads \t as a tab; grep -E does not, which
+# is why the call sites keep [[:space:]] for the grep-based anchor checks.
+awk_re() {
+    printf '%s' "${1//\[\[:space:\]\]/[ \\t]}"
+}
+
 # Insert FRAGMENT (a file) immediately AFTER the first line matching REGEX,
 # wrapped in comment markers. Idempotent: a no-op if the marker is already
 # present. COMMENT is the line-comment token ("//" or "#").
@@ -55,7 +64,7 @@ insert_after_marked() {
     require_anchor "$file" "$regex"
 
     local tmp; tmp="$(mktemp)"
-    awk -v rx="$regex" -v frag="$fragfile" -v c="$comment" \
+    awk -v rx="$(awk_re "$regex")" -v frag="$fragfile" -v c="$comment" \
         -v b="$BEGIN" -v e="$END" -v tag="$tag" '
         { print }
         $0 ~ rx && !done {
@@ -99,7 +108,7 @@ insert_before_unmarked() {
     require_anchor "$file" "$regex"
 
     local tmp; tmp="$(mktemp)"
-    awk -v rx="$regex" -v frag="$fragfile" '
+    awk -v rx="$(awk_re "$regex")" -v frag="$fragfile" '
         $0 ~ rx && !done {
             while ((getline line < frag) > 0) print line
             close(frag)
@@ -123,7 +132,7 @@ insert_after_unmarked() {
     require_anchor "$file" "$regex"
 
     local tmp; tmp="$(mktemp)"
-    awk -v rx="$regex" -v frag="$fragfile" '
+    awk -v rx="$(awk_re "$regex")" -v frag="$fragfile" '
         { print }
         $0 ~ rx && !done {
             while ((getline line < frag) > 0) print line
@@ -154,15 +163,16 @@ else
     tmp="$(mktemp)"
     awk -v n="$N" -v nxt="$NEXT" -v b="$BEGIN" -v e="$END" '
         # Insert PT_ANT just before the PT_NTYPE definition and renumber it.
-        /static[[:space:]]+packet_t[[:space:]]+PT_NTYPE[[:space:]]*=/ && !pdone {
+        # (awk reads \t as a tab; POSIX classes are avoided for old-mawk.)
+        /static[ \t]+packet_t[ \t]+PT_NTYPE[ \t]*=/ && !pdone {
             print "// " b " packet.h"
             print "static const packet_t PT_ANT = " n ";"
             print "// " e " packet.h"
-            sub(/=[[:space:]]*[0-9]+/, "= " nxt)
+            sub(/=[ \t]*[0-9]+/, "= " nxt)
             pdone = 1
         }
         # Early ROUTING classification for PT_ANT, before the DSR/AODV block.
-        /if[[:space:]]*\([[:space:]]*type[[:space:]]*==[[:space:]]*PT_DSR/ && !cdone {
+        /if[ \t]*\([ \t]*type[ \t]*==[ \t]*PT_DSR/ && !cdone {
             print "\t\t// " b " packet.h-class"
             print "\t\tif (type == PT_ANT) return ROUTING;"
             print "\t\t// " e " packet.h-class"
@@ -170,7 +180,7 @@ else
         }
         { print }
         # Printable name, right after the AODV name entry.
-        /name_\[PT_AODV\][[:space:]]*=/ && !ndone {
+        /name_\[PT_AODV\][ \t]*=/ && !ndone {
             print "\t\t// " b " packet.h-name"
             print "\t\tname_[PT_ANT] = \"AntHocNet\";"
             print "\t\t// " e " packet.h-name"

--- a/ns2/patch/apply-patch.sh
+++ b/ns2/patch/apply-patch.sh
@@ -42,13 +42,20 @@ require_anchor() {
     grep -qE "$2" "$1" || die "anchor not found in $1 : /$2/"
 }
 
-# Translate a POSIX [[:space:]] class to [ \t] for awk. GNU grep/sed accept
-# [[:space:]], but the mawk shipped on some systems (e.g. older Ubuntu) does
-# not and silently fails to match -- so every pattern handed to awk goes
-# through this first. awk natively reads \t as a tab; grep -E does not, which
-# is why the call sites keep [[:space:]] for the grep-based anchor checks.
+# Make an ERE safe to pass to awk via -v. Two portability hazards with the
+# mawk found on some systems (e.g. older Ubuntu / GitHub runners):
+#   1. it lacks POSIX classes -> translate [[:space:]] to [ \t] (awk reads \t
+#      as a tab);
+#   2. `awk -v` runs the value through C-string escape processing FIRST, which
+#      strips the backslash from regex escapes like \( \. \{ \$ (mawk warns
+#      "escape sequence treated as plain" and a bare ( is then a fatal
+#      "unmatched (") -> double every backslash so one survives that stage.
+# Order matters: double backslashes first, THEN introduce the single-backslash
+# \t for the space class (which is meant to collapse to a tab).
+# GNU grep/sed accept [[:space:]] directly, so the grep-based anchor checks at
+# the call sites keep using the original [[:space:]] form.
 awk_re() {
-    printf '%s' "${1//\[\[:space:\]\]/[ \\t]}"
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/\[\[:space:\]\]/[ \\t]/g'
 }
 
 # Insert FRAGMENT (a file) immediately AFTER the first line matching REGEX,

--- a/ns2/patch/revert-patch.sh
+++ b/ns2/patch/revert-patch.sh
@@ -27,13 +27,19 @@ strip_markers() {
     mv "$tmp" "$file"
 }
 
+# Translate a POSIX [[:space:]] class to [ \t] for awk (old mawk lacks the
+# POSIX class). See apply-patch.sh:awk_re.
+awk_re() {
+    printf '%s' "${1//\[\[:space:\]\]/[ \\t]}"
+}
+
 # Delete a contiguous block: the line matching START_RE through the first
 # following line matching END_RE (inclusive). Only the first such block.
 delete_block() {
     local file="$1" start_re="$2" end_re="$3"
     [[ -f "$file" ]] || return 0
     local tmp; tmp="$(mktemp)"
-    awk -v s="$start_re" -v e="$end_re" '
+    awk -v s="$(awk_re "$start_re")" -v e="$(awk_re "$end_re")" '
         !inblock && $0 ~ s && !done { inblock = 1; next }
         inblock { if ($0 ~ e) { inblock = 0; done = 1 } ; next }
         { print }

--- a/ns2/patch/revert-patch.sh
+++ b/ns2/patch/revert-patch.sh
@@ -27,10 +27,10 @@ strip_markers() {
     mv "$tmp" "$file"
 }
 
-# Translate a POSIX [[:space:]] class to [ \t] for awk (old mawk lacks the
-# POSIX class). See apply-patch.sh:awk_re.
+# Make an ERE safe to pass to awk via -v (old mawk lacks POSIX classes and runs
+# -v values through string-escape processing). See apply-patch.sh:awk_re.
 awk_re() {
-    printf '%s' "${1//\[\[:space:\]\]/[ \\t]}"
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/\[\[:space:\]\]/[ \\t]/g'
 }
 
 # Delete a contiguous block: the line matching START_RE through the first

--- a/ns3/examples/anthocnet-example.cc
+++ b/ns3/examples/anthocnet-example.cc
@@ -23,7 +23,10 @@ NS_LOG_COMPONENT_DEFINE("AntHocNetExample");
 int main(int argc, char* argv[]) {
     uint32_t nNodes = 10;
     double simTime = 20.0;
-    double areaSize = 500.0;
+    // Keep the area small enough that nodes are within the default YansWifi
+    // range (~50 m) and form a connected multi-hop mesh; a larger area simply
+    // partitions the network and nothing (any protocol) is delivered.
+    double areaSize = 100.0;
 
     CommandLine cmd(__FILE__);
     cmd.AddValue("nNodes", "Number of nodes", nNodes);

--- a/ns3/helper/anthocnet-helper.cc
+++ b/ns3/helper/anthocnet-helper.cc
@@ -1,8 +1,10 @@
 #include "anthocnet-helper.h"
 
 #include "ns3/anthocnet-routing-protocol.h"
+#include "ns3/node.h"
 #include "ns3/node-list.h"
 #include "ns3/names.h"
+#include "ns3/ipv4.h"
 #include "ns3/ipv4-list-routing.h"
 
 namespace ns3 {

--- a/ns3/helper/anthocnet-helper.h
+++ b/ns3/helper/anthocnet-helper.h
@@ -7,6 +7,7 @@
 
 #include "ns3/ipv4-routing-helper.h"
 #include "ns3/object-factory.h"
+#include "ns3/node-container.h"
 
 namespace ns3 {
 

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -91,6 +91,10 @@ void RoutingProtocol::DoDispose() {
         kv.first->Close();
     }
     m_socketAddresses.clear();
+    for (auto& kv : m_socketSubnetBroadcast) {
+        kv.first->Close();
+    }
+    m_socketSubnetBroadcast.clear();
     m_logic.reset();
     Ipv4RoutingProtocol::DoDispose();
 }
@@ -135,6 +139,18 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
     socket->SetIpRecvTtl(true);
     m_socketAddresses[socket] = iface;
 
+    // Second socket bound to the subnet-broadcast address so this interface
+    // actually receives the broadcast hello / forward ants.
+    Ptr<Socket> bcast = Socket::CreateSocket(GetObject<Node>(),
+                                             UdpSocketFactory::GetTypeId());
+    NS_ASSERT(bcast);
+    bcast->SetRecvCallback(MakeCallback(&RoutingProtocol::RecvAnt, this));
+    bcast->BindToNetDevice(l3->GetNetDevice(interface));
+    bcast->Bind(InetSocketAddress(iface.GetBroadcast(), ANT_PORT));
+    bcast->SetAllowBroadcast(true);
+    bcast->SetIpRecvTtl(true);
+    m_socketSubnetBroadcast[bcast] = iface;
+
     Start();
 }
 
@@ -144,6 +160,13 @@ void RoutingProtocol::NotifyInterfaceDown(uint32_t interface) {
     if (socket) {
         socket->Close();
         m_socketAddresses.erase(socket);
+    }
+    for (auto it = m_socketSubnetBroadcast.begin(); it != m_socketSubnetBroadcast.end(); ++it) {
+        if (it->second == iface) {
+            it->first->Close();
+            m_socketSubnetBroadcast.erase(it);
+            break;
+        }
     }
 }
 
@@ -210,7 +233,6 @@ bool RoutingProtocol::RouteInput(Ptr<const Packet> p, const Ipv4Header& header,
     if (!m_logic || m_socketAddresses.empty()) return false;
 
     Ipv4Address dst = header.GetDestination();
-    Ipv4Address origin = header.GetSource();
 
     // Locally destined?
     int32_t iif = m_ipv4->GetInterfaceForDevice(idev);

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -87,7 +87,12 @@ private:
 
     // state
     Ptr<Ipv4> m_ipv4;
+    // Per-interface sockets: one bound to the unicast address (receives
+    // unicast ants), one bound to the subnet-broadcast address (receives
+    // broadcast hello/forward ants). A socket bound only to the unicast
+    // address does NOT receive broadcasts, so both are required.
     std::map<Ptr<Socket>, Ipv4InterfaceAddress> m_socketAddresses;
+    std::map<Ptr<Socket>, Ipv4InterfaceAddress> m_socketSubnetBroadcast;
 
     ::anthocnet::core::Config m_config;
     Ns3Clock m_clock;

--- a/ns3/test/anthocnet-test-suite.cc
+++ b/ns3/test/anthocnet-test-suite.cc
@@ -35,15 +35,17 @@ public:
         m.helloDests = {{8, 1.0}, {9, 0.5}};
 
         Ptr<Packet> packet = Create<Packet>();
-        anthocnet::AntHeader out(m);
+        ns3::anthocnet::AntHeader out(m);
         packet->AddHeader(out);
 
-        anthocnet::AntHeader in;
+        ns3::anthocnet::AntHeader in;
         packet->RemoveHeader(in);
         const AntMessage& r = in.Message();
 
-        NS_TEST_ASSERT_MSG_EQ(r.type == AntType::Proactive, true, "type");
-        NS_TEST_ASSERT_MSG_EQ(r.direction == AntDirection::Down, true, "direction");
+        NS_TEST_ASSERT_MSG_EQ(static_cast<int>(r.type),
+                              static_cast<int>(AntType::Proactive), "type");
+        NS_TEST_ASSERT_MSG_EQ(static_cast<int>(r.direction),
+                              static_cast<int>(AntDirection::Down), "direction");
         NS_TEST_ASSERT_MSG_EQ(r.src, 3, "src");
         NS_TEST_ASSERT_MSG_EQ(r.dst, 17, "dst");
         NS_TEST_ASSERT_MSG_EQ(r.seqNum, 70000u, "seqNum");


### PR DESCRIPTION
## Summary

Turns the repo from a whole vendored `ns-allinone-2.34` snapshot into a lean, patch-only project: one **simulator-agnostic algorithm core** with thin adapters for **NS-2** and **NS-3**. No copy of any simulator ships in the repo — you install AntHocNet onto your own tree.

```
core/   simulator-agnostic C++ (no NS-2/NS-3 deps) + unit tests
ns2/    thin Agent adapter + anchor-based source-patch installer
ns3/    native Ipv4RoutingProtocol module
docs/   architecture + porting notes
```

The repository went from thousands of vendored files to ~110 tracked files.

## What changed, by phase

- **Phase 0** — Move the AntHocNet sources/tcl out, capture every NS-2 integration delta as patch fragments (including the OTcl edits reconstructed from `gen/ns_tcl.cc`), then `git rm` the entire bundled simulator.
- **Phase 1** — `core/` library: POD `AntMessage` + `VisitedPath` vector (replacing the header-resident malloc'd pointer arrays), `PheromoneTable`/`PheromoneEngine`, `AntHistoryTracker`, `AntRouterLogic → RouteDecision`, and the `IClock`/`IRng`/`INeighborProvider`/`ITimerScheduler` ports.
- **Phase 2** — Thin NS-2 `Agent`, POD packet header, port impls, and a Makefile-driven, **idempotent, anchor-based** `apply-patch.sh` / `revert-patch.sh` with dynamically-assigned `PT_ANT`.
- **Phase 3** — Native NS-3 `Ipv4RoutingProtocol` module: `ns3::Header` serializer, request queue, helper, example, test suite, `CMakeLists.txt` (ns-3.36+) and `wscript` (older waf), installed additively into `contrib/anthocnet`.
- **Phase 4** — Root + per-target READMEs, `docs/architecture.md`, `docs/porting-notes.md`, and CI.

## Bugs fixed during extraction (core / NS-2)

- **Header-resident heap pointers** — the original packet header stored malloc'd `AntTimeEntry**` arrays; NS-2 pools and byte-copies header memory, so broadcasting double-freed, leaked, and reported the wrong serialized size. Replaced by value types.
- **Evaporation aged the wrong link** — competing links never decayed because `updateRegularPheromone` operated on the travelled link instead of the iterated one.
- **8-bit sequence number** wrapped after 256 ants (aliasing `(src,seq)` dedup); widened to 32-bit.
- **Unbounded dedup set** — now FIFO-capped.
- **`randomDestination` never randomised** (integer-division bug) — now a proper uniform draw.

## Bugs fixed by actually building/running the NS-3 module

The NS-3 module was first written without a compiler; building it against a real **ns-3.42** tree (and now in CI) surfaced and fixed:

- **No broadcast reception** — each node bound only a unicast UDP socket, so it never received the broadcast hello / forward ants → no neighbours learned → nothing routed (delivery was 0). Fixed by binding a second socket to the subnet-broadcast address (the AODV pattern). Single-hop and multi-hop delivery both work now.
- **Helper missing includes** (`NodeContainer` / `Node` / `Ipv4` incomplete types).
- **Test suite** — qualified `ns3::anthocnet::AntHeader` (ambiguous against the core `::anthocnet` namespace under `using namespace ns3`) and compared the enums via their underlying int.
- **Example out of range** — the 500 m area partitioned the network (any protocol delivers 0); tightened to ~100 m so nodes form a connected mesh.

## Validation — all green in CI on every push

- ✅ **core**: builds standalone (CMake, C++14) and **6 ctest suites pass** — pheromone selection, reinforcement decay, history dedup/eviction, codec round-trip, routing decisions, and an end-to-end multi-hop route-discovery integration test driven through an in-memory network.
- ✅ **NS-2 patch**: validated against a synthetic ns-2 tree — apply is idempotent, the patched `Makefile.in` stays valid, revert restores byte-for-byte. Hardened for portability across `mawk` versions (POSIX classes and `awk -v` escape handling).
- ✅ **NS-3 module**: CI fetches pinned **ns-3.42**, installs the module, configures, **builds**, runs `./test.py -s anthocnet`, and smoke-runs the example. Locally verified that a 3-node line **delivers data over two hops** (forward ant floods → back ant retraces → route installed), and the example delivers across seeds.

> Metric parity between the NS-2 and NS-3 builds is not claimed — the MAC/PHY models differ. Treat cross-simulator comparison as re-validation, not a bit-for-bit port.

## How to use

```bash
make test                                    # build + run core unit tests
make install-ns2  NS2DIR=/path/to/ns-2.3x    # patch + recompile NS-2
make install-ns3  NS3DIR=/path/to/ns-3-dev   # drop-in contrib module
```

See [README.md](README.md), [ns2/README.md](ns2/README.md), [ns3/README.md](ns3/README.md), and [docs/](docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)