### PR TITLE
docs: AntHocNet protocol-fidelity review — 7 ADRs + implementation spec set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,14 @@ this repo alone. **Always run `make test` before committing a core change**, and
 3. **All randomness via `IRng`, all time via `IClock`.** Never call libc
    `rand()` or read the simulator clock directly from shared logic —
    reproducibility depends on this.
-4. **One canonical wire format.** `core/ant_message_codec` defines the
-   little-endian layout. If you change `AntMessage` fields you must update, in
-   the same field order: the codec, the NS-2 header (`ns2/src/ant_packet_ns2`),
-   the NS-3 header (`ns3/model/anthocnet-packet` `AntHeader`), and the
-   round-trip tests (`core/tests/test_codec.cpp`, NS-3 test suite).
+4. **One canonical wire format, versioned.** `core/ant_message_codec` defines the
+ little-endian layout, prefixed by a 1-byte `kWireVersion` (see
+ `docs/wire-format.md` and ADR-0006). If you change `AntMessage` fields — or the
+ units/semantics of an existing field — you must **bump `kWireVersion`** and
+ update, in the same field order: the codec, the NS-2 header
+ (`ns2/src/ant_packet_ns2`), the NS-3 header (`ns3/model/anthocnet-packet`
+ `AntHeader`), the round-trip tests (`core/tests/test_codec.cpp`, NS-3 test
+ suite), and the layout table in `docs/wire-format.md`.
 5. **Keep bounded structures bounded.** The visited path and the `(src,seq)`
    dedup history are capped by `Config::maxPathLength` / `maxHistory`; do not
    reintroduce unbounded growth.
@@ -88,7 +91,7 @@ this repo alone. **Always run `make test` before committing a core change**, and
 | Change the algorithm | `core/src/`, `core/include/anthocnet/core/` |
 | Change routing policy / decision flow | `core/src/ant_router_logic.cpp` |
 | Change pheromone math | `core/src/pheromone_engine.cpp`, `pheromone_table.cpp` |
-| Change the wire format | `core/include/.../ant_message_codec.h` (+ both adapters) |
+| Change the wire format | `docs/wire-format.md` → `core/include/.../ant_message_codec.h` (+ both adapters; bump `kWireVersion`) |
 | Work on the NS-2 adapter | `ns2/src/`, `ns2/tcl/` |
 | Work on the NS-3 adapter | `ns3/model/`, `ns3/helper/`, `ns3/examples/` |
 | Tune defaults | `core/include/anthocnet/core/config.h` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,7 @@ Makefile                  ← make test | install-ns2 | install-ns3 | clean
 docs/
   architecture.md         ← design + decision flow
   porting-notes.md        ← bugs fixed, NS-2 patch anchors, wire format, caveats
+  wire-format.md          ← canonical ant byte layout, version byte, diffs vs original/spec
   adr/*.md                ← architecture decision records
 core/
   include/anthocnet/core/ ← public headers (types, ports, config, messages, logic)
@@ -142,10 +143,16 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 | `AntMessage` | the POD value type describing an ant (replaces header-resident pointers). |
 | `RouteDecision` | the verb the core returns for the adapter to execute. |
 | `AntRouterLogic` | the pure per-node state machine. |
-| Pheromone (regular / virtual) | next-hop goodness learned from real ant traversals / gossiped via hello ants. |
-| Evaporation / reinforcement | multiplicative decay (`alpha`) / smoothed increase (`gamma`) of pheromone. |
+| Regular pheromone | next-hop goodness for a destination learned from real ant traversals (backward ants). Used by data. |
+| Virtual pheromone | next-hop goodness gossiped via hello ants for destinations not reached directly. Used only to guide proactive ants, never data. Config-gated (`enableDiffusion`, ADR-0007). _Avoid_: "diffused pheromone" (the papers' synonym). |
+| Pheromone diffusion | the mechanism: spreading virtual pheromone hop-by-hop through hello ants. The *process*, not the value. Gated with proactive exploration (ADR-0007). |
+| Bootstrapping | the method of deriving a virtual-pheromone value from a neighbour's advertised estimate plus the local one-hop cost (vs. Monte-Carlo sampling by ants). |
+| Reinforcement | the spec's adaptation engine: a running weighted average on backward-ant arrival, `T ← gamma·T + (1−gamma)·estimate`. The `(1−gamma)` term is the "forgetting". |
+| Evaporation | time-proportional decay (`alpha^(Δt/evaporationInterval)`) applied on the maintenance tick. A **secondary safety net** for entries the running average + link-failure removal miss — the original AntHocNet has *no* evaporation term. Config-gated (`enableEvaporation`, default on; ADR-0012). |
 | Forward / backward / hello / repair ant | path collector / pheromone depositor / neighbour-discovery + gossip / link-failure local search. |
-| `NodeAddress` | core address type (`int32_t`); `kInvalidAddress` = -1 = "no route". |
+| Neighbour liveness | a neighbour is "gone" via either missed hellos (core timer, primary) or a failed unicast (MAC signal, fast-path); both call `loseNeighbor`. `INeighborProvider` is advisory, never authoritative for removal (ADR-0008). |
+| Stochastic data routing | data is forwarded by a per-packet pheromone-weighted draw, **excluding the prev hop** (loop safety; only-option fallback). Per-flow stickiness (a bounded `(src,dst)→hop` cache) is config-gated, default off (ADR-0010). |
+| `NodeAddress` | core address type (`int32_t`), = a node's primary interface IP, treated opaquely; `kInvalidAddress` = -1 = "no route / no specific next hop". Broadcast is a `RouteAction`, **never** a `NodeAddress` (ADR-0011). |
 
 ## 10. Open questions for future work
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ History of the work is in the per-phase commits; design rationale is in
 |----------|---------|
 | [docs/architecture.md](docs/architecture.md) | Design, the core/adapter split, and the decision flow. |
 | [docs/porting-notes.md](docs/porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, wire format, version caveats. |
+| [docs/wire-format.md](docs/wire-format.md) | Canonical on-wire ant layout, version byte, and diff vs. the original and the papers. |
 | [docs/adr/](docs/adr) | Architecture Decision Records — the "why" behind the structure. |
 | [CONTEXT.md](CONTEXT.md) | Project orientation: domain background, repo map, current state, glossary, open questions. |
 | [AGENTS.md](AGENTS.md) | Build/verify/conventions and invariants for contributors and AI agents. |

--- a/docs/adr/0006-on-wire-protocol-version.md
+++ b/docs/adr/0006-on-wire-protocol-version.md
@@ -1,0 +1,79 @@
+# ADR-0006: A 1-byte on-wire protocol version, no negotiation
+
+- **Status:** Accepted — implementation tracked in
+  [`docs/improvements/12-codec-hardening-and-threat-model.md`](../improvements/12-codec-hardening-and-threat-model.md)
+- **Date:** 2026-06-25
+
+## Context
+
+[ADR-0004](0004-pod-ant-messages-and-codec.md) established a single canonical,
+length-prefixed wire format shared by the codec and both adapters, and
+[`AGENTS.md`](../../AGENTS.md) golden rule #4 requires that any change to
+`AntMessage` fields be mirrored across the codec, the NS-2 header, the NS-3
+header, and the round-trip tests *in the same field order*.
+
+That rule keeps the **layout** in sync, but the frame has **no version marker**,
+so two classes of change are undetectable on the wire:
+
+- **Silent layout change** — adding/removing a field (e.g. the MAC-cost field in
+  [item 10](../improvements/10-data-loops-multipath-and-mac-metric.md)).
+- **Silent semantic change** — same bytes, new meaning: the back-ant time
+  term's units in [item 02](../improvements/02-backward-ant-delay-metric.md), or
+  `helloDests[].pheromone` going from a constant `1.0` to a real bootstrapped
+  value in [item 03](../improvements/03-pheromone-diffusion.md).
+
+A node on an old build and one on a new build would parse each other's frames as
+garbage with **no error**. Within a single simulation run this cannot happen
+(every node runs one identical build), but it silently breaks NS-2 ↔ NS-3
+cross-validation and any saved trace/pcap compared across versions — exactly the
+interoperability ADR-0004 set out to protect.
+
+Several planned changes (items 02, 03, 10) are already churning the format, so
+the cost of introducing a version marker is at its lowest now.
+
+## Decision
+
+- Add a **1-byte `version` field at offset 0** of every frame (a `kWireVersion`
+  constant, starting at `0x01`), shifting `type` to offset 1.
+- `deserialize` validates `version` **first**, before reading any length field,
+  and returns `false` (drop) on any unknown value.
+- The version constant is defined once in the codec and asserted identical by
+  both adapter headers and the round-trip test. **Any change to field order,
+  width, units, or semantics bumps `kWireVersion`** — semantic-only changes
+  included.
+- **No negotiation, translation, or fallback.** A version mismatch is a dropped
+  packet. We do not support heterogeneous-version networks; we want cross-version
+  artifacts to fail loudly rather than misparse.
+
+The implementation rides along with the codec-hardening work in
+[item 12](../improvements/12-codec-hardening-and-threat-model.md); the layout is
+documented in [`docs/wire-format.md`](../wire-format.md).
+
+## Alternatives considered
+
+- **Freeze the layout, no version; document a "single-build, no on-wire
+  versioning" invariant.** Zero wire cost, but leaves the silent-misparse hazard
+  for cross-version traces and NS-2/NS-3 comparison, and makes the
+  "one canonical format" invariant only prose, not machine-checkable. Rejected:
+  the failure mode is silent, and the items in flight make a corruption
+  plausible the first time someone compares two builds.
+- **A multi-byte magic + version envelope (e.g. 4 bytes).** More robust framing,
+  but costs airtime on every ant in a protocol whose overhead we benchmark
+  ([item 08](../improvements/08-protocol-comparison-benchmarks.md)). One byte is
+  enough to catch the realistic cases and keeps the metric honest.
+- **Full version negotiation / per-version decoders.** Solves a heterogeneity
+  problem this project does not have (one build per run). Pure over-engineering.
+
+## Consequences
+
+- A one-time wire break (taken now, alongside items 02/03/10) buys an O(1),
+  pre-length-check rejection of foreign/garbage/stale frames — strengthening the
+  untrusted-decode story in [item 12](../improvements/12-codec-hardening-and-threat-model.md).
+- The "single canonical wire format" invariant becomes **machine-checkable**:
+  the layout and its version move in lockstep across codec + both adapters +
+  tests, so a forgotten adapter update surfaces as a version/round-trip test
+  failure instead of a silent field-misalignment in a later simulation.
+- Frame size grows by exactly 1 byte; the documented minimum frame is 61 bytes.
+- Maintainers gain one more obligation in the golden-rule #4 checklist: **bump
+  `kWireVersion` on any field or semantic change.** This is written into
+  [`docs/wire-format.md`](../wire-format.md) and item 12's acceptance criteria.

--- a/docs/adr/0007-proactive-diffusion-gated.md
+++ b/docs/adr/0007-proactive-diffusion-gated.md
@@ -1,0 +1,91 @@
+# ADR-0007: Keep virtual pheromone / proactive diffusion, but gate it
+
+- **Status:** Accepted — implementation tracked in
+  [`improvements/03`](../improvements/03-pheromone-diffusion.md),
+  [`improvements/04`](../improvements/04-proactive-ant-sessions.md), measured by
+  [`improvements/07`](../improvements/07-validation-and-benchmarks.md) /
+  [`improvements/08`](../improvements/08-protocol-comparison-benchmarks.md)
+- **Date:** 2026-06-25
+
+## Context
+
+AntHocNet is a *hybrid* protocol: reactive route setup (forward + backward ants
+lay **regular** pheromone that data follows) plus proactive maintenance, in which
+hello messages **diffuse** pheromone to build a **virtual** pheromone table that
+guides **proactive ants** ([1] §3.1, §3.3 — see the glossary in
+[`CONTEXT.md`](../../CONTEXT.md)). Virtual pheromone is never used by data.
+
+Reviewing the current core, virtual pheromone is **half-wired and partly
+self-defeating**:
+
+- Hellos advertise a **constant `1.0`**, so virtual pheromone is a reachability
+  bit, not a goodness gradient ([item 03](../improvements/03-pheromone-diffusion.md)).
+- It is read by **one consumer** — proactive-ant next-hop selection
+  (`sumMaxProbability`, `isProactiveAnt == true`); data/reactive paths never read
+  it.
+- `nextNeighborNode` bails unless the destination is in the **regular**
+  destination set, so a destination known *only* via diffusion is unroutable even
+  for a proactive ant — defeating diffusion's stated purpose (reach destinations
+  not yet sampled by ants).
+- Proactive ants themselves target a **random** destination on a fixed timer
+  rather than active sessions ([item 04](../improvements/04-proactive-ant-sessions.md)).
+
+So "do we need virtual pheromone?" reduces to "do we want informed proactive
+exploration?" — the two stand or fall together, and neither is load-bearing for
+basic correctness (data routes on regular pheromone alone).
+
+## Decision
+
+**Keep** virtual pheromone, pheromone diffusion, and proactive exploration — they
+are the mechanisms that distinguish AntHocNet from a reactive ant/AODV hybrid and
+underpin the "canonical AntHocNet" positioning
+([item 09](../improvements/09-landscape-and-positioning.md)) — **but make the
+whole proactive subsystem config-gated and let benchmarks justify the default:**
+
+- Add `Config::enableProactive` (default `true`), the master switch for proactive
+  ant generation + per-hop exploratory broadcast. Optionally
+  `Config::enableDiffusion` (default `true`, only effective when proactive is on)
+  to gate the hello pheromone payload + virtual-table build + virtual blending,
+  enabling a finer ablation.
+- When disabled: the proactive timer emits nothing, hellos carry **no** pheromone
+  adverts (neighbour-discovery/liveness still runs — see
+  [item 05](../improvements/05-link-failure-detection-and-repair.md)), the virtual
+  table stays empty, and selection never blends virtual pheromone.
+- Make diffusion actually work when enabled: real bootstrapped advert values
+  (item 03), proactive ants for **active sessions** (item 04), and **relax the
+  `nextNeighborNode` reach guard** so proactive selection may route to a
+  destination present in the regular **or** virtual set (data still requires
+  regular). Without that relaxation, diffusion can never extend reach and the
+  feature is pointless.
+- The benchmark harness (items 07/08) runs the ablation — **AntHocNet-full**
+  (both on) vs **AntHocNet-reactive** (proactive off), optionally **proactive-blind**
+  (proactive on, diffusion off) — and the measured PDR/delay/overhead decides
+  whether the shipped default stays on.
+
+## Alternatives considered
+
+- **Cut it entirely.** Remove the virtual table, diffusion, and proactive ants;
+  hellos shrink to neighbour discovery/liveness; drop the `helloDests` pheromone
+  payload from the wire. Simpler and smaller — but it is no longer full
+  AntHocNet, and the item 09 "canonical implementation" claim would have to be
+  downgraded to "reactive AntHocNet variant." Rejected: cutting a *defining*
+  mechanism based on the current half-wired state (not on evidence) throws away
+  the project's identity and the paper-comparison story.
+- **Commit unconditionally (no flag).** Implement 03 + 04 + guard fix, always on.
+  Faithful, but bakes in a mechanism whose benefit in *our* topologies is
+  unproven and gives no ablation for the benchmark write-up. Rejected in favour
+  of a flag that costs almost nothing and yields a free A/B.
+
+## Consequences
+
+- The project stays a faithful AntHocNet by default, with an evidence-based exit:
+  if items 07/08 show diffusion doesn't move the metrics in our scenarios, ship
+  `enableProactive = false` (or `enableDiffusion = false`) by default and
+  document the finding — without deleting code or changing the wire format.
+- One ablation axis is added to the benchmark matrix (items 07/08), which also
+  strengthens the comparison story (we can show AntHocNet-full vs -reactive).
+- The reach-guard relaxation is a behavioural change to proactive selection;
+  it is covered by item 03's acceptance tests (data still ignores virtual).
+- No wire-format change: `HelloDest{node, pheromone}` already carries a double;
+  when diffusion is off, the adverts list is simply empty (no `kWireVersion`
+  bump — the layout is unchanged; see [ADR-0006](0006-on-wire-protocol-version.md)).

--- a/docs/adr/0008-neighbour-liveness-two-detectors.md
+++ b/docs/adr/0008-neighbour-liveness-two-detectors.md
@@ -1,0 +1,75 @@
+# ADR-0008: Neighbour-liveness via two detectors; the provider is advisory
+
+- **Status:** Accepted — implementation tracked in
+  [`improvements/05`](../improvements/05-link-failure-detection-and-repair.md)
+- **Date:** 2026-06-25
+
+## Context
+
+AntHocNet must notice when a neighbour disappears so it can purge that
+neighbour's pheromone and trigger repair/notification. The spec defines detection
+two ways ([1] §3.5):
+
+> "Nodes can detect link failures ... when unicast transmissions fail, or when
+> expected periodic [hello] messages were not received."
+
+The codebase already has an `INeighborProvider` port whose `neighbors()` returns
+the link layer's current one-hop set, and [item 05](../improvements/05-link-failure-detection-and-repair.md)
+additionally proposes a core-side last-seen map expiring neighbours on
+`t_hello × allowed_hello_loss`. That leaves **two notions of "neighbour"** that
+can disagree (a node still in `neighbors()` but silent for 3 hellos; or expired
+by the core but still adjacent at the MAC), and item 05 never said which one is
+allowed to *declare a neighbour gone*. Today only NS-2 detects loss (failed
+unicast); **NS-3 detects nothing**, so dead-link pheromone persists and data is
+sent into the void.
+
+## Decision
+
+Use **both** detectors — they are complementary, not competing — and both feed a
+single `loseNeighbor(n)`:
+
+- **Hello-timeout (core timer) — the portable coverage path, and primary.** The
+  core tracks last-seen per neighbour (touched on any reception) and expires on
+  `helloInterval × allowedHelloLoss` via `onMaintenanceTick()`. This is the
+  spec's detection mechanism, is simulator-agnostic, and is the **only** detector
+  NS-3 has — so it is mandatory and fixes the NS-3 correctness gap. It also
+  covers **idle** neighbours a node isn't actively transmitting to (the MAC is
+  silent for those).
+- **MAC transmit-failure (adapter signal) — a fast-path accelerator.** When a
+  unicast to a next hop fails (NS-2 link-failure callback; NS-3 WiFi MAC / ARP
+  tx-error hook), the adapter calls the same `loseNeighbor` immediately rather
+  than waiting for the timeout. It is never the *sole* detector and never
+  required for correctness.
+- **`INeighborProvider` is advisory only.** It answers "who can I hello / who is a
+  candidate," never "who is alive." Pheromone-table membership is driven by
+  reception + explicit loss events; the provider must not evict.
+- Hello broadcasts (and thus the liveness tick) run **independently of the
+  diffusion gate** ([ADR-0007](0007-proactive-diffusion-gated.md)): turning
+  proactive/diffusion off suppresses only the hello pheromone payload, not the
+  hellos themselves.
+
+## Alternatives considered
+
+- **Make `INeighborProvider` authoritative** — the core diffs successive
+  `neighbors()` snapshots and emits loss for anything that vanished. Simpler core
+  (no last-seen map, no timer), uses ground truth — but it is **not** the spec
+  mechanism, ties "neighbour loss" to each simulator's MAC/table semantics
+  (diverging NS-2 vs NS-3 behaviour and breaking reproducibility /
+  cross-validation), and would not translate to a real deployment. Rejected.
+- **Single detector only.** Hello-timeout alone is slow to react on an active
+  link that just broke; MAC-failure alone misses idle neighbours and gives NS-3
+  nothing portable. Either alone is strictly worse than both. Rejected.
+
+## Consequences
+
+- NS-3 gets working neighbour-loss detection from the hello-timeout path
+  (mandatory), closing the dead-link-pheromone gap; NS-2 keeps its fast MAC path
+  and gains the timeout as a backstop.
+- Detection *policy* (thresholds, notification) lives in `core/`; the detection
+  *signal* (a TX failed) is a simulator event delivered through the adapter —
+  the clean reading of golden rule #2.
+- `INeighborProvider`'s contract is clarified to "advisory adjacency, never
+  authoritative for removal" (the port's doc comment and item 05 should say so).
+- Reproducibility and NS-2/NS-3 cross-validation are preserved because the
+  authoritative detector is the simulator-agnostic core timer, not a per-MAC
+  neighbour table.

--- a/docs/adr/0009-backward-ants-carry-path-not-state.md
+++ b/docs/adr/0009-backward-ants-carry-path-not-state.md
@@ -1,0 +1,82 @@
+# ADR-0009: The wire carries path observations, not computed state
+
+- **Status:** Accepted — implementation tracked in
+  [`improvements/02`](../improvements/02-backward-ant-delay-metric.md)
+- **Date:** 2026-06-25
+
+## Context
+
+Fixing the backward-ant delay metric ([item 02](../improvements/02-backward-ant-delay-metric.md))
+already changes the meaning of `AntHop.time` (cumulative-since-source → per-hop
+delta), which is a semantic change to an existing wire field and therefore bumps
+`kWireVersion` ([ADR-0006](0006-on-wire-protocol-version.md)) regardless.
+
+While scoping that change we found that a backward ant serializes four fields —
+`pheromone`, `hops`, `prevSINR`, `prevHop` — that are **transient compute state**:
+
+- Verified in both adapters (`ns2/src/ant_packet_ns2.cc`,
+  `ns3/model/anthocnet-packet.cc`): they are only *marshaled* header ⇄
+  `AntMessage`; neither adapter reads them to make a routing decision.
+- The core recomputes them at every hop in `advanceBackAnt` (`hops += 1`,
+  `prevHop = current.node`, `pheromone = …`). They do not need to survive across
+  a hop on the wire.
+
+Carrying them is wasted airtime (relevant to the overhead AntHocNet is
+benchmarked on, [item 08](../improvements/08-protocol-comparison-benchmarks.md))
+and a trust hazard: a node *could* believe an upstream-supplied `pheromone`
+instead of computing its own.
+
+## Decision
+
+**A backward ant's wire image carries identity + the path observation, and each
+node computes pheromone locally.** Concretely, as part of item 02:
+
+- **Drop `pheromone`, `hops`, `prevSINR`, `prevHop` from the serialized format.**
+  They become (at most) core-local working fields. `prevSINR` is therefore
+  *removed*, not renamed — the misnomer simply leaves the wire.
+- **Encode time as a per-hop delta** in the existing `AntHop.time` slot (seconds),
+  summed on the backward pass — so no new `timeDest` field is added and the frame
+  shrinks rather than grows.
+- **Bump `kWireVersion`.** Do **not** hard-code the new number: it is a monotonic
+  counter, so use `current + 1`. Coordinate with item 12 — whichever of
+  {item 02, item 12} lands first introduces the `kWireVersion` constant; the
+  other bumps it. See [`docs/wire-format.md`](../wire-format.md) for the target
+  layout.
+
+This is a refinement of [ADR-0004](0004-pod-ant-messages-and-codec.md)'s "one
+canonical wire format": the format encodes what was *observed* (the path and its
+per-hop timing), not what a node *derived* from it.
+
+## Alternatives considered
+
+- **Keep marshaling the four fields (minimal item 02).** Lower blast radius for a
+  P0 fix, and ADR-0006 makes a later slim cheap and detectable. Rejected because
+  the slim is provably low-risk here — the fields are dead-on-the-wire, so we are
+  deleting unused serialized state, not changing logic — and item 02 is already
+  an atomic codec + both-headers + `test_codec.cpp` change, so the slim costs no
+  extra version bump.
+- **Absolute arrival time + a new `timeDest` field.** Simpler subtraction, but
+  *grows* the wire with a field whose only purpose is cross-hop time math that the
+  per-hop-delta encoding does without. Rejected in favour of the delta.
+
+## Consequences
+
+- Every backward ant is smaller (four fewer fixed fields: −24 bytes), trimming
+  control overhead.
+- Item 12's threat model tightens: there is no upstream-supplied pheromone/hop
+  count to validate or distrust — those values never cross the boundary.
+- `prevSINR` disappears from the struct's wire image; if a local time accumulator
+  is still wanted it is a private working field, not a serialized one.
+- Forward and backward ants now have clearly different wire footprints (the
+  backward ant adds nothing beyond the path it inherited) — documented in
+  [`docs/wire-format.md`](../wire-format.md).
+- One more reason the codec must recompute, never trust: a regression test should
+  assert the decoder leaves `pheromone`/`hops` at defaults (they are not on the
+  wire) and the core fills them.
+- **Single-scalar-cost invariant.** Each per-hop path entry stays `{node, cost}` —
+  one scalar. A MAC-aware or otherwise richer per-hop cost (item 10/A2) enters by
+  *improving the measurement* fed into that scalar at `stampForward`
+  (`ILinkDelay`), never by adding per-hop signal fields. The pheromone-metric port
+  (item 16, `ILinkMetric`) is the orthogonal seam for combining path aggregates +
+  node-local signals. Adding per-hop *downstream* signal fields to the wire is a
+  separate, ADR-gated decision, not a default extensibility point.

--- a/docs/adr/0010-data-forwarding-prevhop-excluded-stochastic.md
+++ b/docs/adr/0010-data-forwarding-prevhop-excluded-stochastic.md
@@ -1,0 +1,65 @@
+# ADR-0010: Data forwarding — prev-hop-excluded stochastic, flow-stickiness gated
+
+- **Status:** Accepted — implementation tracked in
+  [`improvements/10`](../improvements/10-data-loops-multipath-and-mac-metric.md) (A1)
+- **Date:** 2026-06-25
+
+## Context
+
+Data packets are forwarded by an independent stochastic draw over regular
+pheromone at **every** hop (`onDataPacket(dest)` → `table_.lookup(dest, rng_)`).
+Two consequences:
+
+- **No prev-hop exclusion** — a packet can be drawn back toward the neighbour it
+  just arrived from, so transient routing loops are possible and only the IP TTL
+  breaks them.
+- **Per-packet reordering** — independent draws scatter a single flow across the
+  path mesh, which is harmless for UDP/CBR (the benchmark traffic) but hurts TCP
+  (dup-ACKs, spurious retransmits).
+
+The spec spreads data stochastically over a mesh but assumes the pheromone
+gradient is effectively loop-free, and real implementations additionally avoid
+sending a packet back the way it came and damp per-packet flapping. Note the
+overlap with `β_data` ([item 01](../improvements/01-data-vs-ant-beta.md)): a high
+greedy `β_data` already concentrates data on the best path and only spreads when
+pheromones are comparable, so per-packet reordering is naturally limited in the
+paper's regime.
+
+## Decision
+
+- **Prev-hop exclusion is always on (not gated).** Thread the incoming neighbour
+  into the core (`onDataPacket(dest, prevHop)` → `lookup(dest, …, exclude=prevHop)`)
+  and skip it when forming the probability sum and selecting — **unless it is the
+  only next hop with pheromone**, in which case forward to it anyway (no
+  black-holes at leaf nodes). This is pure loop-safety, so it is unconditional.
+- **Per-flow stickiness is config-gated, default OFF.** When enabled, a bounded
+  `(src,dst) → next-hop` cache with hysteresis keeps a burst on one path; it is a
+  **core** concern (routing policy, golden rule #2), bounded like the `(src,seq)`
+  dedup history, and requires the adapter to pass the packet **src**
+  (`onDataPacket(dest, prevHop, src)`). Default off because (1) high `β_data`
+  already makes data ~sticky, (2) pure per-packet stochastic is the paper-faithful
+  baseline the benchmarks should measure first, and (3) it only helps
+  reorder-sensitive (TCP) traffic, which the current harness doesn't carry. It
+  becomes another benchmark ablation knob (mirrors [ADR-0007](0007-proactive-diffusion-gated.md)).
+
+## Alternatives considered
+
+- **Stickiness on by default.** TCP-friendliness and smoother delay out of the
+  box, but departs from the paper's pure-stochastic spreading and muddies the
+  "canonical AntHocNet" story until a benchmark with reorder-sensitive traffic
+  justifies it. Rejected as a default; available via the flag.
+- **No prev-hop exclusion (rely on TTL).** Simplest, but accepts transient loops
+  and the wasted transmissions they cause. Rejected — loop-safety is cheap and
+  unconditional.
+
+## Consequences
+
+- The core data entry point gains `prevHop` (always) and `src` (when stickiness
+  is compiled/used); both adapters supply them (NS-3 `RouteInput` `idev`→sender
+  and origin; NS-2 `ch->prev_hop_` and `ih->saddr()`).
+- Loop-safety no longer depends on TTL; the only-option fallback preserves
+  reachability at leaf nodes.
+- One more benchmark ablation axis (sticky vs pure-stochastic), consistent with
+  the gate-and-measure pattern used for diffusion.
+- No wire-format impact: prev-hop and flow identity are local forwarding inputs,
+  not serialized ant fields (no `kWireVersion` bump — ADR-0006/0009).

--- a/docs/adr/0011-nodeaddress-is-ip-broadcast-is-an-action.md
+++ b/docs/adr/0011-nodeaddress-is-ip-broadcast-is-an-action.md
@@ -1,0 +1,64 @@
+# ADR-0011: `NodeAddress` is the node's IP; broadcast is a RouteAction, never an address
+
+- **Status:** Accepted — implementation tracked in
+  [`improvements/11`](../improvements/11-adapter-robustness.md) (B2, B3)
+- **Date:** 2026-06-25
+
+## Context
+
+The NS-3 adapter converts addresses by casting a full IPv4 address to the core's
+`int32` `NodeAddress`:
+
+```cpp
+static NodeAddress ToCore(Ipv4Address a) { return static_cast<NodeAddress>(a.Get()); }
+```
+
+`255.255.255.255` (`0xFFFFFFFF`) becomes `int32 -1`, which is exactly
+`kInvalidAddress` ("no route"); any address ≥ `128.0.0.0` becomes negative. It is
+masked today only because the examples use `10.1.0.0/16`. Underneath the bug is an
+**unstated contract**: is a `NodeAddress` the simulator's IP or an abstract node
+id? And on a **multi-interface** node (B2), which address *is* the node? B2 and B3
+are the same question from two angles.
+
+## Decision
+
+- **`NodeAddress` is the node's primary AntHocNet-interface IPv4 address.** A
+  routing protocol fundamentally speaks IP — the core returns a next-hop
+  `NodeAddress` that the adapter turns directly into a gateway IP + output device —
+  so the core address space *is* the IP space. The core treats it **opaquely**
+  and only ever compares `== kInvalidAddress`.
+- **Broadcast/multicast are a verb, never a noun.** They are expressed *only* as
+  `RouteAction::Broadcast` (with `kInvalidAddress` = "no specific next hop"). The
+  all-ones address is **never** fed through `ToCore` as an identity. With that
+  guard the only IP that maps to `-1` is the broadcast address — which never
+  reaches `ToCore` — so no unicast peer can alias the sentinel. MSB-set unicast
+  IPs still map to *negative* ints, which is fine because `NodeAddress` is opaque
+  and never ordered against the sentinel.
+- **Identity ≠ interface.** A node's identity is its *primary* AntHocNet
+  interface IP; "one AntHocNet interface per node" is the supported/tested
+  topology. B2's multi-interface work is purely **egress selection** (route via
+  the interface facing `next`, not `m_socketAddresses.begin()`) and does **not**
+  change identity.
+- Add `ToCore(unicast) != kInvalidAddress` as an assertion + a round-trip test
+  (`ToIpv4(ToCore(x)) == x` over the supported unicast range).
+
+## Alternatives considered
+
+- **`NodeAddress` = abstract node id (e.g. `Node::GetId()`).** Structurally kills
+  the sentinel collision and decouples identity from interface, so B2 would fall
+  out for free. Rejected: it forces an adapter-maintained id↔IP directory on both
+  NS-2 and NS-3 (to resolve a next-hop id back to a gateway IP + device) that
+  AntHocNet does not otherwise need and would have to populate and keep fresh. The
+  IP-as-identity contract plus the two invariants above fix the bug without that
+  machinery.
+
+## Consequences
+
+- The literal B3 collision is fixed structurally (broadcast never an address;
+  unicast never aliases `-1`) rather than by widening or re-sentinelling the type.
+- B2 reduces to correct egress-interface selection; node identity is unaffected,
+  so multi-interface support can be incremental.
+- The "one AntHocNet interface per node" assumption is now an explicit, documented
+  contract rather than an accident of the example addressing plan.
+- No wire-format impact (addressing is an adapter ⇄ core boundary concern, not a
+  serialized field).

--- a/docs/adr/0012-evaporation-is-a-secondary-safety-net.md
+++ b/docs/adr/0012-evaporation-is-a-secondary-safety-net.md
@@ -1,0 +1,91 @@
+# ADR-0012: Evaporation is a secondary, time-proportional safety net
+
+- **Status:** Accepted — implementation tracked in
+  [`improvements/06`](../improvements/06-evaporation-and-minor.md)
+- **Date:** 2026-06-25
+
+## Context
+
+The codebase ages regular pheromone with a multiplicative `evaporate(v) = α·v`
+that fires only as a side effect of `updateRegular` — i.e. on **backward-ant
+arrival**. So a path that stops being sampled never decays, and the decay rate is
+tied to traffic, not time. This same "age the other links while reinforcing one"
+loop is what produced the original D2 evaporation bug.
+
+It is tempting to "fix" this by making evaporation periodic and time-proportional
+(classic Ant System: `τ ← (1−ρ)τ` every iteration) and call that spec-faithful.
+But the canonical AntHocNet description ([1] Di Caro, Ducatelle & Gambardella,
+ETT 2005) **has no evaporation term at all** — the word never appears. AntHocNet
+deliberately *replaces* classic ACO evaporation with two other mechanisms:
+
+> "the pheromone value ... represents a running average ... `Tᵢ_nd = γ·Tᵢ_nd +
+> (1−γ)·τᵢ_d`" — [1] §3.3
+
+1. **A running weighted average on backward-ant arrival** (the `(1−γ)` term is
+   the "forgetting"; this is the spec's adaptation engine — our `reinforce`).
+2. **Explicit obsolete-route removal** on neighbour loss (hello-timeout
+   `t_hello × allowed-hello-loss`, or failed unicast), which *deletes* entries
+   outright rather than decaying them — this is [ADR-0008](0008-neighbour-liveness-two-detectors.md)
+   / [item 05](../improvements/05-link-failure-detection-and-repair.md).
+
+So the real question is not "event-driven vs time-based evaporation" but **what
+role evaporation plays at all**, given the spec assigns adaptation elsewhere.
+
+## Decision
+
+Keep evaporation, but demote it to an explicit **secondary safety net**, and make
+the form correct:
+
+1. **Primary forgetting stays the spec's two mechanisms** — the running-average
+   `reinforce` (γ) and explicit link-failure / hello-timeout removal (ADR-0008).
+   Evaporation only reaps entries those two miss: e.g. a neighbour that is still
+   *alive* (so liveness never removes it) but whose downstream route to `d`
+   silently died and stopped being sampled (so reinforcement never refreshes it).
+2. **Time-proportional decay.** Replace the per-arrival `α·v` with
+   `factor = α^(Δt / evaporationInterval)`, with `Δt` taken from **`IClock`**
+   (never wall-clock — golden rule #3; this is what keeps NS-2/NS-3 reproducible
+   and cross-validatable). This decouples decay dynamics from how often the tick
+   fires.
+3. **Single source of aging.** `updateRegular` only *reinforces the travelled
+   link*; **all** aging moves into a new `PheromoneEngine::evaporateAll(table, Δt)`.
+   This structurally removes the reinforce-and-age coupling that caused the D2
+   bug — a correctness win, not just tidiness.
+4. **One tick owns it.** `evaporateAll` runs from the single core
+   `onMaintenanceTick()` already introduced for neighbour liveness (ADR-0008).
+   Because (2) scales by actual `Δt`, the same tick can serve both liveness and
+   evaporation regardless of cadence — no separate evaporation timer.
+5. **Config-gated, default ON.** `Config::enableEvaporation = true`. Turning it
+   off yields the paper-faithful "running-average + explicit-removal only" mode,
+   which [item 08](../improvements/08-protocol-comparison-benchmarks.md) runs as
+   an ablation variant so the benchmark — not intuition — justifies keeping it on.
+
+Virtual pheromone already evaporates on **hello reception** (in `updateVirtual`),
+and hellos are periodic, so that path is effectively periodic and roughly matches
+the Bellman-Ford-style diffusion refresh; it may be aligned onto the same tick for
+consistency but is not the deviation this ADR fixes.
+
+## Alternatives considered
+
+- **Event-driven on reinforcement (status quo).** Indefensible on any reading:
+  decay rate is a function of traffic, and quiet paths never age. Rejected — this
+  is the bug.
+- **First-class, tunable time-proportional decay** (treat `α` as a real adaptation
+  knob). Over-weights a mechanism the spec does not have, and invites tuning
+  evaporation to do the job the running average already does. Rejected as default.
+- **Paper-faithful: remove regular evaporation entirely** (rely solely on
+  running-average + link-failure removal). Closest to the letter of the spec, but
+  leaves no backstop for silently-stale regular entries (the live-neighbour /
+  dead-downstream case above). Kept as the *gate-off ablation*, not the default.
+
+## Consequences
+
+- `α`'s meaning changes: it is now a **per-`evaporationInterval`** retention factor
+  applied in proportion to elapsed time, not a per-event multiplier. `α` and the
+  new `Config::evaporationInterval` must be re-tuned against item 07/08 benchmarks,
+  and on the paper-scale scenario, not the unit-test toy.
+- The reinforce/evaporate split makes `updateRegular` simpler and removes the last
+  remnant of the D2 coupling.
+- A new wire-independent config flag (`enableEvaporation`) and interval; no wire
+  change (consistent with [ADR-0009](0009-backward-ants-carry-path-not-state.md)).
+- Documentation must stop calling time-proportional evaporation "the spec"; it is a
+  deliberate, ablatable extension. `CONTEXT.md` and item 06 are updated to say so.

--- a/docs/improvements/01-data-vs-ant-beta.md
+++ b/docs/improvements/01-data-vs-ant-beta.md
@@ -1,0 +1,173 @@
+# 01 — Wire the `beta` exponent; use a greedier β for data than for ants
+
+- **Deviation:** D1
+- **Priority:** P0 (single biggest performance lever)
+- **Effort:** S
+- **Layer:** `core/` (+ expose attributes in both adapters)
+- **Depends on:** nothing
+
+## Summary
+
+The stochastic next-hop selection (Eq.1) is supposed to use an exponent `β` that
+*differs between ants and data*: a small `β1` for ants (more exploratory) and a
+**larger `β2 ≥ β1`** for data (greedy, concentrates traffic on the best paths).
+Today the selection hard-codes `β = 1` for everything and ignores the configured
+`beta` entirely. This makes data routing spread traffic almost uniformly across
+all paths with any pheromone, which badly hurts delivery ratio.
+
+## Spec reference
+
+> Eq.1: `P_nd = (T_nd^i)^β / Σ_{j∈N_d^i} (T_nd^j)^β`, `β ≥ 1`.
+
+> "Nodes in AntHocNet forward data stochastically according to the pheromone
+> values. ... `P_nd` is calculated like for reactive forward ants, using
+> equation 1. **However, a higher value for the exponent β is used in order to
+> be greedy with respect to better paths.**" — [1], §3.4 (Stochastic data routing)
+
+> "...`β2 ≥ β1`." — [1], Eq. for data routing.
+
+Typical values from the literature: `β1 ≈ 2` (ants), `β2 ≈ 20` (data). Make both
+configurable; defaults below.
+
+## Current behaviour
+
+`beta` is plumbed into `Config` and exposed as an NS-3 attribute, but selection
+uses a file-local constant and never reads `Config::beta`:
+
+```7:9:core/src/pheromone_table.cpp
+namespace {
+constexpr int kBeta = 1;  // default exponent; see note in nextNeighborNode.
+}
+```
+
+```63:71:core/src/pheromone_table.cpp
+double PheromoneTable::sumProbability(const PheromoneMap& table, NodeAddress dest) const {
+    double sum = 0.0;
+    for (NodeAddress neighbor : neighborTable_) {
+        auto it = table.find({neighbor, dest});
+        if (it == table.end()) continue;
+        sum += std::pow(it->second, kBeta);
+    }
+    return sum;
+}
+```
+
+`kBeta` is also used in `sumMaxProbability` (line 80) and `nextNeighborNode`
+(line 109). The same selection is used for **data** (`lookup` → `nextNeighborNode(dest, false)`)
+and for **reactive forward ants** (`selectNextHop` → `nextNeighborNode(dest, false)`),
+so there is currently no way to be greedier for data.
+
+`Config::beta` (`core/include/anthocnet/core/config.h:20`) defaults to `1` and is
+unused by the table.
+
+## Impact
+
+With `β = 1`, `P_nd` is linear in pheromone: a path twice as good gets only twice
+the traffic, and very poor paths still receive a meaningful share. Data is
+sprayed over inferior routes → more loss, reordering, and congestion. This is the
+most likely single cause of the low delivery ratio in `docs/benchmarks.md`
+(AntHocNet 10% vs OLSR 34%).
+
+## Required change
+
+The selection function needs to know **which exponent to use**, because the same
+function serves ants (β1) and data (β2). Plumb an explicit `beta` parameter down
+from the call sites.
+
+### 1. Config — two exponents
+
+In `core/include/anthocnet/core/config.h`, replace the single `beta` with:
+
+```cpp
+double betaAnts = 2.0;   ///< BETA1: exponent for ant next-hop choice (exploratory).
+double betaData = 20.0;  ///< BETA2: exponent for data next-hop choice (greedy). betaData >= betaAnts.
+```
+
+(Keep them `double`: Eq.1 permits non-integer exponents and `std::pow` is already
+used.)
+
+### 2. PheromoneTable — accept beta as an argument
+
+In `core/src/pheromone_table.cpp` / its header, remove `kBeta` and thread `double beta`
+through `sumProbability`, `sumMaxProbability`, and `nextNeighborNode`:
+
+```cpp
+NodeAddress PheromoneTable::nextNeighborNode(NodeAddress dest, bool isProactiveAnt,
+                                             double beta, IRng& rng) const;
+NodeAddress PheromoneTable::lookup(NodeAddress dest, double beta, IRng& rng) const;
+```
+
+Use `std::pow(weight, beta)` everywhere `std::pow(weight, kBeta)` appears.
+
+### 3. AntRouterLogic — pass β1 for ants, β2 for data
+
+In `core/src/ant_router_logic.cpp`:
+
+- `selectNextHop(dest, proactive)` (used for forward ants, reactive + proactive)
+  → call `table_.nextNeighborNode(dest, proactive, config_.betaAnts, rng_)`.
+- `onDataPacket(dest)` → call `table_.lookup(dest, config_.betaData, rng_)`.
+
+Note the NS-3 adapter calls `m_logic->selectNextHop(...)` directly in
+`RouteOutput`/`RouteInput`/`FlushQueue` to route **data**. Add a dedicated data
+lookup on the logic so adapters route data with β2:
+
+```cpp
+// AntRouterLogic
+NodeAddress AntRouterLogic::nextHopForData(NodeAddress dest) {
+    return table_.lookup(dest, config_.betaData, rng_);
+}
+```
+
+Then change the NS-3 adapter's data paths (`anthocnet-routing-protocol.cc`
+`RouteOutput`, `RouteInput`, `FlushQueue`) from `selectNextHop(ToCore(dst), false)`
+to `m_logic->nextHopForData(ToCore(dst))`. (NS-2 routes data via
+`onDataPacket`, which already goes through the core — no adapter change needed
+there beyond confirming.)
+
+### 4. Expose the two attributes in adapters
+
+- **NS-3** (`anthocnet-routing-protocol.cc` `GetTypeId` + members): replace the
+  single `Beta` attribute/`m_beta` with `BetaAnts` (default 2.0) and `BetaData`
+  (default 20.0), `DoubleValue`, and set `m_config.betaAnts/.betaData` in
+  `DoInitialize`/`NotifyInterfaceUp`.
+- **NS-2** (`ns2/src/ahn_router.*`): add `bind("beta_ants_", ...)` and
+  `bind("beta_data_", ...)`, copy into `config_` in `startProtocol`. Add defaults
+  to `ns2/patch/fragments/ns-default.tcl.fragment`.
+
+## Files to touch
+
+- `core/include/anthocnet/core/config.h`
+- `core/include/anthocnet/core/pheromone_table.h`
+- `core/src/pheromone_table.cpp`
+- `core/include/anthocnet/core/ant_router_logic.h`
+- `core/src/ant_router_logic.cpp`
+- `ns3/model/anthocnet-routing-protocol.{h,cc}`
+- `ns2/src/ahn_router.{h,cc}`, `ns2/patch/fragments/ns-default.tcl.fragment`
+
+## Acceptance criteria
+
+Add `core/tests/test_beta_selection.cpp` (register in `core/tests/CMakeLists.txt`):
+
+1. **Greedier β concentrates choice.** Build a table for one dest with two
+   neighbours whose pheromones are `2.0` and `1.0`. Using a deterministic
+   `ScriptedRng` sweep of `r ∈ {0.1,...,0.9}`, assert that with `betaData = 20`
+   the better neighbour is chosen for (almost) all `r`, whereas with `beta = 1`
+   it is chosen ~2/3 of the time. (i.e. the selection distribution changes with
+   β.)
+2. **Ants vs data use different exponents.** With `betaAnts=1`, `betaData=20`
+   and the same table/RNG, `selectNextHop(dest,false)` and `nextHopForData(dest)`
+   can return different next hops for the same `r`.
+3. **`betaData` is actually read** (regression for D1): changing
+   `Config::betaData` changes the result of `nextHopForData` for a fixed RNG
+   sequence.
+4. Existing `test_pheromone_table.cpp` updated for the new signatures; `make test`
+   green.
+
+## Risks / notes
+
+- This changes the public signatures of `PheromoneTable::nextNeighborNode` /
+  `lookup`. Update all call sites (NS-3 adapter calls `selectNextHop`/`lookup`).
+- Very large `β2` with `std::pow` is fine for the small pheromone magnitudes used
+  here, but guard against `0^β = 0` (already handled by `phSum == 0` early-out).
+- This is a behaviour change only; **no wire-format change**, so codec/adapters
+  headers are unaffected.

--- a/docs/improvements/02-backward-ant-delay-metric.md
+++ b/docs/improvements/02-backward-ant-delay-metric.md
@@ -1,0 +1,195 @@
+# 02 — Fix the backward-ant delay metric (units + per-hop accumulation)
+
+- **Deviation:** D2
+- **Priority:** P0
+- **Effort:** M
+- **Layer:** `core/`
+- **Depends on:** nothing (but pairs naturally with 01)
+
+## Summary
+
+The pheromone a backward ant deposits is supposed to blend a **time estimate**
+`T̂_d^i` with a **hop-count estimate** `h·T_hop` (Eq.2). In the current code two
+problems make the *time* term effectively vanish, so pheromone ≈ a function of
+hop count alone. That throws away the delay/congestion awareness that is the
+whole point of AntHocNet's quality metric.
+
+## Spec reference
+
+> Eq.2: `τ_d^i = ( (T̂_d^i + h·T_hop) / 2 )^{-1}`
+> where `T̂_d^i` is the estimated **time** for a data packet to travel from `i`
+> to `d` along path `P`, computed incrementally as the sum of per-hop local time
+> estimates `T̂_{j,j+1}`, and `h` is the number of hops from `i` to `d`. — [1] §3.2
+
+> The per-hop local estimate is a running average of the measured MAC
+> queue+transmit time: `T̂_mac = α·T̂_mac + (1−α)·t_mac`. — [1] §3.2
+
+Key point: `T̂_d^i` and `h·T_hop` must be in the **same units** and **comparable
+in magnitude**, so the average `(T̂ + h·T_hop)/2` genuinely blends *time* and
+*hops*. `T_hop` is "the time to take one hop in unloaded conditions" — i.e. tens
+of milliseconds, the same order as a real per-hop delay.
+
+## Current behaviour
+
+Forward ants store, at each hop, the **cumulative** time since the ant was
+created (not a per-hop delta):
+
+```86:90:core/src/ant_router_logic.cpp
+void AntRouterLogic::stampForward(AntMessage& ant) const {
+    if (ant.visited.size() >= config_.maxPathLength) return;
+    const double trip = clock_.now() - ant.timeStart;
+    ant.visited.push_back({address_, trip});
+}
+```
+
+The backward ant then **sums those cumulative stamps** and divides by 1000:
+
+```92:108:core/src/ant_router_logic.cpp
+NodeAddress AntRouterLogic::advanceBackAnt(AntMessage& ant) const {
+    if (ant.visited.empty()) return kInvalidAddress;
+
+    const AntHop current = ant.visited.back();  // this node
+    ant.prevHop = current.node;
+    ant.hops += 1;
+    ant.prevSINR += current.time;
+
+    const double simpleSINR = ant.prevSINR / 1000.0;
+    ant.pheromone = std::pow((ant.hops * config_.hopTimeMs + simpleSINR) / 2.0, -1.0);
+
+    ant.history.push_back(current);
+    ant.visited.pop_back();
+    ...
+```
+
+Two defects:
+
+1. **Wrong accumulation.** `visited[k].time` is *time-since-source* (cumulative),
+   so summing them across hops (`prevSINR += current.time`) is not the path time
+   `T̂_d^i`; it over-counts (roughly a triangular sum of cumulative stamps).
+2. **Unit mismatch / scaling.** `clock_.now()` is in **seconds**, `hopTimeMs` is
+   in **milliseconds** (default 50), and the code further divides the time term
+   by 1000. With per-hop delays ~0.01 s, `simpleSINR` ends up ~1e-4 while
+   `hops·hopTimeMs` is 50–150. The time term is ~6 orders of magnitude too small,
+   so `τ ≈ (h·hopTimeMs/2)^{-1}` — **pure inverse hop count.**
+
+Net effect: the protocol behaves like stochastic shortest-hop routing; delay and
+congestion never influence pheromone.
+
+## Impact
+
+- Loses load-balancing and congestion-avoidance (a core AntHocNet advantage).
+- Makes the `hopTimeMs` "blend" meaningless and the metric non-physical.
+- Interacts with 01: even with a greedy β, "greedy" currently means "fewest hops"
+  rather than "lowest delay".
+
+## Required change
+
+Make the forward ant carry **per-hop deltas**, accumulate the true path time on
+the way back, and keep everything in consistent units (seconds internally;
+express `T_hop` in seconds too).
+
+### 1. Store per-hop time, not cumulative
+
+Change `stampForward` to record the delta since the previous hop. Add a small
+field to `AntMessage` to remember the last stamp time, or compute the delta from
+the previous `visited` entry's absolute time. Cleanest: store **absolute arrival
+time** per hop and difference on the backward pass.
+
+Proposed: store absolute time at each hop:
+
+```cpp
+void AntRouterLogic::stampForward(AntMessage& ant) const {
+    if (ant.visited.size() >= config_.maxPathLength) return;
+    ant.visited.push_back({address_, clock_.now()});  // absolute arrival time
+}
+```
+
+### 2. Accumulate true path time on the backward pass
+
+`T̂_d^i` = (time the ant arrived at `d`) − (time it arrived at `i`). Since the
+back ant pops from `d` toward the source, track the destination's arrival time
+once and subtract the current hop's arrival time:
+
+```cpp
+NodeAddress AntRouterLogic::advanceBackAnt(AntMessage& ant) const {
+    if (ant.visited.empty()) return kInvalidAddress;
+    const AntHop current = ant.visited.back();  // node i, absolute arrival time
+
+    ant.prevHop = current.node;
+    ant.hops   += 1;
+
+    // ant.timeDest is the absolute time the forward ant reached the destination
+    // (set once in createBackAnt). Path time from i to d:
+    const double tHat = ant.timeDest - current.time;          // seconds
+    const double hopCost = ant.hops * config_.hopTimeSec;     // seconds
+    ant.pheromone = std::pow((tHat + hopCost) / 2.0, -1.0);
+
+    ant.history.push_back(current);
+    ant.visited.pop_back();
+    if (ant.visited.empty()) return kInvalidAddress;
+    return ant.visited.back().node;
+}
+```
+
+`createBackAnt` sets `b.timeDest = clock_.now()` (the moment the forward ant
+reached the destination), and `visited` is copied from the forward ant.
+
+### 3. Config: T_hop in seconds
+
+In `config.h`, replace `int hopTimeMs = 50;` with `double hopTimeSec = 0.05;`
+(50 ms expressed in seconds, matching `clock_.now()`), and update the comment.
+Remove the stray `/1000.0`.
+
+### 4. (Recommended) real per-hop MAC estimate — optional, behind a flag
+
+The fully faithful version replaces the wall-clock delta with a smoothed local
+MAC delay `T̂_mac = α·T̂_mac + (1−α)·t_mac` measured by each node, carried as the
+per-hop cost. This needs the adapter to feed a measured/queue+tx time into the
+core (a new port or a value passed on `stampForward`). If you do not have a MAC
+delay signal available in the simulator yet, implement steps 1–3 (correct
+wall-clock path time) and leave a `// TODO(D2): smoothed MAC estimate` note. Step
+1–3 already restore a meaningful, correctly-scaled time term.
+
+### 5. Rename the misnomer
+
+`AntMessage::prevSINR` is not SINR; it is accumulated time. If you keep an
+accumulator field, rename to `pathTime`. Update the codec
+(`core/src/ant_message_codec.cpp`) and both adapter headers + `test_codec.cpp` if
+the set of serialized fields changes. (Note: `prevSINR`/`pathTime`, `hops`,
+`pheromone`, `prevHop` are transient back-ant working fields — confirm whether
+they actually need to be on the wire at all; if a backward ant is only ever
+processed hop-by-hop locally, these can be recomputed and need **not** be
+serialized, which simplifies the wire format. Verify against both adapters before
+removing.)
+
+## Files to touch
+
+- `core/include/anthocnet/core/config.h` (`hopTimeSec`)
+- `core/include/anthocnet/core/ant_message.h` (`timeDest`; rename `prevSINR`)
+- `core/src/ant_router_logic.cpp` (`stampForward`, `createBackAnt`, `advanceBackAnt`)
+- `core/src/ant_message_codec.cpp` + `ns2/src/ant_packet_ns2.*` +
+  `ns3/model/anthocnet-packet.cc` + `core/tests/test_codec.cpp` (only if the wire
+  field set changes)
+
+## Acceptance criteria
+
+Add `core/tests/test_backant_metric.cpp`:
+
+1. **Time influences pheromone.** Construct two paths to the same destination
+   with equal hop count but different per-hop times (drive `FakeClock` so one
+   path accrues more time). Assert the faster path yields a **strictly higher**
+   pheromone after `advanceBackAnt`/`reinforce`. (Today they'd be equal.)
+2. **Units sane.** For a 3-hop path with ~50 ms/hop and `hopTimeSec=0.05`, assert
+   `τ` is within a plausible band (e.g. `τ⁻¹` between `0.05` and `0.5` s), proving
+   the time term is no longer ~1e-4.
+3. **Hop term still present.** With near-zero measured time, `τ ≈ (h·hopTimeSec/2)⁻¹`.
+4. `make test` green; `test_network_integration.cpp` still discovers the route.
+
+## Risks / notes
+
+- `FakeClock` in `core/tests/test_support.h` must allow advancing time between
+  hops; check it supports `advance()`/settable now. Extend if needed.
+- If you remove transient fields from the wire format, do it as one atomic change
+  across codec + both adapters + `test_codec.cpp` (see README "Definition of
+  done").
+- Keep the change isolated from 01 so each can be benchmarked independently.

--- a/docs/improvements/02-backward-ant-delay-metric.md
+++ b/docs/improvements/02-backward-ant-delay-metric.md
@@ -3,8 +3,14 @@
 - **Deviation:** D2
 - **Priority:** P0
 - **Effort:** M
-- **Layer:** `core/`
+- **Layer:** `core/` + codec + **both adapter headers** (this is a wire change)
 - **Depends on:** nothing (but pairs naturally with 01)
+- **Decision:** **slim the wire** per
+  [ADR-0009](../adr/0009-backward-ants-carry-path-not-state.md) — a backward ant
+  carries identity + the path only; `pheromone`/`hops`/`prevSINR`/`prevHop` come
+  **off** the wire, time is a **per-hop delta**, and `kWireVersion` is bumped
+  ([ADR-0006](../adr/0006-on-wire-protocol-version.md)). Coordinate the version
+  number with item 12 (whichever lands first introduces `kWireVersion`).
 
 ## Summary
 
@@ -84,45 +90,45 @@ congestion never influence pheromone.
 
 ## Required change
 
-Make the forward ant carry **per-hop deltas**, accumulate the true path time on
-the way back, and keep everything in consistent units (seconds internally;
-express `T_hop` in seconds too).
+Make the forward ant carry **per-hop deltas** in the existing `AntHop.time` slot,
+accumulate the true path time on the way back, and keep everything in consistent
+units (seconds internally; express `T_hop` in seconds too). No new wire field.
 
-### 1. Store per-hop time, not cumulative
+### 1. Store per-hop time delta, not cumulative
 
-Change `stampForward` to record the delta since the previous hop. Add a small
-field to `AntMessage` to remember the last stamp time, or compute the delta from
-the previous `visited` entry's absolute time. Cleanest: store **absolute arrival
-time** per hop and difference on the backward pass.
-
-Proposed: store absolute time at each hop:
+Change `stampForward` to record the delta since the previous hop. Keep a local
+last-stamp time on the message (a working field, **not** serialized) or derive
+the delta from the elapsed time since the previous stamp:
 
 ```cpp
 void AntRouterLogic::stampForward(AntMessage& ant) const {
     if (ant.visited.size() >= config_.maxPathLength) return;
-    ant.visited.push_back({address_, clock_.now()});  // absolute arrival time
+    const double now   = clock_.now();
+    const double delta = now - ant.lastStamp;   // lastStamp init'd to timeStart at the source
+    ant.lastStamp = now;
+    ant.visited.push_back({address_, delta});    // per-hop delta (seconds)
 }
 ```
 
+`AntHop.time` now means **per-hop delta**, not cumulative-since-source — a
+semantic change to an existing wire field, so `kWireVersion` is bumped (step 5).
+
 ### 2. Accumulate true path time on the backward pass
 
-`T̂_d^i` = (time the ant arrived at `d`) − (time it arrived at `i`). Since the
-back ant pops from `d` toward the source, track the destination's arrival time
-once and subtract the current hop's arrival time:
+`T̂_d^i` is the sum of per-hop deltas from `i` to `d`. The back ant pops from `d`
+toward the source, so accumulate the deltas it walks over (no `timeDest`, no
+absolute times):
 
 ```cpp
 NodeAddress AntRouterLogic::advanceBackAnt(AntMessage& ant) const {
     if (ant.visited.empty()) return kInvalidAddress;
-    const AntHop current = ant.visited.back();  // node i, absolute arrival time
+    const AntHop current = ant.visited.back();   // node i, per-hop delta in .time
 
-    ant.prevHop = current.node;
-    ant.hops   += 1;
-
-    // ant.timeDest is the absolute time the forward ant reached the destination
-    // (set once in createBackAnt). Path time from i to d:
-    const double tHat = ant.timeDest - current.time;          // seconds
-    const double hopCost = ant.hops * config_.hopTimeSec;     // seconds
-    ant.pheromone = std::pow((tHat + hopCost) / 2.0, -1.0);
+    // hops, prevHop, pheromone are LOCAL working fields (not on the wire, ADR-0009):
+    const int    hops    = static_cast<int>(ant.history.size()) + 1;  // derived
+    const double tHat    = (ant.pathTime += current.time);            // running sum of deltas
+    const double hopCost = hops * config_.hopTimeSec;                 // seconds
+    const double pheromone = std::pow((tHat + hopCost) / 2.0, -1.0);  // applied locally via reinforce()
 
     ant.history.push_back(current);
     ant.visited.pop_back();
@@ -131,8 +137,9 @@ NodeAddress AntRouterLogic::advanceBackAnt(AntMessage& ant) const {
 }
 ```
 
-`createBackAnt` sets `b.timeDest = clock_.now()` (the moment the forward ant
-reached the destination), and `visited` is copied from the forward ant.
+`pathTime` is a **local** accumulator (the renamed-and-de-serialized successor to
+`prevSINR`); `hops`/`pheromone`/`prevHop` are likewise local and recomputed each
+hop — none are serialized (step 5).
 
 ### 3. Config: T_hop in seconds
 
@@ -150,26 +157,38 @@ delay signal available in the simulator yet, implement steps 1–3 (correct
 wall-clock path time) and leave a `// TODO(D2): smoothed MAC estimate` note. Step
 1–3 already restore a meaningful, correctly-scaled time term.
 
-### 5. Rename the misnomer
+### 5. Slim the wire (ADR-0009) + bump `kWireVersion`
 
-`AntMessage::prevSINR` is not SINR; it is accumulated time. If you keep an
-accumulator field, rename to `pathTime`. Update the codec
-(`core/src/ant_message_codec.cpp`) and both adapter headers + `test_codec.cpp` if
-the set of serialized fields changes. (Note: `prevSINR`/`pathTime`, `hops`,
-`pheromone`, `prevHop` are transient back-ant working fields — confirm whether
-they actually need to be on the wire at all; if a backward ant is only ever
-processed hop-by-hop locally, these can be recomputed and need **not** be
-serialized, which simplifies the wire format. Verify against both adapters before
-removing.)
+Confirmed: both adapters only *marshal* `prevSINR`/`pheromone`/`hops`/`prevHop`
+(`ns2/src/ant_packet_ns2.cc`, `ns3/model/anthocnet-packet.cc`); nothing reads them
+to decide, and the core recomputes them per hop. So **remove them from the wire**:
+
+- Delete them from `serialize`/`deserialize`, the size constants, the NS-2 POD
+  header (`ant_packet_ns2`), and the NS-3 `AntHeader`
+  (`anthocnet-packet.cc`). In the `AntMessage` struct they become local working
+  fields (or `prevSINR` → a private `pathTime` accumulator); they are no longer
+  part of the serialized image.
+- **Bump `kWireVersion`** for the combined change (slim + `AntHop.time` delta
+  semantics). Don't hard-code the number — use `current + 1`, and coordinate with
+  item 12 (whichever lands first introduces the constant).
+- Update `core/tests/test_codec.cpp`: the round-trip no longer carries those
+  fields, and a decoded backward ant leaves `pheromone`/`hops` at their defaults
+  (the core fills them).
+
+Target layout (with the version byte from item 12) is in
+[`docs/wire-format.md`](../wire-format.md).
 
 ## Files to touch
 
 - `core/include/anthocnet/core/config.h` (`hopTimeSec`)
-- `core/include/anthocnet/core/ant_message.h` (`timeDest`; rename `prevSINR`)
+- `core/include/anthocnet/core/ant_message.h` (`AntHop.time` = per-hop delta;
+  demote `pheromone`/`hops`/`prevHop` to local working fields; `prevSINR` →
+  private `pathTime` accumulator — all four leave the serialized image)
 - `core/src/ant_router_logic.cpp` (`stampForward`, `createBackAnt`, `advanceBackAnt`)
 - `core/src/ant_message_codec.cpp` + `ns2/src/ant_packet_ns2.*` +
-  `ns3/model/anthocnet-packet.cc` + `core/tests/test_codec.cpp` (only if the wire
-  field set changes)
+  `ns3/model/anthocnet-packet.cc` + `core/tests/test_codec.cpp` (**wire change**:
+  drop the four fields, bump `kWireVersion`)
+- `docs/wire-format.md` (keep the byte table in sync)
 
 ## Acceptance criteria
 
@@ -183,13 +202,19 @@ Add `core/tests/test_backant_metric.cpp`:
    `τ` is within a plausible band (e.g. `τ⁻¹` between `0.05` and `0.5` s), proving
    the time term is no longer ~1e-4.
 3. **Hop term still present.** With near-zero measured time, `τ ≈ (h·hopTimeSec/2)⁻¹`.
-4. `make test` green; `test_network_integration.cpp` still discovers the route.
+4. **Wire slimmed (ADR-0009).** `serializedSize` of a backward ant drops by the
+   four removed fields (−24 bytes); a round-trip through the codec carries
+   `visited`/`history` but a freshly decoded message has `pheromone`/`hops` at
+   defaults (the core fills them). `kWireVersion` is the previous value + 1.
+5. `make test` green; `test_network_integration.cpp` still discovers the route.
 
 ## Risks / notes
 
 - `FakeClock` in `core/tests/test_support.h` must allow advancing time between
   hops; check it supports `advance()`/settable now. Extend if needed.
-- If you remove transient fields from the wire format, do it as one atomic change
-  across codec + both adapters + `test_codec.cpp` (see README "Definition of
-  done").
-- Keep the change isolated from 01 so each can be benchmarked independently.
+- The wire slim is **one atomic change** across the struct + codec + both adapter
+  headers + `test_codec.cpp` + `docs/wire-format.md` (golden rule #4 / ADR-0006).
+  Coordinate the `kWireVersion` number with item 12 — don't hard-code it.
+- Verify nothing *else* reads the four removed fields cross-hop before deleting
+  (the adapters were checked; re-confirm if other call sites appeared).
+- Keep the metric change isolated from 01 so each can be benchmarked independently.

--- a/docs/improvements/03-pheromone-diffusion.md
+++ b/docs/improvements/03-pheromone-diffusion.md
@@ -3,8 +3,13 @@
 - **Deviation:** D3
 - **Priority:** P1
 - **Effort:** M
-- **Layer:** `core/` (+ codec, both adapter headers)
+- **Layer:** `core/` (+ `config.h`; no wire change)
 - **Depends on:** 02 (so the advertised value is a real goodness estimate)
+- **Decision:** keep diffusion but **config-gated**, per
+  [ADR-0007](../adr/0007-proactive-diffusion-gated.md). All work below is behind
+  `Config::enableProactive` / `enableDiffusion` (default on) so the benchmark
+  ablation in [item 08](08-protocol-comparison-benchmarks.md) can justify the
+  shipped default.
 
 ## Summary
 
@@ -12,7 +17,7 @@ AntHocNet's *pheromone diffusion* lets nodes learn about destinations they have
 never reached by gossiping pheromone estimates in hello messages. Each hello
 should carry the sender's **best (bootstrapped) pheromone** per advertised
 destination; the receiver combines it with the cost to the sender to form a
-*virtual / diffused* pheromone used to guide proactive ants. Today every hello
+*virtual* pheromone (the papers call it "diffused") used to guide proactive ants. Today every hello
 advertises a **constant `1.0`**, so virtual pheromone is just a reachability bit
 with no goodness gradient — the diffusion mechanism is effectively absent.
 
@@ -82,6 +87,24 @@ ones — minor, but it inflates hello size.
 
 ## Required change
 
+### 0. Gate the diffusion subsystem (ADR-0007)
+
+Add the flags and short-circuit when off:
+
+```cpp
+// config.h
+bool enableProactive = true;   // master: proactive ants + per-hop broadcast (item 04)
+bool enableDiffusion = true;   // hello pheromone adverts + virtual table; only effective when enableProactive
+```
+
+- `createHelloAnt` adds **no** `helloDests` adverts when
+  `!enableProactive || !enableDiffusion` (hellos still serve neighbour
+  discovery/liveness — [item 05](05-link-failure-detection-and-repair.md)).
+- `updateVirtual` is a no-op when disabled, so the virtual table stays empty and
+  `sumMaxProbability` degenerates to the regular-only sum.
+- No wire-format change either way (the adverts list is simply empty; no
+  `kWireVersion` bump — [ADR-0006](../adr/0006-on-wire-protocol-version.md)).
+
 ### 1. Advertise the sender's best real pheromone
 
 Add a helper to `PheromoneTable`:
@@ -109,7 +132,7 @@ for (NodeAddress dest : dests) {
 }
 ```
 
-### 2. Bootstrap the diffused value on receive
+### 2. Bootstrap the virtual value on receive
 
 In `PheromoneEngine::updateVirtual`, form the virtual pheromone from the
 advertised goodness **discounted by one hop** (the cost to reach the advertising
@@ -128,7 +151,7 @@ double phValue = table.getPheromoneVirtual(advert.node, neighbor);
 table.setPheromoneVirtual(advert.node, neighbor, reinforce(phValue, bootstrapped));
 ```
 
-This keeps diffused pheromone consistent in units with regular pheromone (item
+This keeps virtual pheromone consistent in units with regular pheromone (item
 02) and naturally makes farther/worse advertised paths produce smaller virtual
 pheromone — a real gradient.
 
@@ -144,12 +167,43 @@ pheromone — a real gradient.
 Do **not** change this; add a regression test (below) so a future edit can't leak
 virtual pheromone into data routing.
 
+### 4. Let proactive selection reach virtual-only destinations (reach-guard fix)
+
+Diffusion's whole point is to route toward destinations a node has **not** sampled
+with ants — but `nextNeighborNode` bails before the blend unless the destination
+is already in the **regular** set, so a purely-diffused destination is unroutable
+even for a proactive ant:
+
+```86:89:core/src/pheromone_table.cpp
+    // Unknown destination: no route.
+    if (destRegular_.find(dest) == destRegular_.end()) {
+        return kInvalidAddress;
+    }
+```
+
+Relax this guard **for proactive selection only**: a destination is routable if it
+is in the regular set, **or** (when `isProactiveAnt`) in the virtual set. Data
+(`isProactiveAnt == false`) must still require a regular entry, so step 3's
+invariant is untouched:
+
+```cpp
+const bool known = destRegular_.count(dest) ||
+                   (isProactiveAnt && destVirtual_.count(dest));
+if (!known) return kInvalidAddress;
+```
+
+Without this, diffusion can never extend reach and the rest of this item is inert
+(see [ADR-0007](../adr/0007-proactive-diffusion-gated.md) context).
+
 ## Files to touch
 
-- `core/include/anthocnet/core/pheromone_table.h` / `.cpp` (`bestRegular`)
-- `core/src/ant_router_logic.cpp` (`createHelloAnt`)
-- `core/src/pheromone_engine.cpp` (`updateVirtual` bootstrap)
-- (No wire-format change: `HelloDest{node, pheromone}` already carries a double.)
+- `core/include/anthocnet/core/config.h` (`enableProactive`, `enableDiffusion`)
+- `core/include/anthocnet/core/pheromone_table.h` / `.cpp` (`bestRegular`,
+  reach-guard relaxation in `nextNeighborNode`)
+- `core/src/ant_router_logic.cpp` (`createHelloAnt` gating)
+- `core/src/pheromone_engine.cpp` (`updateVirtual` bootstrap + gating)
+- (No wire-format change: `HelloDest{node, pheromone}` already carries a double;
+  when diffusion is off the adverts list is just empty.)
 
 ## Acceptance criteria
 
@@ -161,17 +215,21 @@ Extend `core/tests/test_pheromone_engine.cpp` / add `test_diffusion.cpp`:
 2. **Diffusion produces a gradient.** Two neighbours advertise the same dest with
    different pheromones; after `updateVirtual`, the virtual pheromone via the
    better neighbour is strictly higher.
-3. **One-hop discount.** A diffused (virtual) pheromone for `d` via `m` is
+3. **One-hop discount.** A virtual pheromone for `d` via `m` is
    strictly less than `m`'s advertised pheromone (cost increased by one hop).
-4. **Data ignores virtual pheromone (regression for the guard).** With *only*
-   virtual pheromone for a dest and no regular, `nextHopForData(dest)` returns
-   `kInvalidAddress`, while a proactive `selectNextHop(dest, true)` returns a hop.
-5. `make test` green.
+4. **Data ignores virtual pheromone; proactive reaches it (guard fix).** With
+   *only* virtual pheromone for a dest and no regular, `nextHopForData(dest)`
+   returns `kInvalidAddress`, while a proactive `selectNextHop(dest, true)`
+   returns a hop (validates step 4's relaxed guard *and* step 3's data invariant).
+5. **Gate off ⇒ no virtual pheromone.** With `enableDiffusion = false`,
+   `createHelloAnt` emits zero `helloDests`, `updateVirtual` is a no-op, and a
+   proactive `selectNextHop` for a virtual-only dest returns `kInvalidAddress`.
+6. `make test` green.
 
 ## Risks / notes
 
 - Depends on item 02's consistent units (`hopTimeSec`); if 02 isn't done yet, use
-  the same constant the back-ant metric uses so diffused and regular pheromone
+  the same constant the back-ant metric uses so virtual and regular pheromone
   remain comparable.
 - Hello size: advertising real values doesn't change the field count, but if you
   later cap to active destinations (item 04) wire size shrinks.

--- a/docs/improvements/03-pheromone-diffusion.md
+++ b/docs/improvements/03-pheromone-diffusion.md
@@ -1,0 +1,177 @@
+# 03 — Real pheromone diffusion (bootstrapped pheromone in hello messages)
+
+- **Deviation:** D3
+- **Priority:** P1
+- **Effort:** M
+- **Layer:** `core/` (+ codec, both adapter headers)
+- **Depends on:** 02 (so the advertised value is a real goodness estimate)
+
+## Summary
+
+AntHocNet's *pheromone diffusion* lets nodes learn about destinations they have
+never reached by gossiping pheromone estimates in hello messages. Each hello
+should carry the sender's **best (bootstrapped) pheromone** per advertised
+destination; the receiver combines it with the cost to the sender to form a
+*virtual / diffused* pheromone used to guide proactive ants. Today every hello
+advertises a **constant `1.0`**, so virtual pheromone is just a reachability bit
+with no goodness gradient — the diffusion mechanism is effectively absent.
+
+## Spec reference
+
+> "The proactive behaviour is supported by a lightweight information
+> bootstrapping process. ... nodes include in the hello messages they send out
+> routing information they have about active destinations." — [1] §3.3
+
+> A node `n` receiving from neighbour `m` an advertised pheromone `T_md` computes
+> a **bootstrapped pheromone** for going to `d` via `m`. In Bellman-Ford fashion
+> it combines `m`'s estimate with the local cost to reach `m`. The diffused value
+> is reliable enough to **guide proactive ants** exploring for new paths, but is
+> **not** used directly by data (data uses regular pheromone only). — [2], diffusion section
+
+So:
+- Hello advertises **the sender's best pheromone** `max_n T_nd` per destination
+  `d` (the goodness of the sender's best path to `d`), not a constant.
+- Receiver forms virtual pheromone `T^virt_{m,d}` from that advert + the cost to
+  `m` (1 hop), via the same bootstrapped average used for reinforcement.
+- Virtual pheromone feeds proactive ant selection (already wired via
+  `sumMaxProbability`) and never data (already correct).
+
+## Current behaviour
+
+Hello adverts are hard-coded to `1.0`:
+
+```43:61:core/src/ant_router_logic.cpp
+AntMessage AntRouterLogic::createHelloAnt(std::size_t maxAdverts) {
+    AntMessage m;
+    ...
+    const auto& dests = table_.regularDestinations();
+    for (NodeAddress dest : dests) {
+        if (dests.size() <= maxAdverts ||
+            (rng_.uniform() > 0.5 && m.helloDests.size() < maxAdverts)) {
+            m.helloDests.push_back({dest, 1.0});   // <-- constant, no goodness
+        }
+        if (m.helloDests.size() >= maxAdverts) break;
+    }
+    return m;
+}
+```
+
+The receiver reinforces virtual pheromone toward that advert value:
+
+```95:100:core/src/pheromone_engine.cpp
+    const NodeAddress neighbor = hello.src;
+    for (const HelloDest& advert : hello.helloDests) {
+        double phValue = table.getPheromoneVirtual(advert.node, neighbor);
+        table.setPheromoneVirtual(advert.node, neighbor, reinforce(phValue, advert.pheromone));
+    }
+```
+
+Because `advert.pheromone` is always `1.0`, all virtual links converge to `1.0` →
+no ordering between alternatives.
+
+Also: it advertises **all** regular destinations (random subset), not "active"
+ones — minor, but it inflates hello size.
+
+## Impact
+
+- Proactive exploration can't be *guided* by diffusion (its stated purpose in the
+  paper), so it falls back to blind broadcast — more overhead, fewer useful new
+  paths.
+- Nodes can't pre-position routing info toward soon-to-be-used destinations,
+  losing one of AntHocNet's latency advantages on route setup.
+
+## Required change
+
+### 1. Advertise the sender's best real pheromone
+
+Add a helper to `PheromoneTable`:
+
+```cpp
+double PheromoneTable::bestRegular(NodeAddress dest) const {
+    double best = 0.0;
+    for (NodeAddress n : neighborTable_) {
+        best = std::max(best, getPheromoneRegular(dest, n));
+    }
+    return best;
+}
+```
+
+In `createHelloAnt`, advertise that value (skip destinations with no usable
+pheromone):
+
+```cpp
+for (NodeAddress dest : dests) {
+    double best = table_.bestRegular(dest);
+    if (best <= config_.minPheromone) continue;
+    // (optional) bias toward active destinations — see item 04
+    m.helloDests.push_back({dest, best});
+    if (m.helloDests.size() >= maxAdverts) break;
+}
+```
+
+### 2. Bootstrap the diffused value on receive
+
+In `PheromoneEngine::updateVirtual`, form the virtual pheromone from the
+advertised goodness **discounted by one hop** (the cost to reach the advertising
+neighbour), instead of reinforcing toward the raw advert. A simple, spec-aligned
+bootstrap: treat the advert as `T_md` (the neighbour's best path cost-inverse to
+`d`), and the local one-hop step as adding `T_hop` to the underlying time. Since
+pheromone is an inverse-cost, convert, add a hop, invert back:
+
+```cpp
+// advert.pheromone == neighbour m's best pheromone to d == 1 / cost_m
+// diffused via m: cost = cost_m + T_hop  =>  bootstrapped = 1 / (1/advert + T_hop)
+double bootstrapped = (advert.pheromone > 0.0)
+    ? 1.0 / (1.0 / advert.pheromone + config_.hopTimeSec)
+    : 0.0;
+double phValue = table.getPheromoneVirtual(advert.node, neighbor);
+table.setPheromoneVirtual(advert.node, neighbor, reinforce(phValue, bootstrapped));
+```
+
+This keeps diffused pheromone consistent in units with regular pheromone (item
+02) and naturally makes farther/worse advertised paths produce smaller virtual
+pheromone — a real gradient.
+
+### 3. Keep data on regular pheromone only (already correct — add a guard test)
+
+`nextNeighborNode` only consults virtual pheromone when `isProactiveAnt` is true:
+
+```102:105:core/src/pheromone_table.cpp
+        bool useR = itR != pheromoneRegular_.end();
+        bool useV = (itV != pheromoneVirtual_.end()) && isProactiveAnt;
+```
+
+Do **not** change this; add a regression test (below) so a future edit can't leak
+virtual pheromone into data routing.
+
+## Files to touch
+
+- `core/include/anthocnet/core/pheromone_table.h` / `.cpp` (`bestRegular`)
+- `core/src/ant_router_logic.cpp` (`createHelloAnt`)
+- `core/src/pheromone_engine.cpp` (`updateVirtual` bootstrap)
+- (No wire-format change: `HelloDest{node, pheromone}` already carries a double.)
+
+## Acceptance criteria
+
+Extend `core/tests/test_pheromone_engine.cpp` / add `test_diffusion.cpp`:
+
+1. **Adverts carry real goodness.** Give a node two destinations with different
+   best regular pheromone; assert `createHelloAnt` advertises those distinct
+   values (not `1.0`), and skips destinations with no pheromone.
+2. **Diffusion produces a gradient.** Two neighbours advertise the same dest with
+   different pheromones; after `updateVirtual`, the virtual pheromone via the
+   better neighbour is strictly higher.
+3. **One-hop discount.** A diffused (virtual) pheromone for `d` via `m` is
+   strictly less than `m`'s advertised pheromone (cost increased by one hop).
+4. **Data ignores virtual pheromone (regression for the guard).** With *only*
+   virtual pheromone for a dest and no regular, `nextHopForData(dest)` returns
+   `kInvalidAddress`, while a proactive `selectNextHop(dest, true)` returns a hop.
+5. `make test` green.
+
+## Risks / notes
+
+- Depends on item 02's consistent units (`hopTimeSec`); if 02 isn't done yet, use
+  the same constant the back-ant metric uses so diffused and regular pheromone
+  remain comparable.
+- Hello size: advertising real values doesn't change the field count, but if you
+  later cap to active destinations (item 04) wire size shrinks.

--- a/docs/improvements/04-proactive-ant-sessions.md
+++ b/docs/improvements/04-proactive-ant-sessions.md
@@ -6,6 +6,11 @@
 - **Layer:** `core/` (logic + new "active session" state) and adapters (feed data
   events; rate tied to data)
 - **Depends on:** 03 (diffusion guides the exploratory broadcasts)
+- **Decision:** the whole proactive subsystem is **config-gated** behind
+  `Config::enableProactive` (default on), per
+  [ADR-0007](../adr/0007-proactive-diffusion-gated.md). `enableProactive` is the
+  master switch; item 03's `enableDiffusion` is the sub-switch for the virtual
+  pheromone that guides these ants.
 
 ## Summary
 
@@ -108,9 +113,16 @@ Replace `randomDestination()` selection with a sweep over
 `activeDestinations(...)`. Provide a core entry point so both adapters share it:
 
 ```cpp
-// returns one proactive forward ant per active destination (empty if none)
+// returns one proactive forward ant per active destination
+// (empty if none, or if !config_.enableProactive — the master gate, ADR-0007)
 std::vector<AntMessage> AntRouterLogic::createProactiveAnts();
 ```
+
+Gate at the source: when `!config_.enableProactive`, `createProactiveAnts()`
+returns empty and the per-hop exploratory broadcast in step 3 is skipped, so the
+protocol degrades cleanly to reactive-only (the AntHocNet-reactive benchmark
+variant in [item 08](08-protocol-comparison-benchmarks.md)). Adapters may also
+short-circuit their proactive timer on the same flag to save the tick.
 
 Rate: keep a periodic timer **but** gate it so a proactive ant is only emitted
 for a destination if data has flowed recently (the active-session set already
@@ -149,7 +161,7 @@ pheromone from item 03 guides the first hop.
 
 ## Files to touch
 
-- `core/include/anthocnet/core/config.h` (`proactiveBroadcastProb`, `sessionTtl`)
+- `core/include/anthocnet/core/config.h` (`enableProactive`, `proactiveBroadcastProb`, `sessionTtl`)
 - `core/include/anthocnet/core/ant_router_logic.{h}` + `.cpp`
   (`noteDataSession`, `activeDestinations`, `createProactiveAnts`, per-hop
   broadcast in `onReceiveAnt`)
@@ -177,7 +189,10 @@ Add `core/tests/test_proactive.cpp`:
 5. **Broadcast budget enforced.** A proactive ant broadcast more than
    `broadcastBudget` times stops being re-broadcast (verify with item 05's
    counter).
-6. `make test` green.
+6. **Gate off ⇒ reactive-only.** With `enableProactive = false`,
+   `createProactiveAnts()` returns empty and an in-transit proactive ant with a
+   route never broadcasts; data routing is unaffected.
+7. `make test` green.
 
 ## Risks / notes
 

--- a/docs/improvements/04-proactive-ant-sessions.md
+++ b/docs/improvements/04-proactive-ant-sessions.md
@@ -1,0 +1,187 @@
+# 04 — Proactive ants for active sessions + per-hop broadcast probability
+
+- **Deviation:** D4
+- **Priority:** P1
+- **Effort:** M
+- **Layer:** `core/` (logic + new "active session" state) and adapters (feed data
+  events; rate tied to data)
+- **Depends on:** 03 (diffusion guides the exploratory broadcasts)
+
+## Summary
+
+Proactive forward ants exist to **monitor and improve the paths a node is
+actively using**, and to occasionally explore for better ones. The spec sends
+them from the **source of each active session**, **to that session's
+destination**, at a rate tied to the data rate, with a **small per-hop
+probability of being broadcast** for exploration. The current code instead picks
+a **random known destination** on a **fixed timer**, with no per-hop broadcast
+probability. This wastes overhead on destinations nobody is using and fails to
+maintain the paths that matter.
+
+## Spec reference
+
+> "While a data session is running, the source node sends out proactive forward
+> ants according to the data sending rate (**one ant every n data packets**).
+> They are normally **unicast**, choosing the next hop according to the pheromone
+> values using the same formula as the reactive forward ants, but also **have a
+> small probability at each node of being broadcast (this probability was set to
+> 0.1 in the experiments)**. ... If a forward ant reaches the destination without
+> a single broadcast it simply samples an existing path. ... If on the other hand
+> the ant got broadcast at any point, it will leave the currently known paths and
+> explore new ones." — [1] §3.3
+
+Two requirements:
+1. **Target = active-session destinations**, from the **source** of those
+   sessions, at a data-proportional rate.
+2. **Per-hop broadcast probability** `p_broadcast` (≈0.1): at each intermediate
+   node a proactive ant is normally unicast along pheromone, but with prob.
+   `p_broadcast` it is broadcast to explore.
+
+## Current behaviour
+
+Random destination, fixed timer, no per-hop broadcast:
+
+```379:393:ns3/model/anthocnet-routing-protocol.cc
+void RoutingProtocol::ProactiveTimerExpire() {
+    if (m_logic) {
+        NodeAddress dest = m_logic->randomDestination();
+        if (dest != kInvalidAddress) {
+            AntMessage prfa = m_logic->createForwardAnt(AntType::Proactive, dest);
+            NodeAddress next = m_logic->selectNextHop(dest, /*proactive=*/true);
+            if (next == kInvalidAddress) {
+                SendAnt(prfa, Ipv4Address("255.255.255.255"));
+            } else {
+                SendAnt(prfa, ToIpv4(next));
+            }
+        }
+    }
+    m_proactiveTimer.Schedule(m_proactiveInterval);
+}
+```
+
+(NS-2 `sendProactive` in `ns2/src/ahn_router.cc:314` is identical in spirit.)
+
+And in the core, an in-transit proactive forward ant is only broadcast when it
+has **no** route at all — there is no exploratory broadcast when a route exists:
+
+```151:155:core/src/ant_router_logic.cpp
+        NodeAddress next = selectNextHop(ant.dst, proactive);
+        if (next == kInvalidAddress) {
+            return {{RouteAction::Broadcast, kInvalidAddress, true, ant}};
+        }
+        return {{RouteAction::Unicast, next, true, ant}};
+```
+
+## Impact
+
+- Proactive overhead is spent on destinations with no traffic; active paths get
+  no proactive sampling unless they happen to be drawn at random.
+- Without per-hop broadcast, proactive ants can only *re-sample known paths*,
+  never *discover new* ones — removing the "improve / explore" half of the
+  mechanism. Combined with D3, AntHocNet loses nearly all of its proactive
+  adaptivity.
+
+## Required change
+
+### 1. Track active sessions in the core
+
+Add to `AntRouterLogic` a small set of "active destinations" with a last-used
+timestamp, updated whenever this node **originates** data for a destination:
+
+```cpp
+// AntRouterLogic
+void noteDataSession(NodeAddress dest);            // call when local data is sent to dest
+std::vector<NodeAddress> activeDestinations(double now, double ttl) const;  // recently used
+```
+
+Expire a session if no data has been sent to it for some window (e.g.
+`config_.sessionTtl`, default a few seconds). Drive `now` from `clock_`.
+
+Adapters call `noteDataSession(dest)` from their data path:
+- NS-3: in `RouteOutput` when the packet is locally originated (and in
+  `DeferredRouteOutput`).
+- NS-2: in `handleData` when `ih->saddr() == id_` (locally originated).
+
+### 2. Emit proactive ants per active session
+
+Replace `randomDestination()` selection with a sweep over
+`activeDestinations(...)`. Provide a core entry point so both adapters share it:
+
+```cpp
+// returns one proactive forward ant per active destination (empty if none)
+std::vector<AntMessage> AntRouterLogic::createProactiveAnts();
+```
+
+Rate: keep a periodic timer **but** gate it so a proactive ant is only emitted
+for a destination if data has flowed recently (the active-session set already
+does this). Optionally, to match "one ant every n data packets", have the adapter
+count data packets per destination and request a proactive ant every `n`
+(default `n` configurable, e.g. 30). The session-set approach is the minimum;
+the per-n-packets trigger is the faithful version — implement the session-set
+gating first, leave a TODO for the exact data-proportional trigger if needed.
+
+### 3. Per-hop broadcast probability for proactive ants
+
+In `onReceiveAnt`, for an in-transit **proactive** forward ant that *does* have a
+route, broadcast with probability `p_broadcast` instead of always unicasting:
+
+```cpp
+NodeAddress next = selectNextHop(ant.dst, proactive);
+if (next == kInvalidAddress) {
+    return {{RouteAction::Broadcast, kInvalidAddress, true, ant}};
+}
+if (proactive && rng_.uniform() < config_.proactiveBroadcastProb) {
+    return {{RouteAction::Broadcast, kInvalidAddress, true, ant}};  // explore
+}
+return {{RouteAction::Unicast, next, true, ant}};
+```
+
+Add `double proactiveBroadcastProb = 0.1;` to `Config`. To bound exploration cost
+(the spec limits proliferation), also cap the number of broadcasts a single
+proactive ant may undergo — reuse the bounded-broadcast counter introduced in
+item 05 (`AntMessage::broadcastBudget`), defaulting e.g. to 2 for proactive ants.
+
+### 4. Source-originated proactive ants follow combined pheromone
+
+`createForwardAnt(AntType::Proactive, dest)` then `selectNextHop(dest, true)`
+already uses `sumMaxProbability` (regular ⊕ virtual) — keep that so the diffused
+pheromone from item 03 guides the first hop.
+
+## Files to touch
+
+- `core/include/anthocnet/core/config.h` (`proactiveBroadcastProb`, `sessionTtl`)
+- `core/include/anthocnet/core/ant_router_logic.{h}` + `.cpp`
+  (`noteDataSession`, `activeDestinations`, `createProactiveAnts`, per-hop
+  broadcast in `onReceiveAnt`)
+- `core/include/anthocnet/core/ant_message.h` (`broadcastBudget` — shared with 05)
+- `ns3/model/anthocnet-routing-protocol.cc` (`ProactiveTimerExpire`, data paths
+  call `noteDataSession`)
+- `ns2/src/ahn_router.cc` (`sendProactive`, `handleData` calls `noteDataSession`)
+- Expose `ProactiveBroadcastProb` attribute (NS-3) / `proactive_bcast_prob_` bind
+  (NS-2).
+
+## Acceptance criteria
+
+Add `core/tests/test_proactive.cpp`:
+
+1. **Only active destinations are probed.** After `noteDataSession(d1)` but not
+   `d2` (both in the table), `createProactiveAnts()` yields exactly one ant, for
+   `d1`.
+2. **Session expiry.** After advancing `FakeClock` past `sessionTtl` with no new
+   data, `createProactiveAnts()` returns empty.
+3. **Per-hop exploratory broadcast.** With a route present and a `ScriptedRng`
+   returning `< proactiveBroadcastProb`, an in-transit proactive forward ant
+   yields a `Broadcast`; with `>= prob` it yields a `Unicast`.
+4. **Reactive ants unaffected.** The same scenario with `AntType::Reactive` never
+   broadcasts when a route exists.
+5. **Broadcast budget enforced.** A proactive ant broadcast more than
+   `broadcastBudget` times stops being re-broadcast (verify with item 05's
+   counter).
+6. `make test` green.
+
+## Risks / notes
+
+- `createProactiveAnts` originating multiple ants per tick can raise overhead;
+  the active-session gating is what keeps it bounded — make sure expiry works.
+- Coordinate the `broadcastBudget` field with item 05 so it's added to the wire
+  format exactly once (struct + codec + both adapter headers + `test_codec.cpp`).

--- a/docs/improvements/05-link-failure-detection-and-repair.md
+++ b/docs/improvements/05-link-failure-detection-and-repair.md
@@ -1,0 +1,227 @@
+# 05 — Link-failure detection, failure notification, and bounded repair
+
+- **Deviation:** D5, D6
+- **Priority:** P1
+- **Effort:** L
+- **Layer:** `core/` (detection state, notification, repair bounding) + adapters
+  (hello-timeout tick, NS-3 link-failure hook)
+- **Depends on:** 02 (notification carries pheromone estimates), shares
+  `broadcastBudget` field with 04
+
+## Summary
+
+AntHocNet's failure handling has three parts; the repo implements only a partial
+version of one of them:
+
+1. **Detection** — via failed unicast **or** missed hellos
+   (`t_hello × allowed_hello_loss`). Today: NS-2 detects only failed unicast;
+   **NS-3 detects nothing** (no link-failure hook, no hello-timeout). Stale
+   neighbours/pheromone are never removed in NS-3.
+2. **Link-failure notification** — broadcast a message listing destinations whose
+   best path was lost + the new best estimate, which neighbours apply and
+   propagate. **Not implemented at all.**
+3. **Local repair** — a route-repair ant, **bounded to max 2 broadcasts** and a
+   wait of ~5× the path delay, then discard buffered packets + notify. Today a
+   repair ant is unbounded (`lifeAnt` carried but never enforced), floods like a
+   reactive ant up to `networkDiameter` hops, and exists only in NS-2.
+
+## Spec reference
+
+> "Nodes can detect link failures ... when unicast transmissions fail, or when
+> expected periodic pheromone diffusion messages were not received. ... The
+> disappearance of a neighbour is assumed when such an event has not taken place
+> for a certain amount of time, defined by **t_hello × allowed-hello-loss**." —
+> [1] §3.5
+
+> "When a node `i` discovers the disappearance of a neighbour `n`, it ... removes
+> all associated entries from its pheromone table. Next, `i` **broadcasts a link
+> failure notification message**. This message contains a list of the
+> destinations to which `i` lost its best path, and the new best pheromone ...
+> All its neighbours receive the message and update their pheromone table ... If
+> they in turn lost their best or their only path ... they will pass the updated
+> message on." — [1] §3.5
+
+> "If `i` detected the link failure via the failed transmission of a data packet,
+> and there is no other path available ... it will try to locally repair ... The
+> node broadcasts a route repair ant that travels to the destination like a
+> reactive forward ant ... One important difference is that it has a **maximum
+> number of broadcasts (which we set to 2)** ... The node waits for a certain
+> time (empirically set to **5 times the estimated end-to-end delay** of the lost
+> path), and if no backward repair ant is received by then, ... packets ... are
+> discarded, and the node sends a link failure notification." — [1] §3.5
+
+## Current behaviour
+
+NS-2 link-failure callback: removes neighbour, enqueues the packet, broadcasts an
+unbounded repair ant — **no notification**, **no wait/discard logic**:
+
+```286:304:ns2/src/ahn_router.cc
+void AntHocNetAgent::linkFailed(Packet* p) {
+    struct hdr_cmn* ch = HDR_CMN(p);
+    struct hdr_ip* ih = HDR_IP(p);
+    const nsaddr_t broken = ch->next_hop_;
+
+    if (logic_) logic_->loseNeighbor(broken);
+
+    if (ch->ptype() != PT_ANT) {
+        const nsaddr_t dest = ih->daddr();
+        enqueue(p, dest);
+        if (logic_) {
+            AntMessage rrfa = logic_->createForwardAnt(AntType::Repair, dest);
+            rrfa.lifeAnt = AHN_LIFE_ANT;          // <-- set but never checked
+            sendAnt(rrfa, anthocnet::core::kInvalidAddress, /*broadcast=*/true);
+        }
+    } else {
+        Packet::free(p);
+    }
+}
+```
+
+`loseNeighbor` only cleans the local table:
+
+```25:27:core/src/ant_router_logic.cpp
+void AntRouterLogic::loseNeighbor(NodeAddress neighbor) {
+    engine_.cleanNeighbor(table_, neighbor);
+}
+```
+
+In the **core**, a `Repair` ant is treated exactly like a reactive forward ant
+(`proactive = (ant.type == AntType::Proactive)` is false for `Repair`), and
+`lifeAnt` is never read anywhere. **NS-3 has no link-failure path** — search
+`anthocnet-routing-protocol.cc`: `loseNeighbor` is never called, and there is no
+neighbour-expiry timer.
+
+## Impact
+
+- **NS-3 correctness gap:** neighbours that move away are never removed; pheromone
+  for dead links persists and is selected, so data is sent into the void →
+  delivery collapses (a likely contributor to the NS-3 benchmark numbers).
+- No failure notification → upstream nodes keep stale best-paths, sending data
+  toward a break until their own ants happen to correct it.
+- Unbounded repair ants → network-wide floods on every break (overhead spike),
+  and buffered packets are never deterministically released/discarded.
+
+## Required change
+
+This is the largest item; implement in three sub-steps. Sub-step A is the most
+important (it fixes the NS-3 correctness gap).
+
+### A. Hello-timeout neighbour detection (both adapters, driven by core state)
+
+Track last-seen time per neighbour in the core and expire on a tick.
+
+```cpp
+// PheromoneTable / AntRouterLogic
+void touchNeighbor(NodeAddress n, double now);          // on any reception from n
+std::vector<NodeAddress> expiredNeighbors(double now,   // now - lastSeen > t_hello*allowedLoss
+                                          double maxIdle) const;
+```
+
+- `learnNeighbor`/`onReceiveAnt` already learn from `prevHop` and hello `src`; add
+  `touchNeighbor(n, clock_.now())` there.
+- Add `Config::allowedHelloLoss = 2;` (so `maxIdle = helloInterval * allowedHelloLoss`).
+- Add a core method `std::vector<RouteDecision> onMaintenanceTick()` that calls
+  `expiredNeighbors`, runs `loseNeighbor` on each, and returns any link-failure
+  **notification** broadcasts (sub-step B).
+- **Adapters:** drive `onMaintenanceTick()` from the existing periodic timer
+  (NS-3 `HelloTimerExpire`, NS-2 `AhnHelloTimer::handle`). For NS-3 this is the
+  *only* way neighbour loss is detected, so it is mandatory.
+
+### B. Link-failure notification message
+
+Add a new ant type and a payload of `(dest, newBestPheromone)` entries — reuse
+the existing `helloDests` vector shape (it is already `(node, pheromone)`):
+
+```cpp
+enum class AntType : std::uint8_t {
+    Hello     = 0x01,
+    Reactive  = 0x02,
+    Proactive = 0x04,
+    Repair    = 0x08,
+    LinkFail  = 0x10,   // NEW: link-failure notification
+};
+```
+
+When `loseNeighbor(n)` removes the **best** next hop for one or more destinations:
+- collect those destinations and the node's **new** best pheromone (0 if none
+  left) into a `LinkFail` ant's `helloDests`;
+- return a `Broadcast` `RouteDecision` for it.
+
+On receiving a `LinkFail` ant in `onReceiveAnt`:
+- for each `(dest, newBest)`: update/remove the regular pheromone via the
+  reporting neighbour (`reinforce`/remove);
+- if this node *itself* lost its best or only path to `dest` as a result,
+  **re-broadcast** an updated `LinkFail` ant (propagation), bounded by the
+  `broadcastBudget`/dedup so it can't loop.
+
+(Dedup: `LinkFail` ants get a `(src,seq)` like any ant, so the existing
+`AntHistoryTracker` stops loops.)
+
+### C. Bound the repair ant + wait/discard
+
+1. Add `int broadcastBudget` to `AntMessage` (shared with item 04). On each
+   `RouteAction::Broadcast` of a forward ant, decrement; when it reaches 0,
+   stop broadcasting (return `Drop` instead of `Broadcast`). Initialise repair
+   ants to `config_.repairMaxBroadcasts = 2`.
+2. Enforce `lifeAnt` (or reuse `broadcastBudget` + a hop cap): a repair ant should
+   travel at most a few hops. At minimum, **read `lifeAnt`** and drop the repair
+   ant once exceeded — today it is dead config.
+3. Adapter-side wait/discard: when a repair is launched, schedule a timer for
+   `~5 × estimatedDelay` (use a config default `repairWaitFactor = 5` × a delay
+   estimate, or a flat `config_.repairTimeout` if no delay estimate is available
+   yet). If no backward repair ant arrives by then, **discard** the buffered
+   packets for that destination and emit a `LinkFail` notification. Implement in
+   both adapters (they own the pending queue + timers).
+
+### D. Wire NS-3 data-transmit failure (parity with NS-2)
+
+NS-3 can detect transmit failures via the WiFi MAC `TxErrHeader`/drop traces or
+an `ArpL3Protocol`/`Ipv4L3Protocol` tx-error callback. Hook one and, on failure
+to a next hop, call the same core `loseNeighbor` + repair path used by sub-step
+A/C. If a clean hook isn't readily available, sub-step A (hello timeout) already
+gives NS-3 working detection — document the limitation and leave a TODO.
+
+## Files to touch
+
+- `core/include/anthocnet/core/ant_message.h` (`AntType::LinkFail`, `broadcastBudget`)
+- `core/include/anthocnet/core/config.h` (`allowedHelloLoss`, `repairMaxBroadcasts`,
+  `repairWaitFactor`/`repairTimeout`)
+- `core/include/anthocnet/core/pheromone_table.{h,cpp}` (last-seen, `expiredNeighbors`)
+- `core/include/anthocnet/core/ant_router_logic.{h,cpp}` (`touchNeighbor`,
+  `onMaintenanceTick`, `LinkFail` handling, repair bounding)
+- `core/src/pheromone_engine.cpp` (apply notification updates)
+- `core/src/ant_message_codec.cpp` + `ns2/src/ant_packet_ns2.*` +
+  `ns3/model/anthocnet-packet.cc` + `core/tests/test_codec.cpp` (new field
+  `broadcastBudget`; `LinkFail` reuses `helloDests`)
+- `ns3/model/anthocnet-routing-protocol.cc` (maintenance tick, tx-error hook,
+  repair wait/discard)
+- `ns2/src/ahn_router.cc` (maintenance tick, bounded repair, wait/discard)
+
+## Acceptance criteria
+
+Add `core/tests/test_link_failure.cpp`:
+
+1. **Hello timeout expires a neighbour.** Learn neighbour `n`; advance `FakeClock`
+   beyond `helloInterval × allowedHelloLoss` with no reception; `onMaintenanceTick()`
+   removes `n` and its pheromone.
+2. **Notification emitted on best-path loss.** When losing `n` drops the only path
+   to `d`, `onMaintenanceTick()` (or `loseNeighbor`) returns a `Broadcast`
+   `LinkFail` ant whose `helloDests` contains `d` with the new best (0).
+3. **Notification applied + propagated.** A node receiving a `LinkFail` for `d`
+   updates its table; if it loses its own best path it re-broadcasts (bounded),
+   otherwise it does not.
+4. **Repair bounded.** A `Repair` ant with `broadcastBudget = 2` is broadcast at
+   most twice across nodes, then dropped (assert no `Broadcast` on the 3rd).
+5. **NS-3 parity (build-level):** assert (in code review / a smoke run) that the
+   NS-3 adapter calls `onMaintenanceTick()` on its timer.
+6. `make test` green; codec round-trip still passes with the new field.
+
+## Risks / notes
+
+- This adds a wire field (`broadcastBudget`) and a new ant type — do the codec +
+  both adapter headers + `test_codec.cpp` as one atomic change.
+- Keep `LinkFail` propagation strictly dedup-guarded to avoid broadcast storms.
+- The exact "5× end-to-end delay" wait needs a delay estimate; if item 02's delay
+  metric isn't in yet, use a flat `repairTimeout` and TODO the adaptive version.
+- Sub-step A alone is worth shipping first — it closes the NS-3 correctness gap
+  with modest effort.

--- a/docs/improvements/05-link-failure-detection-and-repair.md
+++ b/docs/improvements/05-link-failure-detection-and-repair.md
@@ -103,10 +103,25 @@ neighbour-expiry timer.
 
 ## Required change
 
-This is the largest item; implement in three sub-steps. Sub-step A is the most
+This is the largest item; implement in four sub-steps. Sub-step A is the most
 important (it fixes the NS-3 correctness gap).
 
-### A. Hello-timeout neighbour detection (both adapters, driven by core state)
+### Detection model (ADR-0008)
+
+Per [ADR-0008](../adr/0008-neighbour-liveness-two-detectors.md), neighbour loss is
+found by **two complementary detectors that both call the same `loseNeighbor(n)`**:
+
+- **A — hello-timeout (core timer): the portable coverage path, and primary.**
+  Spec-faithful, simulator-agnostic, the *only* detector NS-3 has, and the one
+  that covers idle neighbours. Mandatory.
+- **D — MAC transmit-failure (adapter signal): a fast-path accelerator.** Reacts
+  immediately on a failed unicast to an active next hop; never the sole detector.
+
+`INeighborProvider` stays **advisory** ("who can I hello / who's a candidate"),
+never authoritative for removal — its doc comment should say so. The pheromone
+table is driven by reception + explicit loss events only.
+
+### A. Hello-timeout detection — the portable coverage path (both adapters, driven by core state)
 
 Track last-seen time per neighbour in the core and expire on a tick.
 
@@ -126,6 +141,11 @@ std::vector<NodeAddress> expiredNeighbors(double now,   // now - lastSeen > t_he
 - **Adapters:** drive `onMaintenanceTick()` from the existing periodic timer
   (NS-3 `HelloTimerExpire`, NS-2 `AhnHelloTimer::handle`). For NS-3 this is the
   *only* way neighbour loss is detected, so it is mandatory.
+- **Hellos run independently of diffusion.** The diffusion gate
+  (`enableDiffusion`, [ADR-0007](../adr/0007-proactive-diffusion-gated.md)) only
+  suppresses the hello *pheromone payload* — hello broadcasts and this
+  liveness/maintenance tick must keep running even when proactive/diffusion is
+  off, because neighbour-loss detection does not depend on them.
 
 ### B. Link-failure notification message
 
@@ -173,16 +193,23 @@ On receiving a `LinkFail` ant in `onReceiveAnt`:
    packets for that destination and emit a `LinkFail` notification. Implement in
    both adapters (they own the pending queue + timers).
 
-### D. Wire NS-3 data-transmit failure (parity with NS-2)
+### D. MAC transmit-failure — the fast-path accelerator (both adapters)
+
+This is the *second* detector from ADR-0008, not a replacement for A. NS-2 already
+has it (the `linkFailed` callback above); wire the NS-3 equivalent for parity.
 
 NS-3 can detect transmit failures via the WiFi MAC `TxErrHeader`/drop traces or
 an `ArpL3Protocol`/`Ipv4L3Protocol` tx-error callback. Hook one and, on failure
-to a next hop, call the same core `loseNeighbor` + repair path used by sub-step
-A/C. If a clean hook isn't readily available, sub-step A (hello timeout) already
-gives NS-3 working detection — document the limitation and leave a TODO.
+to a next hop, call the **same** `loseNeighbor` + repair path used by sub-steps
+A/C (the two detectors converge on one code path). If a clean hook isn't readily
+available, sub-step A (hello timeout) already gives NS-3 working detection —
+document the limitation and leave a TODO. Because A is mandatory and authoritative,
+D is a latency optimisation: it never changes *what* is detected, only *how fast*.
 
 ## Files to touch
 
+- `core/include/anthocnet/core/ports.h` (clarify `INeighborProvider` doc comment:
+  advisory adjacency, never authoritative for removal — ADR-0008)
 - `core/include/anthocnet/core/ant_message.h` (`AntType::LinkFail`, `broadcastBudget`)
 - `core/include/anthocnet/core/config.h` (`allowedHelloLoss`, `repairMaxBroadcasts`,
   `repairWaitFactor`/`repairTimeout`)

--- a/docs/improvements/06-evaporation-and-minor.md
+++ b/docs/improvements/06-evaporation-and-minor.md
@@ -11,16 +11,27 @@
 A grab-bag of lower-impact fidelity items. The main one: **evaporation is
 event-driven, not time-based.** It only runs as a side effect of reinforcing a
 link (on backward-ant arrival or neighbour learning), so a quiet path neither
-decays nor ages on schedule. Classic ACO (and AntHocNet's pheromone aging) treats
-evaporation as a periodic, time-proportional process. The remaining items are
-small correctness/clarity fixes.
+decays nor ages on schedule. The remaining items are small correctness/clarity
+fixes.
 
 ## Items
 
-### 6.1 — Time-based (periodic) evaporation
+### 6.1 — Evaporation as a time-proportional safety net (ADR-0012)
 
-**Spec/ACO basis:** pheromone evaporation is a function of elapsed time, applied
-regularly, so unused entries decay independently of whether new ants arrive.
+- **Decision:** [ADR-0012](../adr/0012-evaporation-is-a-secondary-safety-net.md)
+  — evaporation is a **secondary** mechanism, made **time-proportional**, with
+  **all aging single-sourced** into a periodic `evaporateAll` on the one IClock
+  maintenance tick, **config-gated** (`enableEvaporation`, default ON).
+
+**Spec reality (read this first):** the canonical AntHocNet description ([1])
+**has no evaporation term** — adaptation is the running-average `reinforce`
+(`Tᵢ_nd = γ·Tᵢ_nd + (1−γ)·τᵢ_d`, the `(1−γ)` term *is* the forgetting) plus
+**explicit removal** of entries on neighbour loss (item 05 / ADR-0008).
+Time-proportional decay is the *classic Ant System* answer, not the AntHocNet
+one. So evaporation here is a deliberate, ablatable **safety net** for entries the
+spec's two mechanisms miss — e.g. a still-alive neighbour whose downstream route
+to `d` silently died and stopped being sampled — **not** the adaptation engine.
+Do **not** tune `alpha` to make decay do the running average's job.
 
 **Current:** `evaporate` only runs inside `updateRegular`'s loop, which is only
 called from `reinforceFromBackAnt` and `learnNeighbor`:
@@ -32,24 +43,39 @@ double PheromoneEngine::evaporate(double phValue) const {
 ```
 
 So a destination that stops receiving backward ants is never aged; its competing
-links freeze at their last values.
+links freeze at their last values, and the decay rate is a function of *traffic*,
+not time.
 
-**Change:** add `PheromoneEngine::evaporateAll(PheromoneTable&)` that ages **every**
-regular (and optionally virtual) entry once, pruning entries below
-`minPheromone`, and call it from the core maintenance tick (`onMaintenanceTick`,
-item 05) at a configurable `Config::evaporationInterval` (e.g. 1–3 s). If the
-decay should be time-proportional, scale by elapsed time:
-`factor = alpha^(Δt / evaporationInterval)`. Keep the per-reinforcement aging too,
-or remove it from `updateRegular` and rely solely on the periodic pass — pick one
-and document it (mixing both double-counts decay). **Recommended:** make
-`updateRegular` *only reinforce the travelled link*, and move all aging into the
-periodic `evaporateAll`. That cleanly separates reinforcement from evaporation
-(and removes the awkward "age other links while reinforcing one" coupling that
-caused the original D2 evaporation bug).
+**Change (per ADR-0012):**
 
-**Acceptance:** `test_pheromone_engine.cpp` — after N periodic evaporations with
-no reinforcement, an entry decays geometrically and is pruned below
-`minPheromone`; a reinforced entry does not decay within the same tick.
+1. Add `PheromoneEngine::evaporateAll(PheromoneTable&, double dtSeconds)` that ages
+   **every** regular entry once with a **time-proportional** factor
+   `alpha^(dtSeconds / evaporationInterval)`, pruning entries below `minPheromone`.
+   `dtSeconds` is `clock_.now()` minus the last evaporation time (from `IClock` —
+   never wall-clock, golden rule #3).
+2. **Single-source the aging:** make `updateRegular` *only reinforce the travelled
+   link*; delete the "age the other links" branch (lines 44–54). All aging now
+   lives in `evaporateAll`. This also removes the reinforce-and-age coupling that
+   caused the original D2 bug.
+3. Call `evaporateAll` from the single core maintenance tick (`onMaintenanceTick`,
+   item 05 / ADR-0008) — because the factor scales by actual `Δt`, the same tick
+   that expires neighbours can evaporate, with **no separate timer**.
+4. Gate it behind `Config::enableEvaporation` (default `true`). Off ⇒ paper-faithful
+   "running-average + explicit-removal only" mode, which item 08 runs as an
+   ablation variant.
+
+Virtual pheromone already evaporates on hello reception (in `updateVirtual`); hellos
+are periodic so that path is effectively periodic and matches diffusion's refresh —
+align it onto the tick for consistency if convenient, but it is not the deviation
+this item fixes.
+
+**Acceptance:** `test_pheromone_engine.cpp` — with `enableEvaporation = true`,
+after advancing `FakeClock` by N·`evaporationInterval` with no reinforcement an
+entry decays geometrically (`≈ alpha^N` of its start value) and is pruned below
+`minPheromone`; a reinforced entry does not decay within the same tick; aging never
+happens inside `updateRegular`; and with `enableEvaporation = false` an
+un-reinforced entry retains its value across ticks (only link-failure removal can
+clear it).
 
 ### 6.2 — `networkDiameter` / expanding-ring TTL
 
@@ -110,7 +136,7 @@ by best pheromone, rather than a coin flip. Minor.
 - `core/src/pheromone_engine.cpp`, `core/include/.../pheromone_engine.h`
   (`evaporateAll`)
 - `core/include/anthocnet/core/config.h` (`evaporationInterval`,
-  reactive backoff knobs)
+  `enableEvaporation` (default `true`), reactive backoff knobs)
 - `core/src/ant_router_logic.cpp` (tick calls evaporate; reactive backoff guard;
   hop cap drop)
 - `ns3/model/anthocnet-routing-protocol.cc` (ant TTL/hop cap)
@@ -125,6 +151,11 @@ by best pheromone, rather than a coin flip. Minor.
 
 ## Risks / notes
 
-- 6.1 changes pheromone dynamics; re-tune `alpha`/`evaporationInterval` against
-  item 07's benchmark. Land it **after** 01/02 so you measure on a correct metric.
+- 6.1 changes pheromone dynamics **and `alpha`'s meaning** (now a per-`evaporationInterval`
+  retention factor scaled by elapsed time, not a per-event multiplier). Re-tune
+  `alpha`/`evaporationInterval` against item 07/08 on the paper-scale scenario, not
+  the unit-test toy. Land it **after** 01/02 so you measure on a correct metric.
+- Evaporation is a deliberate extension beyond the spec, not "the spec" — see
+  [ADR-0012](../adr/0012-evaporation-is-a-secondary-safety-net.md). Keep it
+  secondary to the running average + link-failure removal (item 05).
 - Keep each sub-item a separate commit; they're independent.

--- a/docs/improvements/06-evaporation-and-minor.md
+++ b/docs/improvements/06-evaporation-and-minor.md
@@ -1,0 +1,130 @@
+# 06 — Time-based evaporation + minor deviations
+
+- **Deviation:** D7 (+ small clean-ups)
+- **Priority:** P2
+- **Effort:** S
+- **Layer:** `core/` (+ adapter tick wiring)
+- **Depends on:** ideally after 05 (shares the maintenance tick)
+
+## Summary
+
+A grab-bag of lower-impact fidelity items. The main one: **evaporation is
+event-driven, not time-based.** It only runs as a side effect of reinforcing a
+link (on backward-ant arrival or neighbour learning), so a quiet path neither
+decays nor ages on schedule. Classic ACO (and AntHocNet's pheromone aging) treats
+evaporation as a periodic, time-proportional process. The remaining items are
+small correctness/clarity fixes.
+
+## Items
+
+### 6.1 — Time-based (periodic) evaporation
+
+**Spec/ACO basis:** pheromone evaporation is a function of elapsed time, applied
+regularly, so unused entries decay independently of whether new ants arrive.
+
+**Current:** `evaporate` only runs inside `updateRegular`'s loop, which is only
+called from `reinforceFromBackAnt` and `learnNeighbor`:
+
+```9:11:core/src/pheromone_engine.cpp
+double PheromoneEngine::evaporate(double phValue) const {
+    return phValue - (1.0 - config_.alpha) * phValue;
+}
+```
+
+So a destination that stops receiving backward ants is never aged; its competing
+links freeze at their last values.
+
+**Change:** add `PheromoneEngine::evaporateAll(PheromoneTable&)` that ages **every**
+regular (and optionally virtual) entry once, pruning entries below
+`minPheromone`, and call it from the core maintenance tick (`onMaintenanceTick`,
+item 05) at a configurable `Config::evaporationInterval` (e.g. 1–3 s). If the
+decay should be time-proportional, scale by elapsed time:
+`factor = alpha^(Δt / evaporationInterval)`. Keep the per-reinforcement aging too,
+or remove it from `updateRegular` and rely solely on the periodic pass — pick one
+and document it (mixing both double-counts decay). **Recommended:** make
+`updateRegular` *only reinforce the travelled link*, and move all aging into the
+periodic `evaporateAll`. That cleanly separates reinforcement from evaporation
+(and removes the awkward "age other links while reinforcing one" coupling that
+caused the original D2 evaporation bug).
+
+**Acceptance:** `test_pheromone_engine.cpp` — after N periodic evaporations with
+no reinforcement, an entry decays geometrically and is pruned below
+`minPheromone`; a reinforced entry does not decay within the same tick.
+
+### 6.2 — `networkDiameter` / expanding-ring TTL
+
+**Spec:** reactive forward ants are bounded by a max hop count; the paper notes
+this max is "quite high" and suggests an expanding-ring search or using diffusion
+to bound it.
+
+**Current:** `Config::networkDiameter = 30`, applied as an IP TTL in NS-2
+(`AHN_NETWORK_DIAMETER`) and as the `maxPathLength` guard in `stampForward`. NS-3
+does not appear to apply an equivalent hop cap to broadcast ants.
+
+**Change (small):** ensure **both** adapters cap ant hop count (NS-3 should set
+the ant packet TTL / decrement and drop). Optionally implement a simple
+expanding-ring retry for reactive setup (start TTL small, grow on failure) —
+mark as optional/stretch.
+
+**Acceptance:** an ant exceeding the hop cap is dropped in a core/unit test
+(`maxPathLength` already bounds `visited`; add a TTL/hops check in `onReceiveAnt`
+that returns `Drop` past the cap), and NS-3 broadcast ants don't propagate beyond
+the cap in a smoke run.
+
+### 6.3 — Reactive-ant retry interval
+
+**Spec:** §4.2 of [1] notes the retry interval for reactive forward ants on a
+failed setup is "rather low," causing overhead when a destination is unreachable;
+suggests backing off.
+
+**Current:** the data path re-launches a reactive ant whenever a packet has no
+route (`onDataPacket`), with no per-destination backoff — a stream of packets to
+an unreachable destination floods ants.
+
+**Change:** add a per-destination "reactive ant in flight / last sent" guard in
+the core (or adapter) so at most one reactive setup is outstanding per
+destination, with exponential backoff on repeated failure. Drop buffered packets
+after a max number of failed setups.
+
+**Acceptance:** `test_core_paths.cpp` — multiple `onDataPacket(d)` calls in quick
+succession with no route emit **one** reactive ant (not one per packet) until the
+backoff elapses.
+
+### 6.4 — Naming / clarity (no behaviour change)
+
+- Rename `AntMessage::prevSINR` → `pathTime` (it is accumulated time, not SINR).
+  (Folds into item 02.)
+- The `kBeta` constant is removed by item 01; ensure no stragglers remain.
+- `selectNextHop`'s `proactive` bool would read better as an enum
+  `Exponent{Ant, Data}` once item 01 lands, but keep changes minimal.
+
+### 6.5 — Hello advertises a random subset via `rng_.uniform() > 0.5`
+
+**Current:** `createHelloAnt` includes each destination with prob 0.5 (capped at
+`maxAdverts`). Combined with item 03 (advertise active destinations only), prefer
+advertising **active** destinations deterministically and filling remaining slots
+by best pheromone, rather than a coin flip. Minor.
+
+## Files to touch
+
+- `core/src/pheromone_engine.cpp`, `core/include/.../pheromone_engine.h`
+  (`evaporateAll`)
+- `core/include/anthocnet/core/config.h` (`evaporationInterval`,
+  reactive backoff knobs)
+- `core/src/ant_router_logic.cpp` (tick calls evaporate; reactive backoff guard;
+  hop cap drop)
+- `ns3/model/anthocnet-routing-protocol.cc` (ant TTL/hop cap)
+- tests as named per item
+
+## Acceptance criteria (summary)
+
+- Periodic evaporation decays unused entries; no double decay.
+- One reactive ant per destination per backoff window.
+- Ant hop cap enforced in both adapters.
+- `make test` green.
+
+## Risks / notes
+
+- 6.1 changes pheromone dynamics; re-tune `alpha`/`evaporationInterval` against
+  item 07's benchmark. Land it **after** 01/02 so you measure on a correct metric.
+- Keep each sub-item a separate commit; they're independent.

--- a/docs/improvements/07-validation-and-benchmarks.md
+++ b/docs/improvements/07-validation-and-benchmarks.md
@@ -1,0 +1,129 @@
+# 07 — Validation harness + paper-faithful benchmark scenario
+
+- **Deviation:** — (methodology, not a protocol bug)
+- **Priority:** P2 (run continuously while doing 01–06)
+- **Effort:** M
+- **Layer:** `ns3/` tooling + `core/tests/`
+- **Depends on:** nothing; most useful once 01–02 land
+
+## Summary
+
+The repo's benchmark shows AntHocNet under-performing AODV/OLSR — partly because
+of the protocol deviations (items 01–06) and partly because the **benchmark
+scenario is the one regime the papers say AntHocNet is *not* good at** (small,
+dense, low-mobility). This item sets up (a) per-change unit/behaviour validation
+and (b) a benchmark scenario faithful to the papers, so progress on 01–06 is
+measurable and not masked by an unfavorable scenario.
+
+## Why the current benchmark is misleading
+
+Current scenario (`docs/benchmarks.md`): 16 nodes, 250 m area, max speed 5 m/s,
+4 flows.
+
+> "...with high interference and very short paths, it is clear that the advantages
+> of maintaining multiple paths, stochastically spreading data, using local
+> repair, etc., do not outweigh their costs. A simple, reactive approach as AODV
+> is expected to be much more effective. ... as the environment became more
+> difficult (more mobility, more sparseness, longer paths), the characteristics
+> of AntHocNet became an advantage over those of AODV." — [1] §4.2
+
+A 250 m area with 16 nodes is dense and short-path: exactly where AntHocNet is
+*expected* to lose. The papers' base scenario is **100 nodes, 3000×1000 m, speeds
+0–20 m/s, 30 s pause, ~20 CBR flows, 900 s** — large, sparse, mobile, long paths.
+
+## Part A — protocol behaviour validation (cheap, in CI)
+
+These run without a simulator and pin protocol behaviour the way each item
+requires. Add as `core/tests/` and keep green.
+
+1. **Metric monotonicity (item 02):** lower-delay / fewer-hop path ⇒ higher
+   pheromone.
+2. **Greediness (item 01):** higher `betaData` ⇒ more concentrated next-hop
+   distribution (statistical test over a scripted RNG sweep).
+3. **Diffusion gradient (item 03):** better advertised path ⇒ higher virtual
+   pheromone; data never uses virtual pheromone.
+4. **Active-session proactivity (item 04):** proactive ants only for active
+   destinations; per-hop exploratory broadcast fires at ~`proactiveBroadcastProb`.
+5. **Failure handling (item 05):** hello-timeout expiry; notification emit +
+   propagate; bounded repair.
+6. **Evaporation (item 06):** periodic decay of unused entries; single reactive
+   ant per backoff window.
+
+Add a tiny **multi-hop in-memory scenario** harness (extend
+`core/tests/test_network_integration.cpp`) that measures, with a deterministic
+RNG and `FakeClock`:
+- delivery ratio of N injected data packets,
+- average hop count of delivered packets,
+- control-ant count (overhead proxy).
+
+Assert sane invariants (e.g. delivery ratio == 1.0 in a static connected line/grid
+once a route is set up; overhead doesn't grow super-linearly with packets after
+item 06.3). This catches regressions long before a full NS-3 run.
+
+## Part B — faithful NS-3 benchmark scenario
+
+Extend the existing harness rather than replacing it. The comparison driver is
+`ns3/examples/anthocnet-compare.cc` with wrappers
+`ns3/tools/run-comparison.sh` and `ns3/tools/cross-check.sh`.
+
+1. **Add scenario presets** to `anthocnet-compare` (CLI flags already take
+   nNodes/area/time/flows). Provide named presets:
+   - `dense-small` (current: 16 nodes / 250 m / 5 m/s / 4 flows) — keep for
+     regression continuity.
+   - `paper-base` (≈100 nodes / 3000×1000 m / 0–20 m/s / 30 s pause / 20 flows /
+     900 s) — the regime AntHocNet targets.
+   - `sweep-mobility` and `sweep-size` — vary one axis (speed; node count/area)
+     to reproduce the papers' trend plots.
+2. **Average over ≥10 seeds** (current default 5; the docs already note single
+   seeds are noisy). Make seed count a preset default.
+3. **Report overhead.** The papers weigh AntHocNet's PDR/delay advantage against
+   its higher routing overhead. Add a **routing-overhead** column (control bytes
+   or control packets / delivered data packet) to the FlowMonitor output and to
+   `docs/benchmarks.md`'s table + `ns3/tools/update-benchmarks.py`.
+4. **Keep the auto-generated table**, but add a second table for `paper-base` so
+   the README shows both the (honest) hard case and the regime where AntHocNet is
+   meant to win.
+
+## Part C — measure each item's effect
+
+For each of items 01–06, record a before/after row on `paper-base` (10+ seeds):
+
+| item | PDR % | delay ms | throughput kbps | overhead | notes |
+|------|------:|---------:|----------------:|---------:|-------|
+
+Expected directional effects (hypotheses to confirm, not guarantees):
+- **01 (greedy data β):** PDR ↑, delay ↓ (data stops using bad paths).
+- **02 (delay metric):** delay ↓, better path selection under load.
+- **03+04 (diffusion + active proactivity):** PDR ↑ on mobility, overhead ↓ vs
+  blind proactive broadcast.
+- **05 (failure handling):** PDR ↑ substantially on the mobile/sparse presets,
+  especially in **NS-3** (closes the no-detection gap).
+- **06 (evaporation/backoff):** overhead ↓, stability ↑.
+
+## Files to touch
+
+- `core/tests/test_network_integration.cpp` (metrics harness) + new tests per item
+- `ns3/examples/anthocnet-compare.cc` (scenario presets, overhead metric)
+- `ns3/tools/run-comparison.sh`, `ns3/tools/update-benchmarks.py`
+- `docs/benchmarks.md` (second table + overhead column)
+- `.github/workflows/benchmarks.yml` (optional: add a `paper-base` job, likely
+  manual-dispatch given runtime)
+
+## Acceptance criteria
+
+1. `make test` runs the new behaviour tests in CI (no simulator needed).
+2. `anthocnet-compare --preset=paper-base` runs and emits PDR/delay/throughput
+   **and overhead**, averaged over the preset's seed count.
+3. `docs/benchmarks.md` shows both `dense-small` and `paper-base` tables,
+   auto-regenerated.
+4. A short results note (this file or a sibling) records the before/after table
+   from Part C as items land.
+
+## Risks / notes
+
+- `paper-base` (100 nodes, 900 s, 10 seeds) is **heavy** — gate it behind manual
+  workflow dispatch, not every merge.
+- NS-2 vs NS-3 absolute numbers won't match (`docs/cross-validation.md`); compare
+  each simulator against *itself* before/after a change, and protocols against
+  each other within one simulator.
+- Don't tune `alpha`/`beta`/intervals to the small scenario; tune on `paper-base`.

--- a/docs/improvements/08-protocol-comparison-benchmarks.md
+++ b/docs/improvements/08-protocol-comparison-benchmarks.md
@@ -100,6 +100,33 @@ Update the default protocol list and the CSV/table grep filter accordingly
 baseline some AntHocNet papers use) is **not** in mainline ns-3 — call it out as
 optional/contrib, don't fake it.
 
+### 1b. AntHocNet ablation variants (ADR-0007)
+
+Per [ADR-0007](../adr/0007-proactive-diffusion-gated.md), the proactive/diffusion
+subsystem is config-gated and the benchmark must **decide the shipped default**.
+Add AntHocNet ablation variants driven by the `enableProactive` / `enableDiffusion`
+attributes (exposed via the NS-3 helper / NS-2 bind):
+
+- `anthocnet-full` — `enableProactive=1, enableDiffusion=1` (the default build).
+- `anthocnet-reactive` — `enableProactive=0` (reactive route setup + maintenance
+  only; the cheap, simple baseline).
+- *(optional)* `anthocnet-blind` — `enableProactive=1, enableDiffusion=0`
+  (proactive ants without virtual-pheromone guidance) to isolate diffusion's
+  contribution from proactive exploration's.
+
+Report these alongside the other protocols so the table shows whether diffusion
+actually buys PDR/delay at its overhead cost **in our scenarios**. If
+`anthocnet-full` does not beat `anthocnet-reactive` on `paper-base`, that is the
+signal to ship `enableProactive=false` by default and record it (ADR-0007
+consequence).
+
+Add one more ablation knob from [ADR-0012](../adr/0012-evaporation-is-a-secondary-safety-net.md):
+`enableEvaporation` (default on). A `*-no-evap` variant of the chosen default
+yields the **paper-faithful** mode (running-average + explicit link-failure removal
+only, no time-proportional decay). Report it so the safety-net's default-ON status
+is justified by measured stability/overhead, not intuition — if it does not help,
+that is the signal to ship `enableEvaporation=false`.
+
 ### 2. Add a routing-overhead / NRL metric (protocol-agnostic)
 
 FlowMonitor classifies only the CBR data flows, so control traffic is invisible
@@ -205,6 +232,10 @@ it exposes AntHocNet's higher overhead the papers acknowledge.)
    deterministically (re-running with the same CSV is a no-op).
 5. Both `dense-small` and `paper-base` tables present in `docs/benchmarks.md`.
 6. NS-3 builds with `aodv;olsr;dsdv;dsr;flow-monitor;anthocnet` enabled.
+7. **Ablation present (ADR-0007/0012):** `anthocnet-full` and `anthocnet-reactive`
+   appear as separate rows, driven by the `enableProactive`/`enableDiffusion`
+   attributes, plus a `*-no-evap` row (`enableEvaporation=0`), so the diffusion and
+   evaporation defaults can be justified from measured numbers.
 
 ## Risks / notes
 

--- a/docs/improvements/08-protocol-comparison-benchmarks.md
+++ b/docs/improvements/08-protocol-comparison-benchmarks.md
@@ -1,0 +1,221 @@
+# 08 — Benchmark against other routing protocols (comparison matrix)
+
+- **Deviation:** — (evaluation, not a protocol bug)
+- **Priority:** P2 (run alongside 01–06 to quantify each change)
+- **Effort:** M
+- **Layer:** `ns3/` tooling (+ optional `ns2/` scripts)
+- **Depends on:** complements [07](07-validation-and-benchmarks.md) — 07 defines
+  the **scenarios**; this item defines the **protocol set + metrics + fairness**.
+
+## Summary
+
+The repo already compares AntHocNet against **AODV, OLSR, DSDV** in
+`ns3/examples/anthocnet-compare.cc`, but (a) it omits **DSR** (a reactive
+source-routing baseline the AntHocNet papers care about), (b) it reports only
+PDR / delay / throughput and **no routing overhead** — the metric on which
+AntHocNet deliberately trades off, so leaving it out makes the comparison
+incomplete, and (c) it doesn't report dispersion (stddev / CI) across seeds. This
+item turns the harness into a complete, fair multi-protocol comparison.
+
+## Background / spec
+
+> "We compare its performance with **AODV (with local route repair)**, a
+> state-of-the-art MANET routing algorithm and a de facto standard." — [1] §4
+
+> "AntHocNet outperforms AODV in terms of delivery ratio and delay ... **However,
+> AntHocNet is less efficient in terms of routing overhead.**" — [1] §5
+
+So a fair comparison **must** report routing overhead next to PDR/delay, or it
+flatters AntHocNet's competitors and hides AntHocNet's actual trade-off. Standard
+MANET-comparison metric set (Broch et al. / Perkins): PDR, average end-to-end
+delay, **normalized routing load (NRL)**, throughput, and (optionally) path
+optimality and jitter.
+
+## Current behaviour
+
+`anthocnet-compare.cc` selects the protocol via an `InternetStackHelper` routing
+helper:
+
+```77:91:ns3/examples/anthocnet-compare.cc
+    InternetStackHelper internet;
+    if (proto == "anthocnet") {
+        AntHocNetHelper h;
+        internet.SetRoutingHelper(h);
+    } else if (proto == "aodv") {
+        AodvHelper h;
+        internet.SetRoutingHelper(h);
+    } else if (proto == "olsr") {
+        OlsrHelper h;
+        internet.SetRoutingHelper(h);
+    } else if (proto == "dsdv") {
+        DsdvHelper h;
+        internet.SetRoutingHelper(h);
+    }
+    internet.Install(nodes);
+```
+
+Metrics computed from FlowMonitor (data flows only) — PDR, mean delay,
+throughput; no overhead:
+
+```129:138:ns3/examples/anthocnet-compare.cc
+    for (auto& kv : monitor->GetFlowStats()) {
+        r.txPackets += kv.second.txPackets;
+        r.rxPackets += kv.second.rxPackets;
+        totalDelay += kv.second.delaySum.GetSeconds();
+        rxForDelay += kv.second.rxPackets;
+        totalRxBytes += kv.second.rxBytes;
+    }
+    r.pdr = r.txPackets ? 100.0 * r.rxPackets / r.txPackets : 0.0;
+```
+
+Fairness is already handled well: `RngSeedManager::SetSeed(1); SetRun(seed)` is
+reset before each protocol so every protocol sees the **same** mobility/traffic
+realisation (`anthocnet-compare.cc:44-46`). Keep that.
+
+The **NS-2 side already has per-scenario AODV vs AntHocNet** scripts
+(`ns2/tcl/scenario1/scenario1-AODV.sh`, `scenario1-AntHocNet.sh`, etc.) — extend
+those for parity rather than starting over.
+
+## Required change
+
+### 1. Add DSR to the comparison set (special install path)
+
+DSR in ns-3 is **not** an `Ipv4RoutingProtocol` and is **not** set via
+`SetRoutingHelper`. Install the internet stack first, then layer DSR on top:
+
+```cpp
+// proto == "dsr"
+DsrHelper dsr;
+DsrMainHelper dsrMain;
+internet.Install(nodes);          // install stack WITHOUT a routing helper
+dsrMain.Install(dsr, nodes);      // DSR sits above
+```
+
+Guard the rest of the install so the `internet.Install(nodes)` isn't called twice
+for DSR. Requires the `dsr` module:
+`--enable-modules='...;dsr'` and `#include "ns3/dsr-module.h"`.
+
+Update the default protocol list and the CSV/table grep filter accordingly
+(`anthocnet,aodv,olsr,dsdv,dsr`). Note in the doc that **AOMDV** (the multipath
+baseline some AntHocNet papers use) is **not** in mainline ns-3 — call it out as
+optional/contrib, don't fake it.
+
+### 2. Add a routing-overhead / NRL metric (protocol-agnostic)
+
+FlowMonitor classifies only the CBR data flows, so control traffic is invisible
+to it. Measure overhead by tracing every IP packet handed to L3 for transmission
+at **every** node and partitioning into data vs control:
+
+- Connect to the `Ipv4L3Protocol` `Tx` trace source on all nodes
+  (`ns3::Ipv4L3Protocol/Tx`), counting packets + bytes.
+- A packet is **data** iff it is UDP to the CBR port (9) belonging to a flow;
+  everything else transmitted by the routing layer (AODV RREQ/RREP/RERR on UDP
+  654, OLSR on UDP 698, DSDV periodic updates, AntHocNet ants on UDP 6900, DSR
+  option headers) is **control**. Counting at every hop (not just the source)
+  gives the standard "per-hop control transmissions" figure.
+- Report:
+  - **NRL** = control packets transmitted / data packets **delivered**
+    (dimensionless; lower is better).
+  - **control overhead** = control bytes/s (kbps) for an absolute view.
+
+DSR caveat: DSR piggybacks route information in option headers on data packets,
+so its "control" is partly inside data packets. Document that NRL slightly
+under-counts DSR overhead and that this is a known measurement limitation; the
+per-packet L3 Tx count still captures DSR's RREQ/RREP control packets.
+
+Add fields to `Result`/`Agg` and to the CSV/table output.
+
+### 3. Report dispersion across seeds
+
+Single-seed MANET runs are noisy (the docs already say so). Accumulate per-seed
+values and report **mean ± sample stddev** (or 95% CI = `1.96·stddev/√runs`) for
+each metric, not just the mean. Add `*_stddev` columns to the CSV.
+
+### 4. Scenario presets (defer to 07)
+
+Use the presets defined in [07](07-validation-and-benchmarks.md) — at minimum run
+the comparison on both `dense-small` (current, AntHocNet's hard case) and
+`paper-base` (large/sparse/mobile, AntHocNet's intended regime), plus the
+mobility and size sweeps. Don't re-invent scenarios here.
+
+### 5. Per-protocol fairness rules
+
+- Use each protocol's ns-3 **default tuning** (don't hand-tune competitors);
+  record the ns-3 version and any non-default attributes in the output header.
+- Identical PHY/MAC/mobility/traffic for all protocols (already true).
+- AODV: leave local route repair at its ns-3 default and **state it** (the papers
+  compare against "AODV with local repair").
+- Same warm-up: data starts at t=5 s (already), metrics computed over the whole
+  run; consider discarding a warm-up window so proactive protocols (OLSR/DSDV)
+  aren't penalised for their initial convergence — document whichever you choose.
+
+### 6. Extend NS-2 comparison scripts (optional, parity)
+
+The `ns2/tcl/scenarioN/*` shell scripts already run AODV and AntHocNet. Add DSR
+and DSDV variants (both ship with ns-2) and a small awk/Perl post-processor to
+emit the same metric set (PDR, delay, NRL) from the `.tr` traces, so NS-2 and
+NS-3 comparisons line up qualitatively (see `docs/cross-validation.md` — absolute
+numbers won't match across simulators).
+
+### 7. Plumb new metrics through the pipeline
+
+- `ns3/tools/run-comparison.sh`: widen the CSV grep filter for `dsr,` and pass any
+  new flags; keep emitting only CSV lines.
+- `ns3/tools/update-benchmarks.py`: add the new columns (NRL, overhead, stddev) to
+  the generated table; keep it deterministic (no timestamps) so CI doesn't make
+  empty commits.
+- `docs/benchmarks.md`: the auto-generated table gains NRL + overhead columns;
+  add the second (`paper-base`) table from 07.
+
+## Target table shape
+
+```
+| protocol  | PDR %      | delay (ms)  | thrput (kbps) | NRL        | ctrl (kbps) |
+|-----------|-----------:|------------:|--------------:|-----------:|------------:|
+| anthocnet | 71.2 ± 3.1 | 41.5 ± 5.2  | 6.8 ± 0.3     | 4.10 ± 0.4 | 31.2        |
+| aodv      | 64.8 ± 4.0 | 88.1 ± 9.7  | 6.1 ± 0.4     | 2.35 ± 0.3 | 12.7        |
+| olsr      | 58.3 ± 5.5 | 12.0 ± 1.1  | 5.4 ± 0.5     | 9.80 ± 1.1 | 60.4        |
+| dsdv      | 49.1 ± 6.2 | 120.4 ± 14  | 4.2 ± 0.6     | 7.55 ± 0.9 | 48.9        |
+| dsr       | 60.0 ± 4.8 | 95.3 ± 11   | 5.8 ± 0.4     | 1.90 ± 0.2 | 9.8         |
+```
+
+(Illustrative numbers only — they show the *shape*; the NRL column is the point:
+it exposes AntHocNet's higher overhead the papers acknowledge.)
+
+## Files to touch
+
+- `ns3/examples/anthocnet-compare.cc` (DSR case; L3-Tx overhead trace; NRL;
+  per-seed stddev; CSV columns; version header)
+- `ns3/examples/wscript` / `ns3/CMakeLists.txt` (ensure `dsr` module linked)
+- `ns3/tools/run-comparison.sh` (grep filter, flags)
+- `ns3/tools/update-benchmarks.py` (new columns)
+- `docs/benchmarks.md` (regenerated table + paper-base table)
+- `ns2/tcl/scenario*/...` + a trace post-processor (optional NS-2 parity)
+
+## Acceptance criteria
+
+1. `anthocnet-compare --protocols=anthocnet,aodv,olsr,dsdv,dsr` runs to completion
+   with the `dsr` module and emits all five rows.
+2. Output includes **NRL and control-overhead** columns and **mean ± stddev**
+   over `runs` seeds.
+3. The same RNG realisation is shared across protocols (regression: assert two
+   protocols see identical node initial positions for a fixed seed — e.g. log and
+   diff the first node's start position).
+4. `update-benchmarks.py` regenerates `docs/benchmarks.md` with the new columns,
+   deterministically (re-running with the same CSV is a no-op).
+5. Both `dense-small` and `paper-base` tables present in `docs/benchmarks.md`.
+6. NS-3 builds with `aodv;olsr;dsdv;dsr;flow-monitor;anthocnet` enabled.
+
+## Risks / notes
+
+- **DSR install is the classic ns-3 gotcha** — it must not go through
+  `SetRoutingHelper`, and `internet.Install` must run exactly once. Test the DSR
+  path in isolation first.
+- The `paper-base` preset × 5 protocols × 10 seeds is **expensive**; gate it
+  behind manual workflow dispatch (see 07), keep `dense-small` on the per-merge
+  job.
+- Don't tune competitors to lose; use defaults and record them. The honest story
+  (AntHocNet: better PDR/delay, worse overhead, advantage grows with
+  scale/mobility) is the one the papers tell — the benchmark should be able to
+  reproduce that story on `paper-base`, especially after items 01–05 land.
+- Keep cross-simulator expectations qualitative (`docs/cross-validation.md`).

--- a/docs/improvements/09-landscape-and-positioning.md
+++ b/docs/improvements/09-landscape-and-positioning.md
@@ -1,0 +1,171 @@
+# 09 — Landscape of public AntHocNet implementations + project positioning
+
+- **Deviation:** — (presentation / positioning, not a protocol bug)
+- **Priority:** P2 (high value-for-effort: the project is built well but presents
+  as a third of what it is)
+- **Effort:** S
+- **Layer:** repo metadata, `README.md`, `.gitattributes`, `docs/`
+- **Depends on:** nothing
+
+## Summary
+
+The code and internal docs of this repo are the strongest in the public
+AntHocNet field, but the GitHub "shopfront" still reflects the old 2016 NS-2-only
+project, so visitors see far less than what exists. This item (a) records the
+competitive landscape for positioning, and (b) lists concrete, low-effort fixes
+to make the project present as well as it is engineered.
+
+## The public AntHocNet landscape (as of 2026-06)
+
+Six public implementations exist. Verified by GitHub search + inspecting each
+repo's tree/README.
+
+| Repo | Platform | What it is | Algorithm | Maintained | Presentation |
+|---|---|---|---|---|---|
+| **danieljoppi/AntHocNet** (this) | NS-2 + NS-3 | Portable, **tested** C++ core + two thin adapters | Canonical (with the gaps in items 01–06) | **Yes (2026)** | Strong internal docs; weak GitHub shopfront |
+| **Sawchord/anthocnet** | NS-3 (waf) | Native ns-3 module, Bachelor thesis | **Fuzzy-logic variant** (fuzzylite FIS) | No (2017) | Build-only README; per-dir file docs; no design/results |
+| **netcom-augsburg/contiki-ng-anthocnet** | **Contiki-NG (real IoT OS)** | Embedded port, ICMPv6 ant signaling, RPL alternative | Canonical-ish, embedded | **Yes (2026)** | One-line README (title only) |
+| **jgera/ns-2.35-with-anthocnet** | NS-2.35 | Whole vendored `ns-allinone` tree | Legacy (the lineage with the back-ant defect) | No (2016) | env-setup README; the anti-pattern this repo replaces |
+| **alessandrolugari/...-Netlogo** | NetLogo | Educational agent sim (UNIMORE DAI course) | Canonical, conceptual | No (2022) | **Excellent**: documents every variable + presentation |
+| **martinellop/ant-net** | NetLogo | Educational/visual sim (UNIMORE DAI course) | Canonical, conceptual | No (2024) | **Excellent**: demo GIF + video + screenshots |
+
+### What each is doing (technical)
+
+- **Sawchord** — the only other "serious" simulator implementation. Full native
+  ns-3 module: a fuzzy inference system (`model/anthocnet-fis.*` wrapping
+  fuzzylite 6, `Eval(in1,in2) → quality`) computes pheromone from two link
+  metrics, plus a multi-interface routing table (`anthocnet-rtable`), a
+  per-destination packet cache (`anthocnet-pcache`), a traffic/stats monitor
+  (`anthocnet-stat`), and a sim database/app for evaluation. **More complete on
+  maintenance than this repo, but it is a *modified* (fuzzy) algorithm, fused
+  into ns-3 (not portable), on waf + a fuzzylite submodule (heavy build).**
+- **Contiki-NG (Augsburg)** — the most novel: AntHocNet on real low-power
+  IoT/6LoWPAN motes (Cooja/hardware) as an RPL alternative for mobility. Ant
+  control rides ICMPv6 (`AntHocNet/anthocnet-icmpv6.c`), real pheromone table
+  (`anthocnet-pheromone.*`), `-conf.h`/`-types.h`. Only one targeting embedded
+  systems rather than a simulator. Recent and active.
+- **jgera** — a checked-in `ns-allinone-2.35` tree with AntHocNet preinstalled;
+  the "forked simulator" anti-pattern this repo's design (ADR-0005, anchor patch)
+  exists to eliminate.
+- **NetLogo (both)** — educational agent sims; not deployable routing, but they
+  faithfully model reactive/proactive ants, `Thop`, MAC travel-time estimate,
+  proactive sending rate, and link failures, and they are the **best at
+  explaining the algorithm visually**.
+
+### Field-level pattern
+
+The simulator/embedded repos have **strong code, weak presentation**
+(Sawchord, Contiki, jgera); the NetLogo repos have **weak code, strong
+presentation**. **This repo is the only one with both strong engineering *and*
+strong internal docs** (CONTEXT, architecture, ADRs, porting-notes, CI, unit
+tests, auto-generated benchmarks, dual-simulator portability). On substance it
+leads the field — the only thing missing is the storefront.
+
+## Positioning statement (use in README / abstract)
+
+> The only AntHocNet implementation maintained as a **single, simulator-agnostic,
+> unit-tested algorithm core** that installs onto **both NS-2 (idempotent source
+> patch) and NS-3 (native module)** — no vendored simulator tree, with CI and
+> reproducible AODV/OLSR/DSDV(/DSR) benchmarks.
+
+Differentiators vs each peer:
+- vs **Sawchord** — canonical algorithm (not a fuzzy variant), portable core,
+  modern build, **tested + CI**; Sawchord is unmaintained and waf/fuzzylite-bound.
+- vs **Contiki-NG port** — dual-simulator evaluation + docs; complementary, not
+  competing (different layer). Worth cross-linking.
+- vs **jgera / SourceForge** — not a forked simulator; reversible patch + a clean
+  core; the back-ant defect of that lineage is fixed here.
+- vs **NetLogo** — a real routing protocol, not a teaching toy (but borrow their
+  visual presentation).
+
+## Required change (presentation fixes)
+
+Verified current GitHub state of `danieljoppi/AntHocNet`: `default_branch: main`,
+`archived: false`, `description: "AntHocNet implementation in NS-2"`,
+`topics: []`, `language: Tcl`. All of the following are surface-level and cheap.
+
+### 1. Fix the GitHub repo metadata (no code change)
+
+- **Description** → something like:
+  *"AntHocNet (ant-colony MANET routing) as a portable, tested C++ core with NS-2
+  and NS-3 adapters."*
+- **Topics** → `manet`, `ant-colony-optimization`, `aco`, `routing-protocol`,
+  `ns-3`, `ns-2`, `mobile-ad-hoc-network`, `cpp`, `swarm-intelligence`.
+- Can be done via `gh` (if installed/authed):
+  ```bash
+  gh repo edit danieljoppi/AntHocNet \
+    --description "AntHocNet (ant-colony MANET routing) as a portable, tested C++ core with NS-2 and NS-3 adapters." \
+    --add-topic manet --add-topic ant-colony-optimization --add-topic aco \
+    --add-topic routing-protocol --add-topic ns-3 --add-topic ns-2 \
+    --add-topic mobile-ad-hoc-network --add-topic cpp --add-topic swarm-intelligence
+  ```
+  (Otherwise set them in the GitHub UI "About" panel.)
+
+### 2. Fix language detection → C++ (`.gitattributes`)
+
+GitHub Linguist counts the 30+ `ns2/tcl/scenario*/sim-*.tcl` files and the patch
+fragments as the bulk of the repo, so it labels the project **Tcl**. Add a
+`.gitattributes` at the repo root:
+
+```gitattributes
+# Make GitHub Linguist reflect that this is a C++ project.
+ns2/tcl/**           linguist-vendored
+ns2/patch/fragments/** linguist-vendored
+docs/**              linguist-documentation
+*.tcl                linguist-detectable=false
+```
+
+(Adjust so the example/scenario Tcl and patch fragments don't dominate; verify on
+GitHub after pushing that the language bar shows C++ first.)
+
+### 3. Strengthen the README top
+
+- Add a one-line **positioning statement** (above) right under the title.
+- Surface the **benchmark table** (currently only in `docs/benchmarks.md`) or link
+  it prominently.
+- Add a **"Compared to other implementations"** section (condense the table
+  above) so visitors immediately see how this differs from Sawchord / Contiki /
+  the NetLogo sims. Link out to them.
+
+### 4. Add at least one visual
+
+The NetLogo repos prove a single image massively improves comprehension. Add to
+the README one of:
+- a topology + pheromone-table diagram (reactive setup → backward ant → mesh), or
+- a benchmark bar chart (PDR/delay/NRL vs AODV/OLSR/DSDV — from item 08), or
+- an ASCII/Mermaid sequence of the decision flow (already described in
+  `docs/architecture.md`; render it).
+
+Store under `docs/img/` and embed with a relative path.
+
+### 5. SourceForge mirror
+
+If the SourceForge project is still linked, update its status from "Pre-Alpha"
+and point it at the GitHub repo, or drop the link.
+
+## Files to touch
+
+- GitHub repo settings (description, topics) — via `gh` or UI.
+- `.gitattributes` (new, repo root).
+- `README.md` (positioning line, comparison section, surfaced benchmark, image).
+- `docs/img/` (new diagram or chart asset).
+
+## Acceptance criteria
+
+1. GitHub "About" shows the new description + topics; repo is discoverable under
+   `manet` / `ant-colony-optimization`.
+2. The GitHub language bar shows **C++** as the primary language.
+3. README opens with the positioning statement and contains a
+   "Compared to other implementations" section linking the peer repos.
+4. At least one diagram/chart renders in the README.
+5. No stale "NS-2 only" / "Pre-Alpha" framing remains.
+
+## Risks / notes
+
+- Pure presentation — zero behavioural risk. Safe to do independently of items
+  01–08.
+- Don't overstate maturity: keep the honest caveats already in `CONTEXT.md §8`
+  (no full sim in CI, cross-sim parity not guaranteed). The goal is accurate
+  positioning, not hype.
+- Cross-linking the Contiki-NG port (different layer, complementary) is good
+  citizenship and signals awareness of the field.

--- a/docs/improvements/10-data-loops-multipath-and-mac-metric.md
+++ b/docs/improvements/10-data-loops-multipath-and-mac-metric.md
@@ -1,0 +1,169 @@
+# 10 — Data-loop suppression, multipath safety, reactive broadcast cap, MAC-aware metric
+
+- **Covers:** A1 (data loops / multipath), A3 (reactive max-broadcasts), A2 (MAC-aware per-hop cost)
+- **Priority:** A1 **P1**, A3 **P2**, A2 **P2**
+- **Effort:** M
+- **Layer:** `core/` (+ small adapter hooks for A2)
+- **Depends on:** 02 (A2 deepens it), 04/05 (share `broadcastBudget`)
+
+## A1 — Data-packet loop suppression and multipath safety
+
+- **Decision:** prev-hop exclusion is **always on**; per-flow stickiness is
+  **config-gated, default off**, and lives in `core/` — see
+  [ADR-0010](../adr/0010-data-forwarding-prevhop-excluded-stochastic.md).
+
+### Problem
+
+Data is forwarded by an independent stochastic draw at **every** hop, with no
+exclusion of the hop the packet just came from, so transient routing loops are
+possible and only the IP TTL stops them. Per-packet randomness also reorders a
+single flow's packets across multiple paths.
+
+### Spec basis
+
+AntHocNet spreads data stochastically over a *mesh* of paths, but relies on the
+pheromone gradient being effectively loop-free; real implementations additionally
+avoid sending a packet back the way it came and damp per-packet flapping. The
+paper notes a node "removes the wrong routing information" of the hop a packet
+came from in some cases — i.e. the incoming neighbour is treated specially.
+
+### Current behaviour
+
+In-transit data re-enters the same stochastic path with no prev-hop exclusion:
+
+```250:251:ns3/model/anthocnet-routing-protocol.cc
+    // In-transit forwarding.
+    NodeAddress next = m_logic->selectNextHop(ToCore(dst), /*proactive=*/false);
+```
+
+```176:184:core/src/ant_router_logic.cpp
+std::vector<RouteDecision> AntRouterLogic::onDataPacket(NodeAddress dest) {
+    NodeAddress next = table_.lookup(dest, rng_);
+    if (next == kInvalidAddress) {
+        ...
+    }
+    return {{RouteAction::Unicast, next, false, {}}};
+}
+```
+
+`onDataPacket` takes only `dest`; it cannot exclude the previous hop because it
+isn't told it. (NS-2 `handleData` is the same.)
+
+### Required change
+
+1. Give the core the incoming neighbour: `onDataPacket(dest, prevHop = kInvalidAddress)`
+   and `PheromoneTable::lookup(dest, beta, rng, exclude = kInvalidAddress)`.
+   In `nextNeighborNode`, skip the excluded neighbour when forming `phSum` and
+   when selecting (don't route a packet back to the hop it arrived from, unless it
+   is the *only* next hop).
+2. Adapters pass the previous hop: NS-3 `RouteInput` knows `idev` → map to the
+   sender; NS-2 `handleData` has `ch->prev_hop_`.
+3. **Per-flow stickiness — config-gated, default off (ADR-0010).** Behind
+   `Config::enableFlowStickiness` (default `false`), cache the chosen next hop per
+   `(src,dst)` flow for a short window (`Config::flowStickyTtl`) so a burst follows
+   one path; re-draw only when the cache expires or the path degrades. Keep it
+   **bounded** (FIFO, like the dedup history) and in `core/` (routing policy,
+   golden rule #2). This needs the packet **src**, so the data entry point becomes
+   `onDataPacket(dest, prevHop, src)`; adapters pass it (NS-3 origin / NS-2
+   `ih->saddr()`).
+   - Default off because a high greedy `β_data` ([item 01](01-data-vs-ant-beta.md))
+     already concentrates data on the best path (per-packet reordering is limited
+     in the paper's regime), and pure per-packet stochastic is the paper-faithful
+     baseline. Turn it on only for reorder-sensitive (TCP) traffic, and measure it
+     as a benchmark ablation (item 08).
+
+### Acceptance
+
+- `test_data_routing.cpp`: a packet arriving from neighbour `n` is never
+  forwarded back to `n` while another next hop with pheromone exists; if `n` is
+  the only option it still forwards (no black hole).
+- Loop regression: in a small ring topology with stochastic pheromone, injected
+  data is delivered without TTL-expiry drops.
+- **Stickiness gate (ADR-0010):** with `enableFlowStickiness = false` (default),
+  a flow re-draws each packet; with it `true`, a burst on `(src,dst)` follows a
+  single cached next hop until `flowStickyTtl` expires or the path degrades.
+
+## A3 — Reactive forward-ant maximum broadcasts
+
+### Spec basis
+
+> "...it has a **maximum number of broadcasts (which we set to 2)** so that its
+> proliferation is limited." — [1] §3.2/§3.5 (applies to reactive + repair ants)
+
+### Current behaviour
+
+A reactive forward ant with no route is re-broadcast at every node that lacks
+pheromone, bounded only by `(src,seq)` dedup and IP TTL — there is no cap on how
+many times *the ant* is broadcast end-to-end:
+
+```151:155:core/src/ant_router_logic.cpp
+        NodeAddress next = selectNextHop(ant.dst, proactive);
+        if (next == kInvalidAddress) {
+            return {{RouteAction::Broadcast, kInvalidAddress, true, ant}};
+        }
+```
+
+### Required change
+
+Use the shared `AntMessage::broadcastBudget` (introduced in items 04/05): decrement
+on each broadcast; when it hits 0, `Drop` instead of `Broadcast`. Initialise
+reactive ants to `config_.reactiveMaxBroadcasts` (default 2). This bounds the
+flood independently of TTL/dedup.
+
+### Acceptance
+
+- A reactive ant traversing a region with no pheromone is broadcast at most
+  `reactiveMaxBroadcasts` times, then dropped (unit test counts `Broadcast`
+  decisions across a scripted chain).
+
+## A2 — MAC-aware per-hop cost (deepens item 02)
+
+### Spec basis
+
+> Per-hop estimate is a running average of the measured MAC queue+transmit delay:
+> `T̂_mac = α·T̂_mac + (1−α)·t_mac`. The forward ant sums these to form `T̂_d^i`. — [1] §3.2
+
+### Current behaviour
+
+Even after item 02 fixes units, the per-hop cost is wall-clock arrival delta, not
+a smoothed MAC delay; it ignores local queue occupancy, so the metric doesn't
+reflect congestion (no real load-balancing).
+
+### Required change
+
+1. Add an `ILinkDelay` (or extend an existing port) so the adapter supplies the
+   node's current smoothed MAC delay estimate `T̂_mac`. NS-3: derive from the
+   WifiMac queue + tx stats or a moving average of observed tx times. NS-2: from
+   the ifq length × per-packet service time.
+2. The forward ant accumulates `T̂_mac` per hop **into the existing per-hop scalar
+   `AntHop.time`** (instead of, or blended with, the wall-clock delta from item
+   02). This is a *measurement* change at `stampForward`, **not** a wire-schema
+   change: the entry stays `{node, cost}` and no per-hop signal fields are added,
+   so [ADR-0009](../adr/0009-backward-ants-carry-path-not-state.md)'s slim and the
+   single-scalar invariant hold (no extra `kWireVersion` bump for MAC-awareness).
+3. Keep it behind a config flag so the simpler item-02 metric remains the default
+   until validated.
+
+### Acceptance
+
+- With a congested node (large `T̂_mac`), paths through it receive lower pheromone
+  and data shifts to the alternate path (`test_mac_metric.cpp` with a scripted
+  delay source).
+
+## Files to touch
+
+- `core/include/anthocnet/core/config.h` (`reactiveMaxBroadcasts`, MAC-metric flag,
+  `enableFlowStickiness`, `flowStickyTtl`)
+- `core/include/.../ant_router_logic.{h}` + `.cpp` (`onDataPacket(dest, prevHop, src)`,
+  bounded `(src,dst)→hop` sticky cache, broadcast budget, MAC accumulation)
+- `core/include/.../pheromone_table.{h,cpp}` (`lookup`/`nextNeighborNode` exclude)
+- `core/include/.../ports.h` (`ILinkDelay` for A2)
+- `ns3/model/anthocnet-routing-protocol.cc`, `ns2/src/ahn_router.cc` (pass prevHop;
+  supply MAC delay)
+
+## Risks / notes
+
+- A1's prev-hop exclusion must keep the "only option" fallback or it creates black
+  holes at leaf nodes.
+- A2 needs a real MAC signal; if unavailable, ship A1+A3 and gate A2.
+- `broadcastBudget` is one shared wire field across items 04/05/10 — add it once.

--- a/docs/improvements/11-adapter-robustness.md
+++ b/docs/improvements/11-adapter-robustness.md
@@ -1,0 +1,173 @@
+# 11 — Adapter robustness (NS-2 queue bound, NS-3 multi-interface, address mapping)
+
+- **Covers:** B1 (NS-2 unbounded queue), B2 (NS-3 single-interface assumptions +
+  ant hop cap), B3 (address mapping)
+- **Priority:** B1 **P1** (verified near-bug), B2 **P2**, B3 **P1** (verified
+  latent bug)
+- **Effort:** M
+- **Layer:** adapters (`ns2/`, `ns3/`)
+- **Depends on:** nothing
+
+## B1 — NS-2 pending queue is unbounded and never times out *(verified)*
+
+### Problem
+
+The NS-3 adapter bounds its pending queue and expires stale entries
+(`RequestQueue(64, Seconds(30))`), but the NS-2 adapter uses a plain map of lists
+with **no cap and no timeout**. A destination that never becomes reachable
+accumulates packets forever → memory growth, held `Packet*` (leak risk on
+shutdown), and eventual delivery of very stale packets.
+
+### Current behaviour
+
+```108:108:ns2/src/ahn_router.h
+    std::map<nsaddr_t, std::list<Packet*> > queue_;
+```
+
+```267:269:ns2/src/ahn_router.cc
+void AntHocNetAgent::enqueue(Packet* p, nsaddr_t dest) {
+    queue_[dest].push_back(p);
+}
+```
+
+Compare NS-3:
+
+```30:34:ns3/model/anthocnet-routing-protocol.cc
+RoutingProtocol::RoutingProtocol()
+    : m_started(false),
+      m_queue(64, Seconds(30)),
+```
+
+```11:18:ns3/model/anthocnet-rqueue.cc
+bool RequestQueue::Enqueue(QueueEntry& entry) {
+    ...
+    if (m_queue.size() >= m_maxLen) {
+        ...
+        m_queue.erase(m_queue.begin());   // drop oldest
+    }
+    m_queue.push_back(entry);
+```
+
+### Required change
+
+Give the NS-2 queue the same discipline as NS-3:
+- a per-agent total cap (e.g. `config`-driven, default 64) — drop oldest
+  (`drop(p, DROP_RTR_QFULL)`) when exceeded;
+- a per-packet enqueue timestamp and a periodic purge that `drop`s entries older
+  than a timeout (default 30 s) with `DROP_RTR_QTIMEOUT`;
+- free dropped packets via NS-2 `drop()`/`Packet::free` so traces are correct.
+Drive the purge from the maintenance tick (item 05) or a dedicated timer.
+
+### Acceptance
+
+- NS-2 self-test / a unit-style check: enqueuing > cap drops the oldest; an entry
+  past the timeout is dropped on purge; no packet is leaked (counts balance).
+
+## B2 — NS-3 single-interface assumptions + missing ant hop cap
+
+- **Decision (ADR-0011):** node identity is the node's *primary* AntHocNet
+  interface IP; B2 is **egress selection only** and does not change identity.
+
+### Problem
+
+The NS-3 adapter routinely uses `m_socketAddresses.begin()` as *the* interface
+for output device / source selection, which is incorrect on multi-interface
+nodes; and (per item 06.2) it applies no hop/TTL cap to broadcast ants.
+
+### Current behaviour
+
+```211:219:ns3/model/anthocnet-routing-protocol.cc
+        Ptr<Ipv4Route> route = Create<Ipv4Route>();
+        route->SetDestination(dst);
+        route->SetGateway(ToIpv4(next));
+        Ipv4InterfaceAddress ifaceAddr = m_socketAddresses.begin()->second;
+        route->SetSource(m_ipv4->SourceAddressSelection(
+            m_ipv4->GetInterfaceForAddress(ifaceAddr.GetLocal()), dst));
+        route->SetOutputDevice(m_ipv4->GetNetDevice(
+            m_ipv4->GetInterfaceForAddress(ifaceAddr.GetLocal())));
+```
+
+The same `begin()` pattern recurs in `RouteInput` (line ~257) and `FlushQueue`.
+
+### Required change
+
+- Select the **correct egress interface** for `next` (the interface whose subnet
+  contains the next hop / via `GetInterfaceForDevice`), not `begin()`.
+- Add an ant **hop/TTL cap**: set the ant packet's IP TTL to
+  `config_.networkDiameter` on send and drop on expiry (NS-2 already does; NS-3
+  should too), plus the core-level hop cap from item 06.2.
+- Document the supported topology (single wifi interface per node is the tested
+  path); make multi-interface at least correct, even if not optimised.
+
+### Acceptance
+
+- A two-interface node routes via the interface facing the next hop (test or
+  documented smoke run); broadcast ants do not propagate beyond the hop cap.
+
+## B3 — Address mapping collides broadcast with "no route" *(verified latent bug)*
+
+- **Decision (ADR-0011):** `NodeAddress` *is* the IP (treated opaquely);
+  **broadcast is a `RouteAction`, never an address**, so the all-ones address is
+  never passed through `ToCore`. We do **not** switch to an abstract node id.
+
+### Problem
+
+`ToCore` casts the full 32-bit IPv4 address to `int32`. `255.255.255.255`
+(`0xFFFFFFFF`) becomes `int32 -1`, which is exactly `kInvalidAddress` ("no
+route"). Any address with the MSB set (≥ `128.0.0.0`) becomes negative, which is
+fragile against the `kInvalidAddress` sentinel and signed comparisons.
+
+### Current behaviour
+
+```61:66:ns3/model/anthocnet-routing-protocol.h
+    static ::anthocnet::core::NodeAddress ToCore(Ipv4Address a) {
+        return static_cast<::anthocnet::core::NodeAddress>(a.Get());
+    }
+    static Ipv4Address ToIpv4(::anthocnet::core::NodeAddress a) {
+        return Ipv4Address(static_cast<uint32_t>(a));
+    }
+```
+
+Today it's masked because the examples use `10.1.0.0/16` (small values), but it's
+a latent trap.
+
+### Required change
+
+Per [ADR-0011](../adr/0011-nodeaddress-is-ip-broadcast-is-an-action.md), keep
+`NodeAddress` = the IP (opaque to the core) and fix the contract, **not** the
+type:
+
+- **Never feed the all-ones (or directed-broadcast/multicast) address through
+  `ToCore` as an identity.** Broadcast is `RouteAction::Broadcast`; the adapter
+  maps that decision to its broadcast send, and `ToCore` is only ever called on
+  real unicast peer addresses. With that guard the *only* IP that maps to `-1`
+  (the broadcast address) never reaches `ToCore`, so no unicast peer can alias the
+  sentinel.
+- **Leave MSB-set unicast IPs mapping to negative ints** — that's fine, the core
+  treats `NodeAddress` opaquely and only compares `== kInvalidAddress`. Do **not**
+  switch to an abstract node id (ADR-0011 rejects the id↔IP directory it forces).
+- **Assert** `ToCore(unicast) != kInvalidAddress` at the boundary, and keep
+  `ToIpv4(ToCore(x)) == x` over the supported unicast range.
+- A node's identity is its **primary AntHocNet interface IP**; document
+  "one AntHocNet interface per node" as the supported topology (B2 handles egress
+  for multi-interface, without changing identity).
+
+### Acceptance
+
+- `ToCore(255.255.255.255) != kInvalidAddress`; addresses ≥ `128.0.0.0` round-trip
+  through `ToCore`/`ToIpv4` without aliasing the sentinel (unit test in the NS-3
+  test suite).
+
+## Files to touch
+
+- `ns2/src/ahn_router.{h,cc}` (bounded/timed queue, purge)
+- `ns3/model/anthocnet-routing-protocol.{h,cc}` (egress interface selection, ant
+  TTL, address mapping guard)
+- `ns3/test/anthocnet-test-suite.cc` (B3 round-trip test)
+
+## Risks / notes
+
+- B3's id scheme change touches every `ToCore`/`ToIpv4` call — do it in one pass
+  and keep `ToIpv4(ToCore(x)) == x` for the supported address range.
+- B1's drop semantics should use NS-2 `drop()` so wireless traces stay accurate
+  for the benchmark PDR computation in `docs/cross-validation.md`.

--- a/docs/improvements/12-codec-hardening-and-threat-model.md
+++ b/docs/improvements/12-codec-hardening-and-threat-model.md
@@ -1,0 +1,177 @@
+# 12 — Codec hardening (enforce protocol bounds on untrusted input) + threat model
+
+- **Covers:** C1
+- **Priority:** P1 (trust-boundary; cheap to fix)
+- **Effort:** S
+- **Layer:** `core/` (codec) + docs (`SECURITY.md`)
+- **Depends on:** nothing
+
+## Summary
+
+The wire codec decodes packets that arrive from the network (untrusted). It is
+already **over-read safe** — every length is checked against the remaining bytes
+before use — but it does **not** enforce the protocol's own bounds
+(`Config::maxPathLength`, `Config::maxHistory`) on decoded counts. That breaks
+golden-rule #5 ("keep bounded structures bounded") precisely at the trust
+boundary, and lets a peer push 16-bit-max element counts. This item clamps the
+decode and adds a fuzz target, plus writes down the (currently implicit) threat
+model.
+
+It also introduces the **1-byte wire-version field** decided in
+[ADR-0006](../adr/0006-on-wire-protocol-version.md): a version mismatch is the
+cheapest, earliest possible rejection of a foreign/garbage frame, so it belongs
+in the same hardening pass. The full byte layout is in
+[`docs/wire-format.md`](../wire-format.md).
+
+## What's already good (don't regress)
+
+`deserialize` bounds every variable-length section against the buffer before
+resizing:
+
+```134:147:core/src/ant_message_codec.cpp
+    const std::uint16_t nVisited = r.u16();
+    if (!r.ok || r.remaining < static_cast<std::size_t>(nVisited) * kHopSize) return false;
+    msg.visited.resize(nVisited);
+    for (auto& h : msg.visited) { h.node = r.i32(); h.time = r.dbl(); }
+
+    const std::uint16_t nHistory = r.u16();
+    if (!r.ok || r.remaining < static_cast<std::size_t>(nHistory) * kHopSize) return false;
+    msg.history.resize(nHistory);
+    ...
+    const std::uint16_t nHello = r.u16();
+    if (!r.ok || r.remaining < static_cast<std::size_t>(nHello) * kHelloSize) return false;
+```
+
+So a malformed packet cannot cause an out-of-bounds read or allocate more than
+the buffer can back. Good.
+
+## The gap
+
+- The counts are only bounded by `uint16` (≤ 65535) and by the incoming buffer
+  size, **not** by `maxPathLength` / `maxHistory`. A crafted (or just buggy) peer
+  can hand the core a `visited`/`history` far larger than the algorithm's
+  invariant allows, which then flows into router logic that assumes those caps.
+- `msg.type` / `msg.direction` are cast straight from a byte to the enums with no
+  validation — an unknown value becomes an out-of-range enum.
+- No fuzzing exists for the parser, despite it being the only code that touches
+  untrusted bytes.
+
+## Required change
+
+### 0. Add the wire-version field (ADR-0006)
+
+Prepend a 1-byte `version` at **offset 0** of the frame (shifting `type` to
+offset 1) and validate it before anything else:
+
+```cpp
+// codec-local constant, asserted identical in both adapter headers + tests:
+constexpr std::uint8_t kWireVersion = 0x01;
+
+// serialize(): write first
+putU8(out, kWireVersion);
+
+// deserialize(): read + check first, before any length field
+if (r.u8() != kWireVersion) return false;   // foreign / stale / garbage frame
+```
+
+This is an O(1) reject at the trust boundary, ahead of the count checks below.
+Bump `kWireVersion` on any future field/semantic change (this is the
+golden-rule #4 maintenance rule; see [`docs/wire-format.md`](../wire-format.md)).
+Update the NS-2 (`ant_packet_ns2`) and NS-3 (`AntHeader`) headers and their
+`wireSize()` / `GetSerializedSize()` to account for the extra byte.
+
+### 1. Clamp decoded counts to protocol bounds
+
+`deserialize` should reject (or clamp) counts that exceed the configured maxima.
+Two options — pick reject for strictness:
+
+```cpp
+// after reading nVisited, before resize:
+if (nVisited > kMaxVisitedOnWire) return false;   // kMaxVisitedOnWire == Config::maxPathLength default
+```
+
+Since the free-function codec has no `Config`, expose the caps as codec
+constants (mirroring the `Config` defaults) or add an overload that takes the
+caps. Apply to `visited`, `history`, and `helloDests`.
+
+### 2. Validate the enums
+
+After reading `type`/`direction`, verify they are one of the known values;
+return `false` (drop) otherwise. Prevents undefined enum values reaching the
+state machine.
+
+### 3. Add a fuzz target
+
+Add `core/tests/fuzz_codec.cpp` (libFuzzer):
+
+```cpp
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    anthocnet::core::AntMessage m;
+    anthocnet::core::codec::deserialize(data, size, m);  // must never crash/UB
+    return 0;
+}
+```
+
+Wire an optional `-DANTHOCNET_FUZZ=ON` CMake path (clang `-fsanitize=fuzzer,address`).
+A short OSS-style run in CI (e.g. 60 s) on PRs touching the codec is enough.
+
+### 4. Round-trip + clamp tests
+
+Extend `core/tests/test_codec.cpp`: a packet declaring `nVisited` beyond the cap
+is rejected; an out-of-range `type` byte is rejected; a truncated buffer for each
+section returns `false` (already implicitly covered — make it explicit).
+
+## Threat model (write into `SECURITY.md`)
+
+Document the protocol's security posture honestly (it's a research routing
+protocol):
+
+- **Trust boundary:** `codec::deserialize` is the only parser of untrusted bytes;
+  it is over-read safe and (after this item) bound-enforcing and enum-validating.
+- **Known, by-design limitations (out of scope to fix in the algorithm):**
+  - Ants are **unauthenticated** — a malicious node can inject false pheromone
+    (blackhole/greyhole), advertise bogus hello destinations, or mount wormhole
+    attacks. This is inherent to vanilla AntHocNet; mitigations (signed control
+    messages, trust/reputation) are research extensions, not protocol bugs.
+  - No replay protection beyond `(src,seq)` dedup (bounded history → replays
+    after eviction are possible).
+- **In scope (this item):** memory-safety and resource-bound enforcement of the
+  parser so a single malformed packet cannot crash, over-read, or violate the
+  bounded-structure invariant.
+
+## Files to touch
+
+- `core/src/ant_message_codec.cpp` + its header (version byte + `kWireVersion`;
+  clamp + enum validation; expose caps)
+- `ns2/src/ant_packet_ns2` + `ns3/model/anthocnet-packet` (account for the extra
+  version byte; assert the same `kWireVersion`)
+- `core/tests/test_codec.cpp` (version-mismatch, clamp, enum, truncation tests)
+- `core/tests/fuzz_codec.cpp` + `core/tests/CMakeLists.txt` (optional fuzz target)
+- `docs/wire-format.md` (already documents the layout — keep offsets in sync)
+- `SECURITY.md` (threat model section)
+- `.github/workflows/ci.yml` (optional short fuzz job on codec changes)
+
+## Acceptance criteria
+
+1. A frame whose offset-0 byte is not `kWireVersion` is rejected
+   (`deserialize` returns `false`) before any length field is read; valid frames
+   carry the version byte and still round-trip.
+2. A packet with `nVisited`/`nHistory`/`nHello` above the configured caps is
+   rejected (`deserialize` returns `false`); valid packets still round-trip
+   (existing `test_codec.cpp` passes).
+3. An out-of-range `type`/`direction` byte is rejected.
+4. The fuzz target builds and runs without crashes/UB on a short corpus.
+5. `SECURITY.md` documents the trust boundary + the unauthenticated-ants
+   limitation.
+6. Both adapter headers account for the version byte and assert the same
+   `kWireVersion`; `make test` green; golden rules #4 and #5 now hold at the wire
+   boundary too.
+
+## Risks / notes
+
+- Rejecting (vs clamping) is safer but means a peer running a larger
+  `maxPathLength` than this node will have its legitimately-long ants dropped —
+  keep the on-wire cap a documented constant shared by both adapters (it already
+  must match across the codec + NS-2 + NS-3 headers).
+- Keep the codec free of `Config` coupling if possible (use codec-local constants
+  that equal the `Config` defaults) to preserve its standalone testability.

--- a/docs/improvements/13-ci-e2e-and-fuzzing.md
+++ b/docs/improvements/13-ci-e2e-and-fuzzing.md
@@ -1,0 +1,107 @@
+# 13 — End-to-end simulation smoke in CI + codec fuzzing + property tests
+
+- **Covers:** D1 (e2e smoke), D2 (fuzzing + property tests)
+- **Priority:** P2
+- **Effort:** M
+- **Layer:** CI (`.github/workflows/`) + `core/tests/`
+- **Depends on:** 12 (shares the fuzz target)
+
+## Summary
+
+CI currently runs only the core unit tests + the NS-2 patch apply/revert
+self-test. `CONTEXT.md §8` explicitly flags that **no full simulation runs in
+CI** and behavioural validation on real NS-2/NS-3 trees is manual. This item adds
+(D1) a pinned end-to-end simulator smoke test and (D2) fuzzing + property tests,
+so regressions in actual routing behaviour are caught automatically.
+
+## Current state
+
+```yaml
+# .github/workflows/ci.yml runs: make test (core) + ns2/patch/selftest.sh
+```
+
+The NS-3 module is built only on manual dispatch; nothing runs a real
+end-to-end simulation or asserts delivery.
+
+## D1 — Pinned end-to-end smoke tests
+
+### NS-3 smoke job
+
+Add a CI job (manual dispatch + nightly; too heavy for every push) that:
+1. Checks out a **pinned** ns-3 tag (e.g. `ns-3.40`) — pin the exact version so
+   the job is reproducible and a future ns-3 change can't silently break it.
+2. `make install-ns3 NS3DIR=...`, configures with the modules from
+   `docs/benchmarks.md`, builds.
+3. Runs `anthocnet-example` and asserts a **non-trivial delivery ratio** in a
+   small connected scenario (e.g. PDR > 50% on a static 7-node line), parsing the
+   FlowMonitor/CSV output.
+4. Optionally runs `anthocnet-compare --runs=1 --time=20` and asserts AntHocNet
+   delivers at all (sanity, not a performance gate).
+
+### NS-2 smoke job
+
+Add a job that builds a pinned ns-2 (e.g. `ns-2.35`) with the patch applied and
+runs `ns2/tcl/1-simple.tcl`, asserting non-zero CBR delivery from the trace
+(reuse the awk snippet in `docs/cross-validation.md`). ns-2 builds are slow/old —
+gate behind manual dispatch or a weekly schedule and cache the built tree.
+
+### Guardrails
+
+- Pin simulator versions; record them in the workflow.
+- Make the delivery thresholds **loose** (catch "delivers nothing" regressions,
+  not performance noise — that's items 07/08's job).
+- Keep these jobs off the per-push path (runtime); per-push stays `make test` +
+  patch self-test.
+
+## D2 — Fuzzing + property tests
+
+### Codec fuzzing
+
+Use the `fuzz_codec.cpp` target from item 12; add a short (≤60 s) libFuzzer run in
+CI on PRs that touch `core/src/ant_message_codec.cpp` or the adapter headers.
+Keep a small seed corpus (a few serialized valid ants) in
+`core/tests/fuzz_corpus/`.
+
+### Property / invariant tests
+
+Add `core/tests/test_properties.cpp` asserting invariants over randomized inputs
+(seeded `ScriptedRng`/generator):
+
+- **Selection is a valid distribution:** for any non-empty pheromone table, the
+  per-neighbour selection probabilities are ≥ 0 and the chosen hop always has
+  pheromone > `minPheromone` (or is the only option).
+- **Evaporation is monotonic non-increasing** for an un-reinforced link and
+  converges below `minPheromone` (prune) in bounded steps.
+- **Reinforce is a contraction toward the update:** `reinforce(v,u)` lies between
+  `min(v,u)` and `max(v,u)` for `γ∈[0,1]`.
+- **Codec round-trip:** `deserialize(serialize(m)) == m` for randomized valid
+  `m` (extends the existing single-case `test_codec.cpp`).
+- **Dedup bound:** `AntHistoryTracker` never exceeds `maxHistory` entries and
+  evicts FIFO.
+
+These are cheap, simulator-free, and run on every push with `make test`.
+
+## Files to touch
+
+- `.github/workflows/ci.yml` (codec fuzz job; property tests run via `make test`)
+- `.github/workflows/e2e.yml` (new; manual + scheduled NS-2/NS-3 smoke)
+- `core/tests/test_properties.cpp` + `core/tests/CMakeLists.txt`
+- `core/tests/fuzz_corpus/` (seed inputs)
+
+## Acceptance criteria
+
+1. `make test` now includes property tests and stays green.
+2. A manual-dispatch `e2e` workflow builds a pinned NS-3, runs
+   `anthocnet-example`, and **fails** if PDR is ~0 in a connected scenario.
+3. An NS-2 smoke job builds the patched ns-2.35 and asserts non-zero CBR delivery
+   on `1-simple.tcl`.
+4. The codec fuzz job runs on codec-touching PRs without crashes.
+5. `CONTEXT.md §7/§8` updated to reflect that an e2e smoke now exists (with its
+   cadence/limitations).
+
+## Risks / notes
+
+- ns-2/ns-3 builds are heavy and flaky in CI; cache aggressively, pin versions,
+  and keep them off the blocking per-push path.
+- Don't turn smoke thresholds into performance gates — noise will cause false
+  failures; performance lives in items 07/08 (manual, multi-seed).

--- a/docs/improvements/14-reproducibility-and-release.md
+++ b/docs/improvements/14-reproducibility-and-release.md
@@ -1,0 +1,115 @@
+# 14 — Reproducibility (Docker), citeability (CITATION/releases/DOI), version matrix
+
+- **Covers:** E1 (Docker repro), E2 (CITATION + releases + DOI), E3 (ns-3 version
+  matrix)
+- **Priority:** P2
+- **Effort:** M
+- **Layer:** packaging / CI / docs
+- **Depends on:** complements 07/08 (benchmarks) and 09 (positioning)
+
+## Summary
+
+The project is research software whose audience is people writing papers and
+comparing protocols. Three packaging gaps make it harder to *use* and *cite* than
+it should be: there is no one-command way to reproduce the benchmark environment,
+no machine-readable citation/release metadata, and the "ns-3.36+" support claim
+isn't verified across versions. These are cheap and high-leverage for adoption.
+
+## E1 — Dockerized reproduction environment
+
+### Problem
+
+Running the benchmarks (items 07/08) requires the user to install a specific
+ns-3, enable the right modules, install the AntHocNet module, and build —
+documented, but many steps and version-sensitive. Reviewers usually won't.
+
+### Required change
+
+Add a `docker/` setup that pins everything:
+- A `Dockerfile` based on a known-good toolchain that:
+  - fetches a **pinned** ns-3 tag,
+  - `make install-ns3 NS3DIR=...`,
+  - configures with the benchmark module set,
+  - builds.
+- A `docker/run-benchmarks.sh` that runs `anthocnet-compare`/`run-comparison.sh`
+  and writes the CSV to a mounted volume.
+- (Optional) a separate image for the pinned ns-2.35 + patch.
+
+Document a one-liner in the README:
+```bash
+docker build -t anthocnet-bench -f docker/Dockerfile .
+docker run --rm -v "$PWD/out:/out" anthocnet-bench run-benchmarks.sh
+```
+
+### Acceptance
+
+- `docker build` + `docker run` reproduces a `docs/benchmarks.md`-style CSV on a
+  clean machine with no host ns-3.
+
+## E2 — Citeability: CITATION.cff, tagged releases, DOI
+
+### Problem
+
+No `CITATION.cff`, no tagged releases, no DOI. Academic users can't cite the
+software cleanly, and there's no stable "this is the version I used" reference for
+reproducibility.
+
+### Required change
+
+1. Add `CITATION.cff` (GitHub renders a "Cite this repository" button) with
+   author (Daniel Henrique Joppi), title, the AntHocNet paper references
+   ([1]–[3] in `docs/improvements/README.md`), license, and repo URL.
+2. Adopt **semantic version tags** (e.g. `v0.1.0` for the current refactored
+   baseline) and cut a GitHub Release with notes summarizing the
+   core-+-adapters architecture and the fixes vs the legacy module.
+3. (Optional) Connect the repo to **Zenodo** so each release mints a DOI; add the
+   DOI badge to the README.
+
+### Acceptance
+
+- "Cite this repository" appears on GitHub; a `v0.x.0` release exists; (optional)
+  a Zenodo DOI badge resolves.
+
+## E3 — ns-3 version compatibility matrix
+
+### Problem
+
+`README`/`porting-notes` claim ns-3.36+ (CMake) with a `wscript` for older waf
+builds, but nothing verifies the module actually builds across those versions;
+ns-3 changes its module/build API between releases.
+
+### Required change
+
+- Pick a small set of pinned ns-3 versions to support (e.g. `3.36`, the latest
+  LTS, and `ns-3-dev` as best-effort) and **build the module against each** in a
+  manual-dispatch CI matrix (reuse the e2e workflow from item 13).
+- Record the verified versions in a small table in `ns3/README.md` (and note
+  known breakages), instead of an unbacked "3.36+".
+
+### Acceptance
+
+- A CI matrix builds the NS-3 module against the listed versions; `ns3/README.md`
+  shows the verified-versions table; unsupported versions are stated, not implied.
+
+## Files to touch
+
+- `docker/Dockerfile`, `docker/run-benchmarks.sh` (new)
+- `CITATION.cff` (new, repo root)
+- `ns3/README.md` (version matrix table)
+- `.github/workflows/e2e.yml` (version matrix build; from item 13)
+- `README.md` (Docker one-liner; DOI/cite badges)
+
+## Acceptance criteria (summary)
+
+1. One-command Docker reproduction of the benchmark CSV.
+2. `CITATION.cff` + at least one tagged release (+ optional DOI badge).
+3. CI builds the NS-3 module across the declared supported versions; the matrix
+   is documented.
+
+## Risks / notes
+
+- Pin **everything** (ns-3 tag, base image, compiler) or the "reproducible"
+  environment will drift.
+- Keep the heavy matrix/e2e on manual or scheduled triggers (shared with item 13)
+  — not the per-push path.
+- Version support is a maintenance commitment; list only what CI actually checks.

--- a/docs/improvements/15-observability-and-traces.md
+++ b/docs/improvements/15-observability-and-traces.md
@@ -1,0 +1,100 @@
+# 15 — Observability: trace sources, counters, and routing-table dumps
+
+- **Covers:** F1
+- **Priority:** P2 (enables item 08's NRL/overhead metric and debugging)
+- **Effort:** S–M
+- **Layer:** `core/` (counters/callbacks via a port) + adapters (expose as traces)
+- **Depends on:** feeds 08 (overhead/NRL); pairs with 13 (smoke assertions)
+
+## Summary
+
+There is almost no built-in observability: the only introspection is NS-3's
+`PrintRoutingTable`. To compute routing overhead/NRL (item 08), to assert
+behaviour in smoke tests (item 13), and to debug, the protocol needs counters and
+trace hooks for ant traffic, pheromone changes, and route events — exposed the
+idiomatic way in each simulator (ns-3 `TracedCallback`/`TracedValue`, ns-2 trace
+lines).
+
+## Current state
+
+```416:431:ns3/model/anthocnet-routing-protocol.cc
+void RoutingProtocol::PrintRoutingTable(Ptr<OutputStreamWrapper> stream, Time::Unit) const {
+    ...
+    for (NodeAddress dest : table.regularDestinations()) {
+        *os << "  dest " << ToIpv4(dest) << " neighbours:";
+        ...
+```
+
+That's the extent of it — no ant counters, no pheromone-change trace, no route
+add/remove events, and the NS-2 `log-target`/`tracetarget` plumbing exists but is
+unused.
+
+## Required change
+
+### 1. Core: counters + an observer port (simulator-agnostic)
+
+Keep the core pure: add lightweight counters and an **optional** observer
+interface so the core reports events without doing I/O.
+
+```cpp
+// ports.h
+struct IRouterObserver {
+    virtual ~IRouterObserver() = default;
+    virtual void onAntSent(AntType type, AntDirection dir, bool broadcast) {}
+    virtual void onAntReceived(AntType type, AntDirection dir) {}
+    virtual void onPheromoneChanged(NodeAddress dest, NodeAddress nb, double v) {}
+    virtual void onRouteChanged(NodeAddress dest, NodeAddress nb, bool added) {}
+};
+```
+
+`AntRouterLogic` takes an optional `IRouterObserver*` (default null → zero cost)
+and fires events at the natural points (`onReceiveAnt`, `updateRegular`,
+neighbour add/remove). Also keep plain integer counters
+(`antsSent[type]`, `antsReceived[type]`, `controlBytes`) queryable for tests.
+
+### 2. NS-3: expose as `TracedCallback`/`TracedValue`
+
+Implement an observer that forwards to ns-3 trace sources registered in
+`GetTypeId` (`Tx`/`Rx` ant traces, `PheromoneChanged`, `RouteChanged`). This lets
+`anthocnet-compare` (item 08) count control packets/bytes directly from the
+protocol rather than only via the L3 Tx trace, and lets users `Config::Connect`
+to them.
+
+### 3. NS-2: emit trace lines
+
+Wire the already-present `logtarget_`/`tracetarget` to emit ant send/recv and
+route-change trace lines in the standard ns-2 trace format, so the awk-based PDR/
+overhead post-processors (items 07/08, `docs/cross-validation.md`) can read them.
+
+### 4. Routing-table dump parity
+
+Add an NS-2 equivalent of `PrintRoutingTable` (dump pheromone table on a tcl
+command) so both simulators can snapshot state.
+
+## Files to touch
+
+- `core/include/anthocnet/core/ports.h` (`IRouterObserver`)
+- `core/include/.../ant_router_logic.{h}` + `.cpp` (optional observer, counters,
+  event points)
+- `ns3/model/anthocnet-routing-protocol.{h,cc}` (trace sources + observer impl)
+- `ns2/src/ahn_router.{h,cc}` (trace-line emission, table dump command)
+- `core/tests/` (assert counters increment on the expected events)
+
+## Acceptance criteria
+
+1. Core exposes ant/route counters; a unit test asserts e.g. one reactive ant
+   broadcast increments `antsSent[Reactive]` and fires `onAntSent`.
+2. NS-3 registers `Tx`/`Rx`/`PheromoneChanged`/`RouteChanged` trace sources that a
+   test/example can `Config::Connect` to.
+3. `anthocnet-compare` (item 08) can derive control-packet/byte counts from the
+   protocol's own counters, cross-checked against the L3 Tx trace.
+4. NS-2 emits ant/route trace lines consumable by the benchmark post-processor.
+5. Observer is optional and zero-overhead when unset; `make test` green.
+
+## Risks / notes
+
+- Keep the observer **optional and allocation-free on the hot path** (null check;
+  no per-packet heap). The core must stay pure — the observer only *reports*, it
+  never makes routing decisions or does I/O.
+- Don't let trace emission change behaviour or timing (especially under the
+  deterministic test harness).

--- a/docs/improvements/16-pluggable-link-metric.md
+++ b/docs/improvements/16-pluggable-link-metric.md
@@ -1,0 +1,140 @@
+# 16 — Pluggable link-metric port (ILinkMetric)
+
+- **Covers:** G1
+- **Priority:** P3 (forward-looking; do after 01/02 land so the default metric is
+  correct first)
+- **Effort:** M
+- **Layer:** `core/`
+- **Depends on:** 01 (β), 02 (correct default metric), 10/A2 (MAC metric is the
+  first alternative implementation)
+
+## Summary
+
+How a backward ant turns a path observation into a pheromone value (Eq.2) is
+currently hard-coded in `advanceBackAnt`. The pure-core architecture makes this
+the natural seam for a **strategy port**: extract "compute pheromone from
+{hops, time, and adapter-supplied signals}" into an `ILinkMetric` interface. This
+turns the project's main weakness-vs-peers (Sawchord ships a fuzzy-logic metric;
+the literature has energy-/QoS-aware variants) into a strength: the *same* tested
+core can host the canonical metric **and** pluggable research metrics, selected by
+config, without touching the state machine.
+
+## Rationale / positioning
+
+- Sawchord's differentiator is a fuzzy inference metric; energy-aware and
+  QoS-aware AntHocNet variants are common in the literature. Today, reproducing
+  any of them here means editing core routing code.
+- With an `ILinkMetric` port, a fuzzy/energy/QoS metric becomes a drop-in
+  implementation behind the existing port pattern (`IClock`, `IRng`,
+  `INeighborProvider`, `ITimerScheduler`) — consistent with ADR-0003 (pure core)
+  and the hexagonal design.
+
+## Current behaviour
+
+The metric is inline in the back-ant advance:
+
+```92:108:core/src/ant_router_logic.cpp
+NodeAddress AntRouterLogic::advanceBackAnt(AntMessage& ant) const {
+    ...
+    const double simpleSINR = ant.prevSINR / 1000.0;
+    ant.pheromone = std::pow((ant.hops * config_.hopTimeMs + simpleSINR) / 2.0, -1.0);
+    ...
+```
+
+## Required change
+
+### 1. Define the port
+
+```cpp
+// ports.h
+struct LinkObservation {
+    int    hops;          // hops from this node to destination along the path
+    double pathTime;      // accumulated time estimate (seconds)  [item 02]
+    double hopTime;       // config T_hop (seconds)
+    // room to grow with NODE-LOCAL / PATH-AGGREGATE signals only — e.g. this
+    // node's energyRemaining, a local snr/queueOccupancy reading, or another
+    // path aggregate. NOT per-hop downstream vectors: the wire carries one
+    // scalar cost per hop (ADR-0009), and that invariant holds. A metric that
+    // genuinely needs per-hop downstream signals is a deliberate, ADR-gated wire
+    // extension, not a default.
+};
+
+struct ILinkMetric {
+    virtual ~ILinkMetric() = default;
+    // Map an observation to a pheromone (goodness; higher = better).
+    virtual double pheromone(const LinkObservation& obs) const = 0;
+};
+```
+
+### 2. Provide the canonical implementation as the default
+
+```cpp
+// the Eq.2 metric, post-item-02:
+struct ClassicMetric : ILinkMetric {
+    double pheromone(const LinkObservation& o) const override {
+        return std::pow((o.pathTime + o.hops * o.hopTime) / 2.0, -1.0);
+    }
+};
+```
+
+`AntRouterLogic` takes an `ILinkMetric&` (defaulting to a `ClassicMetric`
+instance) and calls it from `advanceBackAnt` instead of the inline formula.
+
+### 3. Wire selection through config/adapters
+
+Adapters pick the metric (NS-3 attribute `Metric={classic|...}`, NS-2 bind);
+the chosen `ILinkMetric` is injected at construction, exactly like `IClock`/`IRng`.
+
+**Two orthogonal seams (don't conflate them):**
+- **Per-hop cost measurement** (forward pass) — item 10/A2's `ILinkDelay` feeds a
+  measured MAC cost into the single per-hop scalar `AntHop.time`. MAC-awareness
+  lives here, and the default `ClassicMetric` already consumes it (it just sums
+  per-hop costs). The wire stays `{node, cost}` (ADR-0009).
+- **Pheromone metric** (backward pass) — *this* port. It combines path aggregates
+  (`pathTime`, `hops`) + node-local signals into a goodness value. A
+  `FuzzyMetric`/`EnergyMetric` that uses node-local/aggregate inputs can be added
+  later in `ns3/` without core changes.
+
+So "MAC-aware" is achieved by the measurement seam feeding the scalar, **not** by a
+special `ILinkMetric`; a custom metric is only needed when the *combining function*
+itself changes (fuzzy/energy/QoS), not merely the per-hop cost.
+
+### 4. Keep determinism + purity
+
+The metric must be pure (no I/O, no time/RNG reads except via what the
+observation carries). Adapter-supplied signals (energy, SNR, queue) enter through
+the `LinkObservation`, not by the metric calling the simulator.
+
+## Files to touch
+
+- `core/include/anthocnet/core/ports.h` (`ILinkMetric`, `LinkObservation`)
+- `core/include/anthocnet/core/link_metric.h` (+ `ClassicMetric`,
+  optional `MacAwareMetric`)
+- `core/include/.../ant_router_logic.{h}` + `.cpp` (inject + call the metric)
+- `ns3/model/anthocnet-routing-protocol.{h,cc}` (metric attribute + selection)
+- `ns2/src/ahn_router.{h,cc}` (metric bind + selection)
+- `core/tests/test_link_metric.cpp`
+
+## Acceptance criteria
+
+1. With the default `ClassicMetric`, behaviour is identical to the post-item-02
+   inline formula (regression: existing back-ant tests unchanged).
+2. Swapping in a stub metric (e.g. constant, or hops-only) changes pheromone
+   deposits as expected, proving the seam works, with **no** edit to
+   `AntRouterLogic` decision code.
+3. MAC-awareness (item 10/A2) is achieved via the **measurement** seam
+   (`ILinkDelay` feeding the per-hop scalar), with the default `ClassicMetric`
+   unchanged — *not* by a bespoke `ILinkMetric`. A custom metric is exercised only
+   for a changed combining function (e.g. a stub fuzzy/energy metric).
+4. `make test` green; core stays free of simulator/fuzzy-lib dependencies (any
+   such metric lives in an adapter).
+
+## Risks / notes
+
+- Don't build this before items 01/02 — extract the *correct* metric, not the
+  current buggy one, or you cement the wrong formula behind an interface.
+- Keep the default path allocation-free and inlinable (metric called once per
+  back-ant hop).
+- Scope guard: this is an extensibility enabler, not a new algorithm — ship the
+  port + `ClassicMetric` (+ optionally `MacAwareMetric`); leave fuzzy/energy
+  metrics as documented extension points unless explicitly requested.

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -80,6 +80,7 @@ For node `i`, destination `d`, neighbour `n`, pheromone `T_nd^i`:
 | Ant state machine, ant construction, back-ant advance | `core/src/ant_router_logic.cpp` |
 | Ant value type + fields | `core/include/anthocnet/core/ant_message.h` |
 | Wire codec (keep adapters in sync if fields change) | `core/src/ant_message_codec.cpp` |
+| Wire byte layout + version byte (ADR-0006) | `docs/wire-format.md` |
 | NS-3 timers / link I/O / sockets | `ns3/model/anthocnet-routing-protocol.cc` |
 | NS-2 timers / link-failure callback / queue | `ns2/src/ahn_router.cc` |
 | Unit tests | `core/tests/*.cpp` |
@@ -97,6 +98,13 @@ For node `i`, destination `d`, neighbour `n`, pheromone `T_nd^i`:
 | [07](07-validation-and-benchmarks.md) | Validation harness + paper-faithful benchmark scenario | — | **P2** | M |
 | [08](08-protocol-comparison-benchmarks.md) | Benchmark vs AODV/OLSR/DSDV/DSR (+ overhead/NRL, fairness) | — | **P2** | M |
 | [09](09-landscape-and-positioning.md) | Public-implementation landscape + project presentation fixes | — | **P2** | S |
+| [10](10-data-loops-multipath-and-mac-metric.md) | Data-loop suppression, multipath safety, reactive broadcast cap, MAC metric | A1/A2/A3 | **P1**/P2 | M |
+| [11](11-adapter-robustness.md) | NS-2 unbounded queue, NS-3 multi-iface, address-mapping bug | B1/B2/B3 | **P1**/P2 | M |
+| [12](12-codec-hardening-and-threat-model.md) | Enforce protocol bounds on untrusted decode + threat model | C1 | **P1** | S |
+| [13](13-ci-e2e-and-fuzzing.md) | CI end-to-end sim smoke + codec fuzzing + property tests | D1/D2 | P2 | M |
+| [14](14-reproducibility-and-release.md) | Docker repro + CITATION/releases/DOI + ns-3 version matrix | E1/E2/E3 | P2 | M |
+| [15](15-observability-and-traces.md) | Trace sources / counters (feeds item 08 NRL) | F1 | P2 | S–M |
+| [16](16-pluggable-link-metric.md) | Pluggable `ILinkMetric` port (fuzzy/energy/QoS extensibility) | G1 | P3 | M |
 
 Recommended sequence: **01 → 02** first (biggest correctness/performance levers
 and they unlock meaningful benchmarking), then **03 → 04 → 05**, then **06**,
@@ -104,6 +112,15 @@ with **07 + 08** run continuously to measure progress. 07 defines the benchmark
 **scenarios**; 08 defines the **protocol set + metrics + fairness** for the
 cross-protocol comparison. **09** is independent (presentation/positioning, not
 code) and high value-for-effort.
+
+Items **10–16** are a second wave found during deeper review. Highest-value among
+them: the **verified near-bugs** — `11` (NS-2 unbounded pending queue; NS-3
+`ToCore(255.255.255.255) == kInvalidAddress`) and `12` (codec doesn't enforce
+`maxPathLength`/`maxHistory` on untrusted input) — plus `10`/A1 (data-loop
+suppression). `13`–`15` harden testing/repro/observability; `16` is a
+forward-looking extensibility seam (do after 01/02). Grouping: **10** fidelity ·
+**11** adapter correctness · **12** security · **13** testing · **14** packaging ·
+**15** observability · **16** extensibility.
 
 ## Definition of done (per item)
 

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -1,0 +1,130 @@
+# AntHocNet — protocol-fidelity improvement specs
+
+> **Audience: an implementing agent (human or AI).** Each file in this folder is
+> a self-contained, implementable work item. They describe where the current
+> code deviates from the canonical AntHocNet specification, why it matters, and
+> exactly what to change, with acceptance criteria. Read this index first, then
+> implement the items in the order given (or pick one — each is independent
+> unless a dependency is noted).
+
+## How to use these docs
+
+1. Read this README for shared context (spec, code map, conventions, invariants).
+2. Open one numbered spec file. Each has the same sections:
+   - **Summary** — one paragraph.
+   - **Spec reference** — the exact AntHocNet behaviour + citation.
+   - **Current behaviour** — what the code does today, with `file:line` anchors.
+   - **Impact** — why the deviation matters.
+   - **Required change** — precise, step-by-step edits (with proposed code).
+   - **Files to touch.**
+   - **Acceptance criteria** — tests/observable behaviour that must hold.
+   - **Risks / notes.**
+3. Keep the architecture invariant intact (see below): algorithm changes go in
+   `core/`; adapters only translate and execute.
+4. After each item: `make test` must stay green, and add the test(s) named in
+   that item's acceptance criteria.
+
+## Architecture invariant (do not break)
+
+```
+core/   simulator-agnostic algorithm. No NS-2/NS-3 headers. Pure: returns
+        RouteDecisions, performs no I/O. Time & randomness come via ports
+        (IClock, IRng). THIS is where protocol logic lives.
+ns2/    thin Agent adapter + source patch. Translates header <-> AntMessage,
+        executes RouteDecisions, owns timers + link-failure callback.
+ns3/    native Ipv4RoutingProtocol module. Same responsibilities as ns2.
+```
+
+Rule of thumb: **if a change affects routing decisions, it belongs in `core/`
+and must be covered by a `core/tests/` unit test.** Adapters get changed only to
+feed the core new inputs (e.g. a periodic "tick", an active-session set) or to
+carry out a new `RouteAction`.
+
+## Canonical specification (the source of truth)
+
+All "Spec reference" sections cite these. Equation numbers refer to the journal
+version [1].
+
+- **[1]** G. Di Caro, F. Ducatelle, L. M. Gambardella. *AntHocNet: an adaptive
+  nature-inspired algorithm for routing in mobile ad hoc networks.* European
+  Transactions on Telecommunications, 16(5):443–455, 2005. (IDSIA-27-04)
+- **[2]** F. Ducatelle. *Adaptive Routing in Ad Hoc Wireless Multi-hop
+  Networks.* PhD thesis, 2007 (the most detailed description of diffusion +
+  link-failure handling).
+- **[3]** Di Caro, Ducatelle, Gambardella. *AntHocNet: an ant-based hybrid
+  routing algorithm for MANETs.* PPSN VIII, LNCS 3242, 2004. (IDSIA-25-04)
+
+### The three core equations
+
+For node `i`, destination `d`, neighbour `n`, pheromone `T_nd^i`:
+
+- **Eq.1 — stochastic next-hop probability**
+  `P_nd = (T_nd^i)^β / Σ_{j∈N_d^i} (T_nd^j)^β`, with `β ≥ 1`.
+  Two exponents are used: **β1** for ants, **β2 ≥ β1** (larger, greedier) for
+  data. See `01-data-vs-ant-beta.md`.
+- **Eq.2 — pheromone a backward ant deposits at node i**
+  `τ_d^i = ( (T̂_d^i + h·T_hop) / 2 )^{-1}`, where `T̂_d^i` is the estimated
+  time to reach `d` from `i` along the path, `h` is the hop count from `i` to
+  `d`, and `T_hop` is a fixed per-hop time in unloaded conditions. See
+  `02-backward-ant-delay-metric.md`.
+- **Eq.3 — pheromone update (bootstrapped average)**
+  `T_nd^i = γ·T_nd^i + (1−γ)·τ_d^i`, `γ ∈ [0,1]`. Paper uses `γ = α = 0.7`.
+
+## Code map (where things live today)
+
+| Concern | File |
+|---|---|
+| Tunables (`alpha`/`beta`/`gamma`/intervals/...) | `core/include/anthocnet/core/config.h` |
+| Pheromone math (evaporate/reinforce/update) | `core/src/pheromone_engine.cpp` |
+| Stochastic next-hop selection (Eq.1) | `core/src/pheromone_table.cpp` |
+| Ant state machine, ant construction, back-ant advance | `core/src/ant_router_logic.cpp` |
+| Ant value type + fields | `core/include/anthocnet/core/ant_message.h` |
+| Wire codec (keep adapters in sync if fields change) | `core/src/ant_message_codec.cpp` |
+| NS-3 timers / link I/O / sockets | `ns3/model/anthocnet-routing-protocol.cc` |
+| NS-2 timers / link-failure callback / queue | `ns2/src/ahn_router.cc` |
+| Unit tests | `core/tests/*.cpp` |
+
+## Work items (priority order)
+
+| # | Item | Deviation | Priority | Est. effort |
+|---|------|-----------|----------|-------------|
+| [01](01-data-vs-ant-beta.md) | Wire `beta`; use β2 > β1 for data vs ants | D1 | **P0** | S |
+| [02](02-backward-ant-delay-metric.md) | Fix back-ant delay metric (units + per-hop) | D2 | **P0** | M |
+| [03](03-pheromone-diffusion.md) | Real diffused/bootstrapped pheromone in hellos | D3 | **P1** | M |
+| [04](04-proactive-ant-sessions.md) | Proactive ants for active sessions + broadcast prob | D4 | **P1** | M |
+| [05](05-link-failure-detection-and-repair.md) | Hello-timeout detection, failure notification, repair bounding | D5/D6 | **P1** | L |
+| [06](06-evaporation-and-minor.md) | Time-based evaporation + minor deviations | D7 | **P2** | S |
+| [07](07-validation-and-benchmarks.md) | Validation harness + paper-faithful benchmark scenario | — | **P2** | M |
+| [08](08-protocol-comparison-benchmarks.md) | Benchmark vs AODV/OLSR/DSDV/DSR (+ overhead/NRL, fairness) | — | **P2** | M |
+| [09](09-landscape-and-positioning.md) | Public-implementation landscape + project presentation fixes | — | **P2** | S |
+
+Recommended sequence: **01 → 02** first (biggest correctness/performance levers
+and they unlock meaningful benchmarking), then **03 → 04 → 05**, then **06**,
+with **07 + 08** run continuously to measure progress. 07 defines the benchmark
+**scenarios**; 08 defines the **protocol set + metrics + fairness** for the
+cross-protocol comparison. **09** is independent (presentation/positioning, not
+code) and high value-for-effort.
+
+## Definition of done (per item)
+
+- Change lives in the correct layer (core vs adapter) per the invariant.
+- `make test` is green; new unit test(s) from the item's acceptance criteria are
+  added under `core/tests/` and registered in `core/tests/CMakeLists.txt`.
+- Both adapters still compile (NS-2 patch self-test `bash ns2/patch/selftest.sh`;
+  NS-3 builds) — and if a wire field changed, both the NS-2 header
+  (`ns2/src/ant_packet_ns2.*`) and NS-3 header (`ns3/model/anthocnet-packet.cc`)
+  and `core/src/ant_message_codec.cpp` are updated together and the codec
+  round-trip test (`core/tests/test_codec.cpp`) still passes.
+- New tunables are exposed as NS-2 TCL binds and NS-3 `TypeId` attributes.
+- `docs/porting-notes.md` / `CONTEXT.md` updated if behaviour or wire format
+  changed.
+
+## Conventions for the implementer
+
+- C++14. Match existing style (2-space indent, `lowerCamelCase` members with
+  trailing `_`, `namespace anthocnet::core`).
+- Do not add narrating comments; comment only non-obvious intent.
+- Prefer extending `Config` over new magic constants.
+- Any new `AntMessage` field must be added to **all three** of: the struct,
+  the codec, and both adapter headers — and to `test_codec.cpp`.
+- Keep `RouteDecision` as the only output channel from the core.

--- a/docs/porting-notes.md
+++ b/docs/porting-notes.md
@@ -67,11 +67,17 @@ synthetic tree: apply is idempotent and revert restores byte-for-byte.
 
 ## Wire format
 
-`core/include/anthocnet/core/ant_message_codec.h` defines the canonical
-little-endian layout. The NS-2 header (`ant_packet_ns2`) and the NS-3 header
-(`AntHeader`) follow the same field order. The NS-3 header serializes directly
-against `Buffer::Iterator`; the NS-2 header is a fixed-capacity POD whose
-`wireSize()` reports the same byte count the codec would emit.
+The byte-level layout, the version byte, and the field-by-field diff against the
+original implementation and the protocol papers live in
+[`wire-format.md`](wire-format.md) (the single source of truth).
+
+In short: `core/include/anthocnet/core/ant_message_codec.h` defines the canonical
+little-endian layout, prefixed by a 1-byte `kWireVersion`
+([ADR-0006](adr/0006-on-wire-protocol-version.md)). The NS-2 header
+(`ant_packet_ns2`) and the NS-3 header (`AntHeader`) follow the same field order.
+The NS-3 header serializes directly against `Buffer::Iterator`; the NS-2 header
+is a fixed-capacity POD whose `wireSize()` reports the same byte count the codec
+would emit. **Any field or semantic change bumps `kWireVersion`.**
 
 ## Version caveats
 

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -1,0 +1,175 @@
+# Wire format
+
+Canonical, simulator-agnostic on-wire layout of an ant packet. This is the
+single source of truth referenced by [`AGENTS.md`](../AGENTS.md) golden rule #4
+and by [`docs/porting-notes.md`](porting-notes.md). The encoder/decoder lives in
+`core/src/ant_message_codec.cpp`; the NS-2 header (`ns2/src/ant_packet_ns2`) and
+the NS-3 `AntHeader` (`ns3/model/anthocnet-packet`) both delegate to it, so a
+byte produced on one simulator is interpreted identically on the other.
+
+All multi-byte integers and `double`s are **little-endian**. Variable arrays are
+**length-prefixed** with a `uint16` count. There is exactly one layout — see
+[ADR-0006](adr/0006-on-wire-protocol-version.md) for why we version it and why
+we do *not* negotiate alternative layouts.
+
+> **Status.** The table below is the layout **the codec emits today**. Three
+> decided changes are not yet implemented and are listed under
+> [planned evolution](#planned-wire-evolution): the offset-0 version byte
+> ([item 12](improvements/12-codec-hardening-and-threat-model.md), ADR-0006), the
+> backward-ant slim + per-hop-delta time
+> ([item 02](improvements/02-backward-ant-delay-metric.md), ADR-0009), and the
+> repair/link-failure additions ([item 05](improvements/05-link-failure-detection-and-repair.md)).
+> Keep this section in sync with the code as each lands.
+
+## Frame layout (current code)
+
+| Offset | Field | Type | Bytes | Meaning |
+|-------:|-------|------|------:|---------|
+| 0  | `type`      | `u8`     | 1 | Ant role (`AntType`): `0x01` Hello, `0x02` Reactive, `0x04` Proactive, `0x08` Repair. |
+| 1  | `direction` | `u8`     | 1 | `AntDirection`: `0x11` Up (forward), `0x12` Down (backward). |
+| 2  | `src`       | `i32`    | 4 | Originating node. |
+| 6  | `dst`       | `i32`    | 4 | Final destination. |
+| 10 | `seqNum`    | `u32`    | 4 | Per-source ant sequence number (32-bit; see [vs. original](#vs-the-original-implementation)). |
+| 14 | `timeStart` | `f64`    | 8 | Generation time, for trip-time accounting. |
+| 22 | `lifeAnt`   | `f64`    | 8 | Repair-ant lifetime budget (seconds). |
+| 30 | `prevHop`   | `i32`    | 4 | Previous hop (set while a backward ant retraces). *Slated for removal — item 02.* |
+| 34 | `hops`      | `i32`    | 4 | Hop count accumulated so far. *Slated for removal — item 02.* |
+| 38 | `prevSINR`  | `f64`    | 8 | Accumulated time/cost term (misnamed; **removed**, not renamed, by [item 02](improvements/02-backward-ant-delay-metric.md)). |
+| 46 | `pheromone` | `f64`    | 8 | Running pheromone estimate on the backward ant. *Slated for removal — item 02.* |
+| 54 | `nVisited`  | `u16`    | 2 | Count of `visited` entries. |
+| 56 | `visited[]` | `AntHop` | 12·n | Forward stack: `{ i32 node; f64 time }` per hop (`time` is **cumulative-since-source** today; → per-hop delta in item 02). |
+| …  | `nHistory`  | `u16`    | 2 | Count of `history` entries. |
+| …  | `history[]` | `AntHop` | 12·n | Back-ant stack being reinforced: `{ i32 node; f64 time }`. |
+| …  | `nHello`    | `u16`    | 2 | Count of `helloDests` entries. |
+| …  | `helloDests[]` | `HelloDest` | 12·n | Hello adverts: `{ i32 node; f64 pheromone }` (virtual-pheromone gossip). |
+
+Fixed prefix (`type` through `pheromone`) is **54 bytes**; the three empty arrays
+add 6 bytes of counts, so the minimum frame is **60 bytes**. Worst-case size is
+bounded because `nVisited`/`nHistory` are capped at `Config::maxPathLength` /
+`maxHistory` on decode (enforcement added by
+[item 12](improvements/12-codec-hardening-and-threat-model.md)).
+
+## Planned wire evolution
+
+These are **decided** (ADR-backed) but not yet in the codec. `kWireVersion` is a
+**monotonic counter**, not a fixed value — whichever wire change lands first
+introduces the constant; each subsequent change increments it. Do not hard-code a
+number; use `current + 1`.
+
+1. **Version byte** — [item 12](improvements/12-codec-hardening-and-threat-model.md),
+   [ADR-0006](adr/0006-on-wire-protocol-version.md). Prepend `version : u8` at
+   **offset 0** (shifting every field +1). `deserialize` checks it first and
+   drops unknown values in O(1).
+2. **Backward-ant slim + per-hop-delta time** —
+   [item 02](improvements/02-backward-ant-delay-metric.md),
+   [ADR-0009](adr/0009-backward-ants-carry-path-not-state.md). **Remove**
+   `prevHop`, `hops`, `prevSINR`, `pheromone` from the serialized image (they are
+   recomputed locally; verified that neither adapter consumes them), and redefine
+   `AntHop.time` as a **per-hop delta** (seconds). −24 fixed bytes.
+3. **Repair / link-failure** —
+   [item 05](improvements/05-link-failure-detection-and-repair.md). Add
+   `broadcastBudget` and the `AntType::LinkFail` role (the notification reuses the
+   `helloDests` `{node, pheromone}` shape).
+
+### Target layout after items 12 + 02
+
+| Offset | Field | Type | Bytes |
+|-------:|-------|------|------:|
+| 0  | `version`   | `u8`  | 1 |
+| 1  | `type`      | `u8`  | 1 |
+| 2  | `direction` | `u8`  | 1 |
+| 3  | `src`       | `i32` | 4 |
+| 7  | `dst`       | `i32` | 4 |
+| 11 | `seqNum`    | `u32` | 4 |
+| 15 | `timeStart` | `f64` | 8 |
+| 23 | `lifeAnt`   | `f64` | 8 |
+| 31 | `nVisited`  | `u16` | 2 |
+| 33 | `visited[]` | `AntHop` (`{i32 node; f64 delta}`) | 12·n |
+| …  | `nHistory` + `history[]` | … | 2 + 12·n |
+| …  | `nHello` + `helloDests[]` | … | 2 + 12·n |
+
+Fixed prefix shrinks to **31 bytes**; minimum frame **37 bytes** (was 60). The
+backward ant adds nothing beyond the path it inherited.
+
+## Versioning
+
+- **Offset 0 is a `u8` version constant** (`kWireVersion`), once item 12 lands.
+- `deserialize` checks it **first** and returns `false` on any unknown value —
+  before reading any length field — so foreign, corrupt, or stale-version frames
+  are rejected in O(1) at the trust boundary.
+- The constant is defined once in the codec and asserted identical by the NS-2
+  and NS-3 headers and the round-trip test. **Any change to field order,
+  width, units, or semantics bumps `kWireVersion`** (see the maintenance rule in
+  [ADR-0006](adr/0006-on-wire-protocol-version.md)).
+- We do **not** negotiate or translate between versions. A mismatched version is
+  a dropped packet, not a fallback — within a single simulation every node runs
+  the same build, and across builds we *want* cross-version traces to fail loudly
+  rather than silently misparse. This is the deliberate trade-off recorded in the
+  ADR.
+
+This makes the "one canonical wire format" invariant machine-checkable: the
+field layout and its version move together, in lockstep, across the codec and
+both adapters.
+
+## vs. the original implementation
+
+The original NS-2 module (vendored inside `ns-allinone-2.34`) had **no codec and
+no portable wire format at all** — the ant lived as a C++ object whose
+`visited`/`history`/hello lists were `AntTimeEntry**` heap arrays referenced
+directly from the NS-2 packet header. That carried three defects (see
+[ADR-0004](adr/0004-pod-ant-messages-and-codec.md) and
+[porting-notes](porting-notes.md)):
+
+| Aspect | Original | This implementation |
+|--------|----------|---------------------|
+| Path / history / hello storage | Header-resident `AntTimeEntry**` heap pointers | Length-prefixed value arrays in a byte buffer |
+| Broadcast semantics | Byte-copying the header duplicated a raw pointer → **double-free** | POD copy is safe; ants are trivially copyable |
+| Serialized size | `size()` returned `sizeof(pointer)` → **wrong airtime/MAC modelling** | `serializedSize()` returns the true byte count |
+| `seqNum` width | `u_int8_t` → wrapped after 256 ants, aliasing `(src,seq)` dedup | `u32` |
+| Path / dedup growth | Unbounded | Capped by `Config::maxPathLength` / `maxHistory` (also enforced on decode) |
+| Endianness / portability | Native struct layout (compiler/arch dependent) | Explicit little-endian, compiler/arch independent |
+| Version marker | None | None today; 1-byte `version` at offset 0 *planned* (item 12, ADR-0006) |
+| Transient compute state on the wire | N/A (live object) | `prevHop`/`hops`/`prevSINR`/`pheromone` today; *being removed* (item 02, ADR-0009) so the wire carries only identity + path |
+
+So there is no "original wire format" to be byte-compatible *with*; this codec is
+the first portable format, and the planned version byte exists so the *next*
+change is detectable in a way the original never was.
+
+## vs. the protocol specification
+
+AntHocNet is defined by its papers ([1], [2], [3] in
+[improvements/README](improvements/README.md)), **not** by any byte-level wire
+standard. The papers specify the *contents and semantics* of ants, never an
+octet layout, so this format is one faithful encoding of the paper's fields —
+plus a few implementation-only fields. There is no newer or competing wire
+specification to track.
+
+| Wire field | Status vs. spec | Notes |
+|------------|-----------------|-------|
+| `type`, `direction` | **Spec concept** | Reactive/proactive forward ants, backward ants, hello messages, repair ants ([1] §3). |
+| `src`, `dst` | **Spec concept** | Session endpoints an ant is routing between. |
+| `visited`, `history` (node + time) | **Spec concept** | Forward ant records the path and per-hop timing; backward ant retraces it to deposit pheromone ([1] §3.1–3.2). |
+| `helloDests` (node + pheromone) | **Spec concept** | Pheromone diffusion: hellos advertise virtual-pheromone goodness for active destinations ([2], diffusion section). The value is real, not constant — see [item 03](improvements/03-pheromone-diffusion.md). |
+| `hops` | **Spec-aligned** | Hop count in the path metric. *Computed locally, removed from the wire by item 02 (ADR-0009).* |
+| `prevSINR` | **Implementation** | Accumulated time/cost term; misnamed (the spec's metric is delay/quality, not SINR). *Removed from the wire, not renamed, by [item 02](improvements/02-backward-ant-delay-metric.md).* |
+| `pheromone` | **Implementation** | Running estimate on the backward ant; the spec computes pheromone per node. *Removed from the wire by item 02 — each node recomputes.* |
+| `lifeAnt` | **Implementation** | Repair-ant TTL budget — a concrete realisation of the spec's bounded local repair. |
+| `timeStart`, `seqNum` | **Implementation** | Trip-time accounting and `(src,seq)` duplicate suppression. The spec assumes ant identification; these are the mechanisms. |
+| `prevHop` | **Implementation** | Retrace bookkeeping. *Computed locally, removed from the wire by item 02.* |
+| `version` | **Implementation** | Frame envelope; no spec analogue. *Planned, item 12.* |
+
+Where a field's behaviour deviates from the paper, the deviation is tracked in
+`docs/improvements/` (items 02, 03 in particular), not here — this document
+describes only the *bytes*.
+
+## Maintenance checklist
+
+When you change `AntMessage` fields, update **in the same field order** and bump
+`kWireVersion`:
+
+1. `core/include/anthocnet/core/ant_message.h` (the struct).
+2. `core/src/ant_message_codec.cpp` (serialize + deserialize + size constants).
+3. `ns2/src/ant_packet_ns2` (NS-2 POD header + `wireSize()`).
+4. `ns3/model/anthocnet-packet` (`AntHeader` Serialize/Deserialize/GetSerializedSize).
+5. `core/tests/test_codec.cpp` (round-trip + the version-mismatch rejection test).
+6. This table and the offsets above.


### PR DESCRIPTION
## Summary

A spec-grounded review of the AntHocNet core against the canonical papers
(Di Caro/Ducatelle/Gambardella) and other public implementations, turned into
two things downstream implementers can act on directly:

- **7 Architecture Decision Records (ADR-0006–0012)** capturing the design
  forks resolved in this pass, each grounded in the spec and the current code.
- **A 16-item implementation spec set** (`docs/improvements/`) — one
  self-contained file per work item with spec references, code anchors,
  required changes, acceptance tests, and risks — written to be handed to
  another agent for implementation.

No production/core code changes; this is design + documentation only.

## What's included

**ADRs (`docs/adr/`)**
- `0006` — 1-byte on-wire protocol version (detectable wire changes).
- `0007` — keep-but-gate proactive exploration + pheromone diffusion
  (`enableProactive`/`enableDiffusion`); fixes the `nextNeighborNode` reach guard.
- `0008` — neighbour liveness via two detectors (hello-timeout primary,
  MAC tx-failure fast-path); `INeighborProvider` is advisory.
- `0009` — backward ants carry the path observation, not working state
  (slims the wire; per-hop delta time; bumps `kWireVersion`).
- `0010` — data forwarding is prev-hop-excluded stochastic; per-flow
  stickiness is config-gated, default off.
- `0011` — `NodeAddress` is the node's primary-interface IP; broadcast is a
  `RouteAction`, never an address (fixes the NS-3 `255.255.255.255` →
  `kInvalidAddress` collision).
- `0012` — evaporation is a secondary, time-proportional safety net
  (the spec has no evaporation term — adaptation is the running average +
  explicit link-failure removal); single-sourced aging, gated default-on.

**Implementation specs (`docs/improvements/01–16` + `README.md` index)**
covering: data-vs-ant β split, backward-ant delay metric, pheromone diffusion,
proactive ants, link-failure detection/notification/repair, time-based
evaporation + minor fixes, validation & benchmarks, protocol-comparison matrix,
landscape/positioning, data-loop/multipath/MAC-metric, adapter robustness,
codec hardening + threat model, CI e2e + fuzzing, reproducibility & release,
observability/traces, and a pluggable `ILinkMetric` port.

**New reference doc**
- `docs/wire-format.md` — canonical, versioned `AntMessage` wire layout, with
  the deltas vs. the original implementation.

**Updated guides**
- `AGENTS.md` — golden rule #4 now covers wire versioning + `kWireVersion`;
  "where to look" table refreshed.
- `CONTEXT.md` — glossary updated (virtual pheromone, diffusion, neighbour
  liveness, stochastic routing, `NodeAddress`, reinforcement vs evaporation).
- `README.md` / `docs/porting-notes.md` — link the new wire-format doc and the
  versioning decision.

## Latent bugs surfaced (documented, fixed by the linked items)

- NS-3 `ToCore` maps broadcast to `kInvalidAddress`, colliding with "no route"
  (item 11 / ADR-0011).
- NS-2 pending queue is unbounded and untimed → leak / stale delivery (item 11).
- `nextNeighborNode` guard blocks proactive ants from virtual-only destinations,
  defeating diffusion (item 03 / ADR-0007).
- Codec doesn't enforce `maxPathLength`/`maxHistory` bounds on decoded counts —
  robustness/DoS gap (item 12 / ADR-0006).
- Regular-pheromone evaporation is event-driven (traffic-coupled), a remnant of
  the original D2 bug coupling (item 06 / ADR-0012).

## Test plan

- [ ] Docs-only change — `make test` and `bash ns2/patch/selftest.sh` remain
      green (no code touched).
- [ ] ADR cross-links and `docs/improvements/README.md` index resolve.
- [ ] Spec citations in each item match the referenced paper sections.