### PR TITLE
docs: add CONTEXT, AGENTS, and ADRs for the core/adapters architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md — guide for AI coding agents
+
+Operational guide for LLM agents working in this repository. Read this plus
+[`CONTEXT.md`](CONTEXT.md) before changing anything. Design detail lives in
+[`docs/architecture.md`](docs/architecture.md), maintenance detail in
+[`docs/porting-notes.md`](docs/porting-notes.md), and the rationale behind the
+structure in the [ADRs](docs/adr/).
+
+## What this repo is
+
+AntHocNet — an ant-colony-optimization MANET routing protocol — implemented
+**once** as a simulator-agnostic algorithm core, with thin adapters for **NS-2**
+and **NS-3**. The repo does **not** vendor a simulator; the adapters install
+onto *your* NS-2 / NS-3 tree.
+
+```
+core/   simulator-agnostic C++ (no NS-2/NS-3 headers) + unit tests
+ns2/    NS-2 Agent adapter + idempotent anchor-based source patch
+ns3/    native ns3::Ipv4RoutingProtocol contrib module
+docs/   architecture.md, porting-notes.md, adr/
+```
+
+## Build & verify
+
+```bash
+make test                                  # build core (CMake) + run ctest — fast, no simulator
+bash ns2/patch/selftest.sh                 # NS-2 patch apply/revert round-trip on a synthetic tree
+make install-ns2  NS2DIR=/path/to/ns-2.3x  # install onto a real NS-2 tree
+make install-ns3  NS3DIR=/path/to/ns-3-dev # install onto a real NS-3 tree
+make clean                                 # remove core/build
+```
+
+`make test` and the NS-2 patch self-test are the two checks that run in CI
+(`.github/workflows/ci.yml`) on every push/PR and are runnable here. An actual
+NS-2/NS-3 build needs an external simulator tree and is **not** possible from
+this repo alone. **Always run `make test` before committing a core change**, and
+`bash ns2/patch/selftest.sh` before touching `ns2/patch/`.
+
+## Golden rules (invariants — do not break)
+
+1. **`core/` must never include an NS-2 or NS-3 header.** Time comes through
+   `IClock`, randomness through `IRng`, neighbours through `INeighborProvider`,
+   deferred work through `ITimerScheduler` (see `core/include/.../ports.h`).
+   This is the property that keeps one algorithm working on both simulators.
+2. **Adapters must not reimplement routing logic.** An adapter only: converts
+   its packet header ⇄ `core::AntMessage`, carries out the `RouteDecision`s the
+   core returns, owns the periodic timers and the pending-packet queue (and,
+   for NS-2, the link-failure callback). Behaviour belongs in `core/`.
+3. **All randomness via `IRng`, all time via `IClock`.** Never call libc
+   `rand()` or read the simulator clock directly from shared logic —
+   reproducibility depends on this.
+4. **One canonical wire format.** `core/ant_message_codec` defines the
+   little-endian layout. If you change `AntMessage` fields you must update, in
+   the same field order: the codec, the NS-2 header (`ns2/src/ant_packet_ns2`),
+   the NS-3 header (`ns3/model/anthocnet-packet` `AntHeader`), and the
+   round-trip tests (`core/tests/test_codec.cpp`, NS-3 test suite).
+5. **Keep bounded structures bounded.** The visited path and the `(src,seq)`
+   dedup history are capped by `Config::maxPathLength` / `maxHistory`; do not
+   reintroduce unbounded growth.
+6. **NS-2 patching is anchor-based, never line-numbered.** Edits live as
+   fragments under `ns2/patch/fragments/` and inject at stable text anchors
+   with `ANTHOCNET-BEGIN/END` markers (or grep-guarded where a comment is
+   illegal). Apply must stay idempotent and revert must restore byte-for-byte;
+   `selftest.sh` enforces both.
+7. **Cover core logic changes with a core unit test** in `core/tests/`.
+
+## Conventions
+
+- C++14 for `core/` (aggregate init with default member initializers); see the
+  `-std=c++14` caveat for old NS-2 toolchains in `docs/porting-notes.md`.
+- Namespace `anthocnet::core` for shared code.
+- Make minimal, reviewable changes; update the relevant doc/ADR when you change
+  a documented decision.
+- Do not open a pull request unless explicitly asked.
+
+## Git workflow
+
+- Active development branch: `claude/anthocnet-protocol-review-wu1huq`.
+- Commit with a descriptive message; push with `git push -u origin <branch>`.
+
+## Where to look
+
+| You want to… | Go to |
+|--------------|-------|
+| Understand the design & decision flow | `docs/architecture.md` |
+| Understand a structural decision / its "why" | `docs/adr/` |
+| Maintain the NS-2 patch / wire format | `docs/porting-notes.md`, `ns2/patch/` |
+| Change the algorithm | `core/src/`, `core/include/anthocnet/core/` |
+| Change routing policy / decision flow | `core/src/ant_router_logic.cpp` |
+| Change pheromone math | `core/src/pheromone_engine.cpp`, `pheromone_table.cpp` |
+| Change the wire format | `core/include/.../ant_message_codec.h` (+ both adapters) |
+| Work on the NS-2 adapter | `ns2/src/`, `ns2/tcl/` |
+| Work on the NS-3 adapter | `ns3/model/`, `ns3/helper/`, `ns3/examples/` |
+| Tune defaults | `core/include/anthocnet/core/config.h` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,158 @@
+# Project Context — AntHocNet
+
+> Orientation document for contributors and for "grill-with-docs" comprehension
+> checks. It captures *what* this project is, *why* it is shaped this way, its
+> *current state*, and the *open questions*. For design detail read
+> [`docs/architecture.md`](docs/architecture.md); for maintenance detail read
+> [`docs/porting-notes.md`](docs/porting-notes.md); for the reasoning behind the
+> structure read the [ADRs](docs/adr/).
+
+## 1. One-paragraph summary
+
+AntHocNet is an **Ant Colony Optimization (ACO)** routing protocol for mobile
+ad-hoc networks. This repository implements it **once**, as a
+**simulator-agnostic algorithm core** (`core/`), and ships **thin adapters**
+that install the protocol onto an existing **NS-2** (source patch) or **NS-3**
+(additive contrib module) tree. The core has no simulator dependency and is
+covered by unit tests; the adapters translate packets and execute the
+decisions the core returns.
+
+## 2. Why this project exists / history
+
+- The protocol is a legacy academic implementation (originally by Daniel
+  Henrique Joppi, ~2008–2011) written *inside* a vendored `ns-allinone-2.34`
+  snapshot for NS-2.34.
+- It was reviewed and fixed, then **refactored** into the current shape: the
+  algorithm was extracted from NS-2 into a portable, tested `core/`, the
+  vendored simulator tree was removed, and NS-2/NS-3 adapters were added. The
+  refactor also fixed several latent bugs (see §6).
+- The motivation: one maintained algorithm, runnable on two simulators, with no
+  forked simulator tree to carry.
+
+## 3. Domain background (enough to follow the code)
+
+- **MANET**: mobile nodes, no fixed infrastructure; links come and go as nodes
+  move, so routing must adapt continuously.
+- **ACO routing**: "forward ants" explore toward a destination recording their
+  path; "backward ants" retrace it depositing **pheromone** — a numeric
+  goodness value per `(neighbor, destination)` next-hop choice. Data packets are
+  then forwarded **stochastically** in proportion to `pheromone^beta`, spreading
+  traffic over multiple good paths. Unused paths **evaporate**.
+- **AntHocNet** is *hybrid*: routes are set up **reactively** on demand (a data
+  packet with no route triggers a flooded reactive forward ant; the returning
+  backward ant lays the route), **maintained proactively** while in use, and
+  **repaired** locally on link failure. It also disseminates **virtual**
+  pheromone via hello ants so nodes can route toward destinations they have not
+  yet reached themselves.
+
+## 4. Architecture at a glance
+
+A ports-and-adapters (hexagonal) design — full diagram in
+[`docs/architecture.md`](docs/architecture.md).
+
+```
+            core/  (no simulator headers)
+   PheromoneTable · PheromoneEngine · AntHistoryTracker
+   AntRouterLogic  ── pure: returns RouteDecisions, performs no I/O
+   AntMessage (POD) · VisitedPath · AntMessageCodec (canonical wire format)
+   Ports: IClock · IRng · INeighborProvider · ITimerScheduler
+                         ▲                      ▲
+        implements ports │  returns decisions   │
+              ┌──────────┴──────────┐ ┌─────────┴───────────┐
+              │        ns2/         │ │        ns3/          │
+              │ Agent adapter +     │ │ Ipv4RoutingProtocol  │
+              │ source patch        │ │ contrib module       │
+              └─────────────────────┘ └──────────────────────┘
+```
+
+- **`AntRouterLogic`** is the pure state machine: `onReceiveAnt(msg, prevHop)`
+  and `onDataPacket(dst)` return `vector<RouteDecision>`; the adapter executes
+  each `RouteDecision { action ∈ {Unicast,Broadcast,Queue,Deliver,Drop,None},
+  nextHop, message }`.
+- **Adapters** convert headers ⇄ `AntMessage`, carry out decisions, own the
+  timers and pending-packet queue (and the NS-2 link-failure callback).
+
+## 5. Repository map
+
+```
+README.md                 ← start here: what/why, quick start, what changed
+CONTEXT.md                ← this file
+AGENTS.md                 ← build/verify/conventions for AI agents
+Makefile                  ← make test | install-ns2 | install-ns3 | clean
+docs/
+  architecture.md         ← design + decision flow
+  porting-notes.md        ← bugs fixed, NS-2 patch anchors, wire format, caveats
+  adr/*.md                ← architecture decision records
+core/
+  include/anthocnet/core/ ← public headers (types, ports, config, messages, logic)
+  src/                    ← implementation (.cpp)
+  tests/                  ← ctest unit tests (codec, pheromone, history, logic)
+  CMakeLists.txt
+ns2/
+  src/                    ← Agent adapter (ahn_router, ant_packet_ns2, ahn_adapters)
+  patch/                  ← idempotent anchor-based installer + fragments + selftest
+  tcl/                    ← example scenarios
+ns3/
+  model/ helper/ examples/ test/   ← native NS-3 module
+.github/workflows/ci.yml  ← core tests + NS-2 patch round-trip (+ optional NS-3 build)
+```
+
+## 6. Bugs fixed during the extraction (see `docs/porting-notes.md`)
+
+These were latent in the original NS-2 module and are fixed in `core/`:
+
+1. **Header-resident heap pointers** → the packet stored `malloc`'d
+   `AntTimeEntry**`; NS-2 byte-copies headers, so broadcasting an ant
+   double-freed and leaked, and `size()` reported `sizeof(pointer)`. Replaced
+   by `AntMessage` value types + a length-prefixed codec.
+2. **Evaporation aged the wrong link** (competing links never decayed).
+3. **8-bit sequence number** wrapped after 256 ants, aliasing dedup.
+4. **Unbounded dedup history** → now FIFO-capped (`Config::maxHistory`).
+5. **`randomDestination` never randomised** (integer-division bug) → uniform.
+
+## 7. Current state
+
+- **`core/` builds and all unit tests pass** (`make test`, 5/5 — verified).
+- **NS-2 patch apply/revert round-trips** on a synthetic tree
+  (`bash ns2/patch/selftest.sh`, in CI).
+- **NS-3 module** builds against ns-3.36+; CI builds it only on manual dispatch
+  (heavy). No end-to-end NS-2/NS-3 simulation is run from this repo — that needs
+  an external simulator tree.
+
+## 8. What is missing / caveats
+
+- **Cross-simulator metric parity is not guaranteed.** NS-2 and NS-3 have
+  different MAC/PHY models; treat a cross-sim comparison as behaviour
+  re-validation, not a bit-for-bit port.
+- **No full simulation runs in CI** — only the core tests and the NS-2 patch
+  round-trip. Behavioural validation on real NS-2/NS-3 trees is manual.
+- **Old NS-2 toolchains** may default to < C++14 and need `-std=c++14` added to
+  `CCOPT` (documented in `docs/porting-notes.md`).
+- The NS-2 patch depends on **stable text anchors** in upstream files; a future
+  NS-2 release that moves an anchor makes the installer fail loudly (by design)
+  and the fragment must be updated.
+
+## 9. Glossary
+
+| Term | Meaning |
+|------|---------|
+| Core | the simulator-agnostic algorithm library in `core/`. |
+| Adapter | the thin NS-2 or NS-3 layer that wires the core to a simulator. |
+| Port | an interface the core depends on, implemented by adapters (`IClock`, `IRng`, `INeighborProvider`, `ITimerScheduler`). |
+| `AntMessage` | the POD value type describing an ant (replaces header-resident pointers). |
+| `RouteDecision` | the verb the core returns for the adapter to execute. |
+| `AntRouterLogic` | the pure per-node state machine. |
+| Pheromone (regular / virtual) | next-hop goodness learned from real ant traversals / gossiped via hello ants. |
+| Evaporation / reinforcement | multiplicative decay (`alpha`) / smoothed increase (`gamma`) of pheromone. |
+| Forward / backward / hello / repair ant | path collector / pheromone depositor / neighbour-discovery + gossip / link-failure local search. |
+| `NodeAddress` | core address type (`int32_t`); `kInvalidAddress` = -1 = "no route". |
+
+## 10. Open questions for future work
+
+- What scenario + metrics (delivery ratio, delay, overhead vs. AODV) define
+  "working", and on which simulator are they the reference?
+- Should there be an automated end-to-end smoke test against a pinned NS-3
+  checkout in CI (beyond the current build job)?
+- Are the `Config` defaults (`alpha`/`beta`/`gamma`, intervals, `maxPathLength`,
+  `maxHistory`) the right operating point, or should they be tuned per
+  simulator?

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ protocol buried inside it. This refactor:
 History of the work is in the per-phase commits; design rationale is in
 [docs/](docs).
 
+## Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [docs/architecture.md](docs/architecture.md) | Design, the core/adapter split, and the decision flow. |
+| [docs/porting-notes.md](docs/porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, wire format, version caveats. |
+| [docs/adr/](docs/adr) | Architecture Decision Records — the "why" behind the structure. |
+| [CONTEXT.md](CONTEXT.md) | Project orientation: domain background, repo map, current state, glossary, open questions. |
+| [AGENTS.md](AGENTS.md) | Build/verify/conventions and invariants for contributors and AI agents. |
+| [ns2/README.md](ns2/README.md) · [ns3/README.md](ns3/README.md) | Per-adapter install/run details. |
+
 ## License
 
 See [LICENSE](LICENSE). Original implementation by Daniel Henrique Joppi.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,32 @@
+# ADR-0001: Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+
+## Context
+
+This project was refactored from a legacy NS-2-only implementation (buried in a
+vendored `ns-allinone-2.34` tree) into a simulator-agnostic core with NS-2 and
+NS-3 adapters. The new structure embodies several deliberate, non-obvious
+decisions (a pure I/O-free core behind ports, POD ant messages with a canonical
+codec, an idempotent anchor-based NS-2 patch). Without written rationale, future
+contributors — human or LLM — will re-litigate settled choices or break
+load-bearing invariants (e.g. by including a simulator header in `core/`).
+
+## Decision
+
+Keep lightweight **Architecture Decision Records** under `docs/adr/`, one per
+significant or surprising decision, each stating Status, Context, Decision, and
+Consequences. ADRs are append-only: supersede with a new ADR rather than
+rewriting an old one.
+
+Together with [`CONTEXT.md`](../../CONTEXT.md),
+[`docs/architecture.md`](../architecture.md) and
+[`docs/porting-notes.md`](../porting-notes.md), the ADRs form the documentation
+corpus used for onboarding and "grill-with-docs" comprehension checks.
+
+## Consequences
+
+- Decisions and their trade-offs are discoverable from the repo.
+- Reviews can cite an ADR instead of re-deriving context.
+- A small ongoing cost to write an ADR when a notable decision is made.

--- a/docs/adr/0002-one-core-two-adapters.md
+++ b/docs/adr/0002-one-core-two-adapters.md
@@ -1,0 +1,38 @@
+# ADR-0002: One simulator-agnostic core, thin per-simulator adapters
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+
+## Context
+
+The protocol must run on **NS-2** and **NS-3**. These simulators have
+fundamentally different architectures (OTcl + `Agent` + pooled C-style packet
+headers vs. C++ `Ipv4RoutingProtocol` + `ns3::Header` serialization), so there
+is no single universal patch or shared base class. The original code fused the
+algorithm with NS-2 internals, which made it impossible to reuse and hard to
+test.
+
+## Decision
+
+Adopt a **ports-and-adapters (hexagonal)** structure:
+
+- All routing behaviour lives in [`core/`](../../core) and **never includes a
+  simulator header**. It depends only on small interfaces (*ports*): `IClock`,
+  `IRng`, `INeighborProvider`, `ITimerScheduler`.
+- Each simulator provides a **thin adapter** that implements the ports and does
+  only what is intrinsically simulator-specific: convert its packet header ⇄
+  `core::AntMessage`, execute the core's `RouteDecision`s, own the periodic
+  timers and pending-packet queue (and, for NS-2, the link-failure callback).
+- Adapters **must not reimplement routing logic**.
+
+## Consequences
+
+- The algorithm is written, fixed, and unit-tested **once**; both simulators
+  share it verbatim, so behaviour cannot silently diverge.
+- Adding a third target is a new adapter, not a fork.
+- The core is testable without any simulator (`make test`).
+- A hard invariant to police in review: no simulator include may appear in
+  `core/`, and no behaviour may leak into an adapter.
+- Cross-simulator *metric* parity is still not guaranteed — MAC/PHY models
+  differ — see [ADR-0005](0005-ns2-idempotent-anchor-patch.md) and the porting
+  notes.

--- a/docs/adr/0003-pure-core-returns-route-decisions.md
+++ b/docs/adr/0003-pure-core-returns-route-decisions.md
@@ -1,0 +1,39 @@
+# ADR-0003: The core is pure and returns RouteDecisions
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+
+## Context
+
+Given the one-core/two-adapters split ([ADR-0002](0002-one-core-two-adapters.md)),
+the core still has to express *effects* — send this ant to that neighbour,
+broadcast, queue a data packet, deliver locally, drop. One option is to let the
+core call back into the adapter (callbacks / an output port it invokes). That
+re-introduces control-flow coupling and makes the core's behaviour depend on
+when and how the adapter responds, which is hard to test deterministically.
+
+## Decision
+
+Make `AntRouterLogic` a **pure decision function**. Its entry points —
+`onReceiveAnt(msg, prevHop)` and `onDataPacket(dst)` — **return values**:
+
+```
+std::vector<RouteDecision>
+RouteDecision { RouteAction action; NodeAddress nextHop; AntMessage message; }
+RouteAction ∈ { None, Unicast, Broadcast, Queue, Deliver, Drop }
+```
+
+The core performs no I/O: it reads time via `IClock` and randomness via `IRng`,
+mutates only its own state (pheromone table, dedup history, sequence counter),
+and hands back a list of decisions. The adapter maps each action onto its
+simulator (schedule a send, enqueue, deliver to the local transport, drop).
+
+## Consequences
+
+- The state machine is **deterministic and unit-testable** from the injected
+  clock/RNG with no simulator in the loop (`core/tests/test_router_logic.cpp`).
+- Effects are explicit and auditable as data, not hidden in callbacks.
+- The adapter owns *how* an action happens (e.g. NS-2 jitters broadcasts); the
+  core owns *which* action happens.
+- New effects require extending the `RouteAction` enum and handling it in both
+  adapters — a deliberately visible, reviewable change.

--- a/docs/adr/0004-pod-ant-messages-and-codec.md
+++ b/docs/adr/0004-pod-ant-messages-and-codec.md
@@ -1,0 +1,41 @@
+# ADR-0004: POD ant messages with a single canonical wire codec
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+
+## Context
+
+The original ant packet stored its visited-node path as a heap-allocated
+`AntTimeEntry**` array referenced from the NS-2 packet header. NS-2 pools and
+**byte-copies** header memory and runs no constructors, so:
+
+- broadcasting an ant duplicated the raw pointer → **double-free**;
+- the arrays were never freed → **leak**;
+- `size()` returned `sizeof(pointer)` → a wrong serialized packet size,
+  distorting MAC/airtime modelling.
+
+Each simulator also needs to serialize ants, and the two must agree on the wire
+layout or they cannot interoperate or be compared.
+
+## Decision
+
+- Represent an ant as a **plain, copyable value type** `AntMessage` (type,
+  direction, src/dst, 32-bit `seqNum`, timing, `VisitedPath` =
+  `std::vector<AntHop>`, history, hello adverts, back-ant pheromone fields). No
+  heap-resident pointers in any packet header.
+- Define **one canonical, length-prefixed little-endian wire format** in
+  `core/ant_message_codec`. Both adapter headers — the NS-2 POD
+  `ant_packet_ns2` and the NS-3 `AntHeader` — follow the **same field order**,
+  and the codec is round-trip tested (`core/tests/test_codec.cpp`).
+- Bound the carried path and the dedup history via `Config::maxPathLength` /
+  `maxHistory` so they cannot grow without limit.
+
+## Consequences
+
+- The double-free, the leak, and the wrong-size bug are eliminated by
+  construction.
+- Value semantics make ants trivially copyable/broadcastable and testable.
+- **Coupling to manage:** changing `AntMessage`'s fields means updating, in the
+  same order, the codec, the NS-2 header, the NS-3 header, and the round-trip
+  tests. This is called out as a golden rule in [`AGENTS.md`](../../AGENTS.md).
+- A POD header has a fixed capacity; `maxPathLength` caps the worst-case size.

--- a/docs/adr/0005-ns2-idempotent-anchor-patch.md
+++ b/docs/adr/0005-ns2-idempotent-anchor-patch.md
@@ -1,0 +1,43 @@
+# ADR-0005: Install on NS-2 via an idempotent, anchor-based source patch
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+
+## Context
+
+NS-2 has no module system: a routing protocol must edit core simulator files
+(`common/packet.h`, `trace/cmu-trace.*`, `Makefile.in`, and three
+`tcl/lib/*.tcl` files). The original project shipped these edits by **vendoring
+an entire `ns-allinone-2.34` snapshot** — heavy, impossible to apply to a
+different NS-2 version, and entangling the protocol with a frozen simulator
+copy. We need to install onto a user's own `ns-2.34`/`ns-2.35` tree instead.
+(NS-3, by contrast, supports additive `contrib/` modules and needs no core
+edits — see [ns3/README.md](../../ns3/README.md).)
+
+## Decision
+
+Ship the NS-2 integration as an **idempotent, anchor-based patch**
+(`ns2/patch/`):
+
+- Inject each delta at a **stable textual anchor** (a regex on surrounding
+  code), **never at a line number**. If an upstream release moves an anchor the
+  installer **fails loudly** (missing anchor) rather than corrupting the file.
+- Wrap edits in `ANTHOCNET-BEGIN/END` markers so they are re-runnable and
+  cleanly removable; where a comment is illegal (inside a Tcl list/`switch`
+  brace, or the backslash-continued `OBJ_CC` make variable) insert unmarked and
+  guard with a content grep.
+- Assign `PT_ANT` the tree's **current `PT_NTYPE`** value at install time and
+  bump `PT_NTYPE`, so the packet-type id never collides across NS-2 releases.
+- Provide `revert-patch.sh` (byte-for-byte restore) and `selftest.sh` (CI
+  validates apply-idempotency and revert on a synthetic tree).
+
+## Consequences
+
+- One protocol install works across NS-2 versions without vendoring a
+  simulator; uninstall is clean.
+- The repo no longer carries thousands of upstream simulator files.
+- Maintenance burden: anchors are a coupling to upstream source text; when NS-2
+  changes one, the corresponding fragment in `ns2/patch/fragments/` must be
+  updated. `selftest.sh` is the guard and must stay green.
+- Full mechanics are documented in
+  [`docs/porting-notes.md`](../porting-notes.md).


### PR DESCRIPTION
## Summary

Documentation-only PR for the refactored layout (simulator-agnostic `core/` +
NS-2/NS-3 adapters). It adds the docs master did not yet have, written for the
current structure.

> **History:** this branch originally carried bug fixes and docs against the old
> vendored `ns-allinone-2.34` tree. Master has since been rewritten by PR #5
> (the `core/` extraction), which **supersedes** those changes — the round-1
> fixes are already in master's history, and the `core/` rewrite independently
> fixed the same bugs (header-resident pointers / leak / double-free / packet
> size, evaporation, sequence-number width, dedup bound, random destination).
> The branch was therefore **reset onto master** and repurposed as docs only.

## What this PR adds

- **`CONTEXT.md`** — project orientation for onboarding / grill-with-docs:
  summary, history, MANET/ACO domain background, the ports-and-adapters
  architecture, repo map, the bugs fixed during extraction, current state,
  caveats, glossary, and open questions.
- **`AGENTS.md`** — build/verify commands (`make test`, `bash ns2/patch/selftest.sh`,
  `make install-ns2/ns3`) and the golden invariants: `core/` never includes a
  simulator header; adapters don't reimplement logic; randomness via `IRng` and
  time via `IClock`; one canonical codec kept in sync across `core/` + both
  adapters; bounded history/path; anchor-based NS-2 patching. Plus a
  where-to-look map.
- **`docs/adr/0001–0005`** — decision records: ADR practice; one-core/two-adapters
  (hexagonal); pure core returning `RouteDecision`s; POD ant messages + a single
  canonical wire codec; and the idempotent anchor-based NS-2 patch.
- **`README.md`** — a Documentation index linking architecture, porting-notes,
  ADRs, CONTEXT, AGENTS, and the per-adapter READMEs.

## Verification

- `make test` builds `core/` and passes **5/5** ctest cases in this environment.
- All intra-doc links resolve to files that exist.
- **No code changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYatkKbPeHGb9inrZ7TmTh