### PR TITLE
Observability traces + ant-level benchmark diagnostics (items 15/08)

### DIFF
--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -1,0 +1,73 @@
+name: Paper benchmark (manual)
+
+# Heavy, manually-dispatched benchmark in AntHocNet's *intended* regime (the
+# paper's large/sparse/mobile scenario, 300 m range), with --diag so we can see
+# whether routes actually form. Not part of per-merge CI: the paper scenario is
+# expensive, and the dense-small smoke in ci.yml is the fast regression gate.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'ns-3 image tag'
+        default: '3.42'
+      nNodes:
+        description: 'Number of nodes'
+        default: '50'
+      time:
+        description: 'Sim time (s) — 900 is the full paper run; lower for speed'
+        default: '300'
+      runs:
+        description: 'RNG runs to average'
+        default: '3'
+      areaX:
+        description: 'Area long edge (m) — paper sweeps 1500..2500'
+        default: '1500'
+      pause:
+        description: 'Random-waypoint pause time (s) — paper sweeps 0..900'
+        default: '30'
+      protocols:
+        description: 'Comma-separated protocol list'
+        default: 'anthocnet,aodv,olsr,dsdv'
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  paper:
+    name: paper scenario + diagnostics
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/ns3:${{ github.event.inputs.version }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install AntHocNet module
+        run: make install-ns3 NS3DIR=/opt/ns-3
+      - name: Configure
+        run: |
+          cd /opt/ns-3
+          ./ns3 configure --enable-examples \
+            --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+      - name: Build
+        run: cd /opt/ns-3 && ./ns3 build
+      - name: Run paper scenario (with diagnostics)
+        run: |
+          cd /opt/ns-3
+          args="--scenario=paper --diag \
+            --protocols=${{ github.event.inputs.protocols }} \
+            --runs=${{ github.event.inputs.runs }} \
+            --nNodes=${{ github.event.inputs.nNodes }} \
+            --time=${{ github.event.inputs.time }} \
+            --areaX=${{ github.event.inputs.areaX }} \
+            --pause=${{ github.event.inputs.pause }}"
+          echo "anthocnet-compare $args"
+          ./ns3 run "anthocnet-compare $args" 2>/dev/null \
+            | tee "$GITHUB_WORKSPACE/paper-results.txt"
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper-benchmark
+          path: paper-results.txt

--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -42,6 +42,17 @@ public:
     const PheromoneTable& table() const { return table_; }
     PheromoneEngine& engine() { return engine_; }
 
+    // --- observability (item 15) -----------------------------------------
+    /// Attach an optional observer for ant/route events (nullptr to detach).
+    /// Zero-overhead when unset; the observer only reports, never decides.
+    void setObserver(IRouterObserver* observer) { observer_ = observer; }
+    /// Ants of `type` this node has put on the medium (origination + forward).
+    std::uint64_t antsSent(AntType type) const;
+    /// Non-duplicate ants of `type` this node has received and processed.
+    std::uint64_t antsReceived(AntType type) const;
+    /// Total ant control packets sent across all types (routing overhead).
+    std::uint64_t controlPacketsSent() const;
+
     // --- neighbour learning ----------------------------------------------
     /// Record that `neighbor` is reachable (link-layer detection / hello),
     /// seeding an equal-weight regular pheromone entry as the legacy code did.
@@ -125,7 +136,10 @@ private:
     /// Turn a forward/notification ant into a Broadcast decision, honouring its
     /// broadcastBudget: an untracked ant (-1) always broadcasts; a budgeted ant
     /// decrements and broadcasts while >0, and is Dropped once exhausted.
-    RouteDecision broadcastForward(AntMessage& ant) const;
+    RouteDecision broadcastForward(AntMessage& ant);
+    /// Build a Unicast/Broadcast decision carrying `ant`, counting it as sent
+    /// and notifying the observer (the single choke point for ant emission).
+    RouteDecision sendAnt(RouteAction action, NodeAddress nextHop, const AntMessage& ant);
     /// Apply a received LinkFail notification and, if it costs this node its own
     /// best path, return a bounded propagated notification.
     std::vector<RouteDecision> handleLinkFail(const AntMessage& note, NodeAddress reporter);
@@ -148,6 +162,10 @@ private:
     std::map<NodeAddress, double> lastSeen_;        ///< neighbor -> last reception time
     std::map<NodeAddress, double> lastReactive_;    ///< dest -> last reactive-ant time
     double lastEvaporation_ = 0.0;                  ///< last evaporateAll time
+
+    IRouterObserver* observer_ = nullptr;           ///< optional, item 15
+    std::map<AntType, std::uint64_t> antsSent_;     ///< sent counters by type
+    std::map<AntType, std::uint64_t> antsReceived_; ///< received counters by type
 };
 
 } // namespace core

--- a/core/include/anthocnet/core/ports.h
+++ b/core/include/anthocnet/core/ports.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <vector>
 
+#include "anthocnet/core/ant_message.h"
 #include "anthocnet/core/types.h"
 
 namespace anthocnet {
@@ -47,6 +48,22 @@ class ITimerScheduler {
 public:
     virtual ~ITimerScheduler() = default;
     virtual void schedule(Time delay, std::function<void()> callback) = 0;
+};
+
+/// Optional observer the core notifies of routing events (item 15). It only
+/// *reports* — it never makes routing decisions or does I/O, so the core stays
+/// pure. Adapters implement it to fan events out to their native trace
+/// machinery (ns-3 TracedCallback, ns-2 trace lines). All methods default to
+/// no-ops; when no observer is set the core pays only a null-pointer check.
+class IRouterObserver {
+public:
+    virtual ~IRouterObserver() = default;
+    /// This node put an ant on the medium (origination or forwarding).
+    virtual void onAntSent(AntType /*type*/, AntDirection /*dir*/, bool /*broadcast*/) {}
+    /// This node processed a (non-duplicate) received ant.
+    virtual void onAntReceived(AntType /*type*/, AntDirection /*dir*/) {}
+    /// A neighbour/route entry was added (true) or removed (false).
+    virtual void onRouteChanged(NodeAddress /*dest*/, NodeAddress /*nb*/, bool /*added*/) {}
 };
 
 } // namespace core

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -19,15 +19,19 @@ AntRouterLogic::AntRouterLogic(NodeAddress address, const Config& config, IClock
 
 void AntRouterLogic::learnNeighbor(NodeAddress neighbor) {
     if (neighbor == address_ || neighbor == kInvalidAddress) return;
+    const bool isNew = lastSeen_.find(neighbor) == lastSeen_.end();
     table_.addNeighbor(neighbor);
     // Seed an equal-weight regular entry, as the legacy recvAHN did.
     engine_.updateRegular(table_, neighbor, neighbor, 1.0);
     lastSeen_[neighbor] = clock_.now();  // liveness: any reception refreshes it
+    if (isNew && observer_) observer_->onRouteChanged(neighbor, neighbor, true);
 }
 
 void AntRouterLogic::loseNeighbor(NodeAddress neighbor) {
+    const bool had = lastSeen_.find(neighbor) != lastSeen_.end();
     engine_.cleanNeighbor(table_, neighbor);
     lastSeen_.erase(neighbor);
+    if (had && observer_) observer_->onRouteChanged(neighbor, neighbor, false);
 }
 
 std::vector<RouteDecision> AntRouterLogic::onMaintenanceTick() {
@@ -54,10 +58,35 @@ std::vector<RouteDecision> AntRouterLogic::onMaintenanceTick() {
     return out;
 }
 
-RouteDecision AntRouterLogic::broadcastForward(AntMessage& ant) const {
+RouteDecision AntRouterLogic::broadcastForward(AntMessage& ant) {
     if (ant.broadcastBudget == 0) return RouteDecision::drop();  // budget exhausted
     if (ant.broadcastBudget > 0) ant.broadcastBudget -= 1;       // -1 == untracked
-    return {RouteAction::Broadcast, kInvalidAddress, true, ant};
+    return sendAnt(RouteAction::Broadcast, kInvalidAddress, ant);
+}
+
+RouteDecision AntRouterLogic::sendAnt(RouteAction action, NodeAddress nextHop,
+                                      const AntMessage& ant) {
+    antsSent_[ant.type] += 1;
+    if (observer_) {
+        observer_->onAntSent(ant.type, ant.direction, action == RouteAction::Broadcast);
+    }
+    return {action, nextHop, true, ant};
+}
+
+std::uint64_t AntRouterLogic::antsSent(AntType type) const {
+    auto it = antsSent_.find(type);
+    return it == antsSent_.end() ? 0 : it->second;
+}
+
+std::uint64_t AntRouterLogic::antsReceived(AntType type) const {
+    auto it = antsReceived_.find(type);
+    return it == antsReceived_.end() ? 0 : it->second;
+}
+
+std::uint64_t AntRouterLogic::controlPacketsSent() const {
+    std::uint64_t total = 0;
+    for (const auto& kv : antsSent_) total += kv.second;
+    return total;
 }
 
 std::vector<RouteDecision> AntRouterLogic::reportNeighborLoss(NodeAddress n) {
@@ -147,6 +176,10 @@ std::vector<AntMessage> AntRouterLogic::createProactiveAnts() {
             continue;
         }
         ants.push_back(createForwardAnt(AntType::Proactive, it->first));
+        // Origination: the adapter sends these directly (they don't pass
+        // through a RouteDecision here), so count them at the source.
+        antsSent_[AntType::Proactive] += 1;
+        if (observer_) observer_->onAntSent(AntType::Proactive, AntDirection::Up, false);
         ++it;
     }
     return ants;
@@ -179,6 +212,11 @@ AntMessage AntRouterLogic::createHelloAnt(std::size_t maxAdverts) {
     m.dst       = kInvalidAddress;  // adapter maps to its broadcast address
     m.seqNum    = nextSeq();
     m.timeStart = clock_.now();
+
+    // Origination: the adapter broadcasts every hello on its timer, so count it
+    // here (hellos are consumed locally at the receiver, never re-forwarded).
+    antsSent_[AntType::Hello] += 1;
+    if (observer_) observer_->onAntSent(AntType::Hello, AntDirection::Up, true);
 
     // Diffusion adverts are gated (ADR-0007); a hello with no adverts still
     // serves neighbour discovery / liveness.
@@ -285,6 +323,10 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
         return {RouteDecision::drop()};
     }
 
+    // Count the non-duplicate reception (observability, item 15).
+    antsReceived_[incoming.type] += 1;
+    if (observer_) observer_->onAntReceived(incoming.type, incoming.direction);
+
     // Link-layer neighbour detection from the previous hop.
     if (prevHop != kInvalidAddress) {
         learnNeighbor(prevHop);
@@ -311,7 +353,7 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
             AntMessage back = createBackAnt(ant);
             NodeAddress next = advanceBackAnt(back);
             if (next == kInvalidAddress) return {RouteDecision::drop()};
-            return {{RouteAction::Unicast, next, true, back}};
+            return {sendAnt(RouteAction::Unicast, next, back)};
         }
         if (ant.src == address_) {
             return {RouteDecision::drop()};  // our own forward ant looped back
@@ -328,7 +370,7 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
             rng_.uniform() < config_.proactiveBroadcastProb) {
             return {broadcastForward(ant)};
         }
-        return {{RouteAction::Unicast, next, true, ant}};
+        return {sendAnt(RouteAction::Unicast, next, ant)};
     }
 
     // Backward ant: rebuild the deposit state from the carried path (the four
@@ -347,7 +389,7 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
 
     NodeAddress next = advanceBackAnt(ant);
     if (next == kInvalidAddress) return {RouteDecision::drop()};
-    return {{RouteAction::Unicast, next, true, ant}};
+    return {sendAnt(RouteAction::Unicast, next, ant)};
 }
 
 std::vector<RouteDecision> AntRouterLogic::onDataPacket(NodeAddress dest,
@@ -363,7 +405,7 @@ std::vector<RouteDecision> AntRouterLogic::onDataPacket(NodeAddress dest,
         if (it == lastReactive_.end() || now - it->second >= config_.reactiveRetryInterval) {
             lastReactive_[dest] = now;
             AntMessage refa = createForwardAnt(AntType::Reactive, dest);
-            out.push_back({RouteAction::Broadcast, kInvalidAddress, true, refa});
+            out.push_back(sendAnt(RouteAction::Broadcast, kInvalidAddress, refa));
         }
         return out;
     }

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(ANTHOCNET_TESTS
   test_data_routing
   test_link_metric
   test_properties
+  test_observability
 )
 
 foreach(test ${ANTHOCNET_TESTS})

--- a/core/tests/test_observability.cpp
+++ b/core/tests/test_observability.cpp
@@ -1,0 +1,121 @@
+// Item 15: ant/route counters and the optional IRouterObserver fire at the
+// expected events, and are zero-cost (unset observer) by construction.
+#include <vector>
+
+#include "anthocnet/core/ant_router_logic.h"
+#include "test_support.h"
+
+using namespace anthocnet::core;
+using anthocnet::test::FakeClock;
+using anthocnet::test::ScriptedRng;
+
+namespace {
+
+struct RecordingObserver : IRouterObserver {
+    struct Sent { AntType type; AntDirection dir; bool broadcast; };
+    std::vector<Sent> sent;
+    std::vector<AntType> received;
+    int routeAdds = 0;
+    int routeRemoves = 0;
+
+    void onAntSent(AntType t, AntDirection d, bool b) override {
+        sent.push_back({t, d, b});
+    }
+    void onAntReceived(AntType t, AntDirection /*d*/) override {
+        received.push_back(t);
+    }
+    void onRouteChanged(NodeAddress /*dest*/, NodeAddress /*nb*/, bool added) override {
+        if (added) ++routeAdds; else ++routeRemoves;
+    }
+};
+
+}  // namespace
+
+int main() {
+    Config cfg;
+
+    // --- reactive broadcast on data with no route increments antsSent ------
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 1, cfg, clock, rng);
+        RecordingObserver obs;
+        router.setObserver(&obs);
+
+        router.onDataPacket(/*dest*/ 9);
+        CHECK_EQ(router.antsSent(AntType::Reactive), static_cast<std::uint64_t>(1));
+        CHECK_EQ(router.controlPacketsSent(), static_cast<std::uint64_t>(1));
+        CHECK_EQ(obs.sent.size(), static_cast<std::size_t>(1));
+        CHECK(obs.sent[0].type == AntType::Reactive);
+        CHECK(obs.sent[0].dir == AntDirection::Up);
+        CHECK(obs.sent[0].broadcast == true);
+
+        // A second packet to the same dest within reactiveRetryInterval must
+        // NOT launch another ant (rate-limited), so the counter is unchanged.
+        router.onDataPacket(/*dest*/ 9);
+        CHECK_EQ(router.antsSent(AntType::Reactive), static_cast<std::uint64_t>(1));
+    }
+
+    // --- received counter + route-added on neighbour learn -----------------
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 1, cfg, clock, rng);
+        RecordingObserver obs;
+        router.setObserver(&obs);
+
+        AntMessage hello;
+        hello.type = AntType::Hello;
+        hello.direction = AntDirection::Up;
+        hello.src = 2;
+        hello.seqNum = 1;
+        hello.helloDests = {{9, 1.0}};
+
+        router.onReceiveAnt(hello, /*prevHop*/ 2);
+        CHECK_EQ(router.antsReceived(AntType::Hello), static_cast<std::uint64_t>(1));
+        CHECK_EQ(obs.received.size(), static_cast<std::size_t>(1));
+        CHECK(obs.received[0] == AntType::Hello);
+        CHECK(obs.routeAdds >= 1);  // neighbour 2 was learned
+
+        // Duplicate (same src,seq) is deduped: not counted as received again.
+        router.onReceiveAnt(hello, /*prevHop*/ 2);
+        CHECK_EQ(router.antsReceived(AntType::Hello), static_cast<std::uint64_t>(1));
+    }
+
+    // --- forwarding the spawned backward ant counts as a send --------------
+    {
+        FakeClock clock;
+        clock.set(1.0);
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 9, cfg, clock, rng);
+        RecordingObserver obs;
+        router.setObserver(&obs);
+
+        AntMessage fwd;
+        fwd.type = AntType::Reactive;
+        fwd.direction = AntDirection::Up;
+        fwd.src = 3;
+        fwd.dst = 9;  // this node is the destination
+        fwd.seqNum = 1;
+        fwd.timeStart = 0.0;
+        fwd.visited = {{3, 0.0}, {4, 0.01}};
+
+        router.onReceiveAnt(fwd, /*prevHop*/ 4);
+        // The destination unicasts a backward ant home -> one send, direction Down.
+        CHECK_EQ(router.antsSent(AntType::Reactive), static_cast<std::uint64_t>(1));
+        CHECK_EQ(obs.sent.size(), static_cast<std::size_t>(1));
+        CHECK(obs.sent[0].dir == AntDirection::Down);
+        CHECK(obs.sent[0].broadcast == false);
+    }
+
+    // --- no observer set: counters still work, no crash --------------------
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 1, cfg, clock, rng);
+        router.onDataPacket(/*dest*/ 9);
+        CHECK_EQ(router.antsSent(AntType::Reactive), static_cast<std::uint64_t>(1));
+    }
+
+    return RUN_TESTS();
+}

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -96,14 +96,14 @@ For node `i`, destination `d`, neighbour `n`, pheromone `T_nd^i`:
 | [05](05-link-failure-detection-and-repair.md) | Hello-timeout detection, failure notification, repair bounding | D5/D6 | **P1** | L | ✅ detection+notify+repair; NS-3 MAC hook TODO |
 | [06](06-evaporation-and-minor.md) | Time-based evaporation + minor deviations | D7 | **P2** | S | 🟡 6.1 evap + 6.3 backoff done; 6.2/6.4/6.5 minor |
 | [07](07-validation-and-benchmarks.md) | Validation harness + paper-faithful benchmark scenario | — | **P2** | M | 🟡 paper base scenario + area/pause sweeps via `--scenario=paper` |
-| [08](08-protocol-comparison-benchmarks.md) | Benchmark vs AODV/OLSR/DSDV/DSR (+ overhead/NRL, fairness) | — | **P2** | M | 🟡 PDR + mean/99th delay + throughput + uniform NRL in anthocnet-compare; DSR + full multi-seed write-up pending |
+| [08](08-protocol-comparison-benchmarks.md) | Benchmark vs AODV/OLSR/DSDV/DSR (+ overhead/NRL, fairness) | — | **P2** | M | 🟡 PDR + mean/99th delay + throughput + uniform NRL + `--diag` ant-level diagnostics + manual `paper-benchmark` workflow; DSR + per-seed stddev pending |
 | [09](09-landscape-and-positioning.md) | Public-implementation landscape + project presentation fixes | — | **P2** | S |
 | [10](10-data-loops-multipath-and-mac-metric.md) | Data-loop suppression, multipath safety, reactive broadcast cap, MAC metric | A1/A2/A3 | **P1**/P2 | M | 🟡 A1 prevhop + A3 cap done; A2 MAC + stickiness deferred |
 | [11](11-adapter-robustness.md) | NS-2 unbounded queue, NS-3 multi-iface, address-mapping bug | B1/B2/B3 | **P1**/P2 | M | 🟡 B1+B3 done (P1); B2 multi-iface deferred |
 | [12](12-codec-hardening-and-threat-model.md) | Enforce protocol bounds on untrusted decode + threat model | C1 | **P1** | S | ✅ done |
 | [13](13-ci-e2e-and-fuzzing.md) | CI end-to-end sim smoke + codec fuzzing + property tests | D1/D2 | P2 | M | ✅ property tests + codec fuzz + NS-3 & NS-2 asserted-delivery smokes |
 | [14](14-reproducibility-and-release.md) | Docker repro + CITATION/releases/DOI + ns-3 version matrix | E1/E2/E3 | P2 | M | 🟡 E1 Docker images (ns2 2.34/2.35 + ns3 3.41/3.42) + GHCR workflow; E2/E3 pending |
-| [15](15-observability-and-traces.md) | Trace sources / counters (feeds item 08 NRL) | F1 | P2 | S–M | 🟡 uniform IP-layer routing-overhead counting (NRL) in the harness; module-level trace sources/counters pending |
+| [15](15-observability-and-traces.md) | Trace sources / counters (feeds item 08 NRL) | F1 | P2 | S–M | 🟡 core ant/route counters + optional `IRouterObserver` (unit-tested) + NS-3 `Tx`/`Rx`/`RouteChanged` trace sources, surfaced via `--diag`; NS-2 trace lines + pheromone-change trace pending |
 | [16](16-pluggable-link-metric.md) | Pluggable `ILinkMetric` port (fuzzy/energy/QoS extensibility) | G1 | P3 | M | ✅ port + ClassicMetric (core); adapter selection is an extension point |
 
 Recommended sequence: **01 → 02** first (biggest correctness/performance levers

--- a/ns3/README.md
+++ b/ns3/README.md
@@ -78,10 +78,27 @@ comparison. Results vary by node density, mobility and traffic — this is a
 re-validation harness, not a claim that any one protocol always wins.
 
 Options: `--scenario=paper --nNodes --time --area --areaX --areaY --speed
---pause --range --flows --cbrBps --runs --protocols --csv`. (`--scenario=paper`
-sets the paper defaults; any explicit flag overrides them, which is how the
-area/pause sweeps above work. The numbers above are illustrative.)
-(e.g. `--protocols=anthocnet,aodv`).
+--pause --range --flows --cbrBps --runs --protocols --csv --diag`.
+(`--scenario=paper` sets the paper defaults; any explicit flag overrides them,
+which is how the area/pause sweeps above work. The numbers above are
+illustrative.) (e.g. `--protocols=anthocnet,aodv`).
+
+### Diagnostics (`--diag`)
+
+`--diag` emits a `# diag` line per run with the first-delivery time and, for
+AntHocNet, per-type ant send/receive tallies — so you can see whether routes
+actually form (reactive ants sent vs. received elsewhere; back-ant arrivals)
+rather than just the aggregate PDR:
+
+```
+# diag anthocnet seed=1 pdr=92.40 firstDeliveryS=6.21 ctrlTx=18342 \
+    antTx[hello=...,reactive=...,proactive=...,repair=...,linkfail=...] antRx[...]
+```
+
+These come from the protocol's item-15 trace sources (`Tx`, `Rx`,
+`RouteChanged` on `ns3::anthocnet::RoutingProtocol`), which any script can
+`Config::Connect` to. The heavy paper-regime run is wired up as the
+manually-dispatched **Paper benchmark** GitHub Actions workflow.
 
 ## Uninstall
 

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -67,6 +67,25 @@ void CountControlTx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t) {
     if (udp.GetDestinationPort() != kDataPort) ++g_controlPkts;
 }
 
+// --- diagnostics (--diag): ant-level introspection for AntHocNet -----------
+// Answers "are routes forming and when?": per-type ant send/receive tallies
+// (from the protocol's own item-15 Tx/Rx trace sources) and the time of the
+// first delivered data packet (works for every protocol, from the sink's Rx).
+bool g_diag = false;
+std::map<uint8_t, uint64_t> g_antTx;   // by AntType byte
+std::map<uint8_t, uint64_t> g_antRx;
+double g_firstDeliveryS = -1.0;
+
+void DiagAntTx(uint8_t type, uint8_t /*dir*/, bool /*broadcast*/) {
+    if (g_diag) g_antTx[type] += 1;
+}
+void DiagAntRx(uint8_t type, uint8_t /*dir*/) {
+    if (g_diag) g_antRx[type] += 1;
+}
+void DiagSinkRx(Ptr<const Packet>, const Address&) {
+    if (g_firstDeliveryS < 0.0) g_firstDeliveryS = Simulator::Now().GetSeconds();
+}
+
 struct Params {
     uint32_t nNodes;
     double   simTime;
@@ -95,6 +114,9 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     RngSeedManager::SetSeed(1);
     RngSeedManager::SetRun(seed);
     g_controlPkts = 0;
+    g_antTx.clear();
+    g_antRx.clear();
+    g_firstDeliveryS = -1.0;
 
     NodeContainer nodes;
     nodes.Create(P.nNodes);
@@ -192,6 +214,25 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     }
     sinks.Start(Seconds(0.0));
 
+    if (g_diag) {
+        // First-delivery timestamp from every data sink (all protocols).
+        for (uint32_t i = 0; i < sinks.GetN(); ++i) {
+            sinks.Get(i)->TraceConnectWithoutContext("Rx", MakeCallback(&DiagSinkRx));
+        }
+        // Per-type ant tallies from AntHocNet's own trace sources (item 15).
+        // Guarded to anthocnet: other protocols have no "Tx"/"Rx" ant traces.
+        if (proto == "anthocnet") {
+            for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+                Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
+                if (!ip) continue;
+                Ptr<Ipv4RoutingProtocol> rp = ip->GetRoutingProtocol();
+                if (!rp) continue;
+                rp->TraceConnectWithoutContext("Tx", MakeCallback(&DiagAntTx));
+                rp->TraceConnectWithoutContext("Rx", MakeCallback(&DiagAntRx));
+            }
+        }
+    }
+
     FlowMonitorHelper fmHelper;
     Ptr<FlowMonitor> monitor = fmHelper.InstallAll();
 
@@ -244,6 +285,34 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         }
     }
 
+    // Diagnostics line (prefixed "# " so CSV consumers ignore it). Shows whether
+    // routes form (reactive ants sent vs received elsewhere; back-ant arrivals)
+    // and when the first packet is delivered.
+    if (g_diag) {
+        std::cout << std::fixed << std::setprecision(2)
+                  << "# diag " << proto << " seed=" << seed
+                  << " pdr=" << r.pdr
+                  << " firstDeliveryS=" << g_firstDeliveryS
+                  << " ctrlTx=" << g_controlPkts;
+        if (proto == "anthocnet") {
+            auto n = [](std::map<uint8_t, uint64_t>& m, uint8_t k) {
+                auto it = m.find(k);
+                return it == m.end() ? static_cast<uint64_t>(0) : it->second;
+            };
+            std::cout << " antTx[hello=" << n(g_antTx, 0x01)
+                      << ",reactive=" << n(g_antTx, 0x02)
+                      << ",proactive=" << n(g_antTx, 0x04)
+                      << ",repair=" << n(g_antTx, 0x08)
+                      << ",linkfail=" << n(g_antTx, 0x10) << "]"
+                      << " antRx[hello=" << n(g_antRx, 0x01)
+                      << ",reactive=" << n(g_antRx, 0x02)
+                      << ",proactive=" << n(g_antRx, 0x04)
+                      << ",repair=" << n(g_antRx, 0x08)
+                      << ",linkfail=" << n(g_antRx, 0x10) << "]";
+        }
+        std::cout << "\n";
+    }
+
     Simulator::Destroy();
     return r;
 }
@@ -276,6 +345,7 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("runs", "Number of RNG runs to average (seeds 1..runs)", runs);
     cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
     cmd.AddValue("protocols", "Comma-separated list", protocols);
+    cmd.AddValue("diag", "Emit per-run '# diag' lines (ant tallies, first delivery)", g_diag);
     cmd.Parse(argc, argv);
     if (runs < 1) runs = 1;
 

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -94,8 +94,40 @@ TypeId RoutingProtocol::GetTypeId() {
                           "Seconds a data session stays active for proactive probing.",
                           DoubleValue(5.0),
                           MakeDoubleAccessor(&RoutingProtocol::m_sessionTtl),
-                          MakeDoubleChecker<double>());
+                          MakeDoubleChecker<double>())
+            .AddTraceSource("Tx",
+                            "An ant control packet was put on the medium by this "
+                            "node (type, direction, broadcast).",
+                            MakeTraceSourceAccessor(&RoutingProtocol::m_txAntTrace),
+                            "ns3::anthocnet::RoutingProtocol::AntTxCallback")
+            .AddTraceSource("Rx",
+                            "A non-duplicate ant control packet was received and "
+                            "processed (type, direction).",
+                            MakeTraceSourceAccessor(&RoutingProtocol::m_rxAntTrace),
+                            "ns3::anthocnet::RoutingProtocol::AntRxCallback")
+            .AddTraceSource("RouteChanged",
+                            "A neighbour/route entry was added or removed "
+                            "(dest, neighbour, added).",
+                            MakeTraceSourceAccessor(&RoutingProtocol::m_routeChangedTrace),
+                            "ns3::anthocnet::RoutingProtocol::RouteChangedCallback");
     return tid;
+}
+
+// --- observability: forward core events to ns-3 trace sources (item 15) ------
+
+void RoutingProtocol::onAntSent(::anthocnet::core::AntType type,
+                                ::anthocnet::core::AntDirection dir, bool broadcast) {
+    m_txAntTrace(static_cast<uint8_t>(type), static_cast<uint8_t>(dir), broadcast);
+}
+
+void RoutingProtocol::onAntReceived(::anthocnet::core::AntType type,
+                                    ::anthocnet::core::AntDirection dir) {
+    m_rxAntTrace(static_cast<uint8_t>(type), static_cast<uint8_t>(dir));
+}
+
+void RoutingProtocol::onRouteChanged(::anthocnet::core::NodeAddress dest,
+                                     ::anthocnet::core::NodeAddress nb, bool added) {
+    m_routeChangedTrace(static_cast<uint32_t>(dest), static_cast<uint32_t>(nb), added);
 }
 
 // --- lifecycle --------------------------------------------------------------
@@ -165,6 +197,7 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.proactiveInterval = m_proactiveInterval.GetSeconds();
         m_logic.reset(new ::anthocnet::core::AntRouterLogic(
             ToCore(iface.GetLocal()), m_config, m_clock, m_rng));
+        m_logic->setObserver(this);  // fan core events to the trace sources
     }
 
     // One UDP socket per interface for ant control traffic.

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -14,6 +14,7 @@
 #include "ns3/ipv4-l3-protocol.h"
 #include "ns3/socket.h"
 #include "ns3/timer.h"
+#include "ns3/traced-callback.h"
 
 #include <map>
 #include <memory>
@@ -36,7 +37,12 @@
 namespace ns3 {
 namespace anthocnet {
 
-class RoutingProtocol : public Ipv4RoutingProtocol
+// The protocol is also a core IRouterObserver (item 15): it forwards the core's
+// ant/route events to ns-3 trace sources so users can Config::Connect and so the
+// comparison harness can read ant-level diagnostics. The interface is all
+// no-op-default virtuals, so this adds no state to the core.
+class RoutingProtocol : public Ipv4RoutingProtocol,
+                        public ::anthocnet::core::IRouterObserver
 {
 public:
     static TypeId GetTypeId();
@@ -44,6 +50,19 @@ public:
 
     RoutingProtocol();
     ~RoutingProtocol() override;
+
+    // Trace-source callback signatures (introspection names used in GetTypeId).
+    typedef void (*AntTxCallback)(uint8_t type, uint8_t direction, bool broadcast);
+    typedef void (*AntRxCallback)(uint8_t type, uint8_t direction);
+    typedef void (*RouteChangedCallback)(uint32_t dest, uint32_t neighbor, bool added);
+
+    // core::IRouterObserver
+    void onAntSent(::anthocnet::core::AntType type,
+                   ::anthocnet::core::AntDirection dir, bool broadcast) override;
+    void onAntReceived(::anthocnet::core::AntType type,
+                       ::anthocnet::core::AntDirection dir) override;
+    void onRouteChanged(::anthocnet::core::NodeAddress dest,
+                        ::anthocnet::core::NodeAddress nb, bool added) override;
 
     // Ipv4RoutingProtocol
     Ptr<Ipv4Route> RouteOutput(Ptr<Packet> p, const Ipv4Header& header,
@@ -134,6 +153,11 @@ private:
     bool m_enableDiffusion;
     double m_proactiveBroadcastProb;
     double m_sessionTtl;
+
+    // trace sources (item 15): ant sent/received and route add/remove.
+    TracedCallback<uint8_t, uint8_t, bool> m_txAntTrace;
+    TracedCallback<uint8_t, uint8_t> m_rxAntTrace;
+    TracedCallback<uint32_t, uint32_t, bool> m_routeChangedTrace;
 };
 
 } // namespace anthocnet


### PR DESCRIPTION
## Why

Investigating why AntHocNet looks bad in the published benchmark. The current CI table is the deliberately-hard **dense-small** scenario (16 nodes / 250 m / 25 s) where *every* protocol does badly — it's a noisy regression tripwire, not a verdict, and AntHocNet's intended regime (large/sparse/mobile, 300 m range) was never actually measured here. This PR builds the instrument to diagnose it from data instead of guessing.

## What

**Core observability (item 15)** — fully unit-tested locally (`make test`: 17/17):
- Optional `IRouterObserver` port (no-op defaults, zero cost when unset) + per-type ant sent/received counters on `AntRouterLogic`. All ant emission routed through one `sendAnt()` choke point; hello/proactive ants counted at origination. `onRouteChanged` fires on neighbour add/remove. The observer only *reports* — the core stays pure.
- New `test_observability` asserts counters/observer fire on the expected events (reactive broadcast, dedup-suppressed receive, back-ant forward) and that an unset observer is safe.

**NS-3 traces (item 15):**
- `RoutingProtocol` implements `IRouterObserver` and exposes `Tx` / `Rx` / `RouteChanged` `TracedCallback` sources (registered in `GetTypeId`), so users can `Config::Connect` and the harness can read ant-level activity.

**Benchmark diagnostics (item 08):**
- `anthocnet-compare --diag` emits per-run `# diag` lines: first-delivery time (all protocols) + per-type ant send/receive tallies (AntHocNet). Answers *"are routes forming, and when?"* not just aggregate PDR. CSV field order untouched → existing parsers and the CI smoke are unaffected (`#`-prefixed lines are dropped by the CSV grep).
- New manually-dispatched **`paper-benchmark`** workflow runs the paper-regime scenario with `--diag`.

## Validation

- Core: `make test` green (17/17), including the new observability test.
- NS-3 (build/trace wiring) validated by CI — I can't compile ns-3 locally. The dense-small e2e smoke still parses field 7 (`pdr_pct`) unchanged.

## Not in this PR

DSR protocol case and per-seed stddev (item 08) remain — deferred to keep this focused on the diagnostic goal. Once CI is green I'll dispatch the paper-benchmark workflow and report the numbers so we can target real fixes from evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GczoAwKTzys91p5wQ4WehK)_