### PR TITLE
chore: project hygiene — fix language stats, community files, lint CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# EditorConfig — https://editorconfig.org
+# Codifies the existing style so editors stay consistent across contributors.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# C++ (core/ + adapters): 4-space indent, matching the existing source.
+[*.{c,cc,cpp,h,hpp}]
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+# Markdown: keep trailing whitespace (it is a hard line break).
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Generated ns-2 mobility + CBR traffic scenario files are machine-produced
+# (setdest / cbrgen output), not authored source. Exclude them from GitHub's
+# language statistics and collapse them in diffs/reviews. Without this, ~160k
+# lines of generated Tcl dominate the repo and mislabel this C++ project as Tcl.
+ns2/tcl/scenario*/sim-*.tcl linguist-generated=true
+
+# Auto-generated benchmark charts (produced by the benchmarks workflow).
+docs/benchmarks/*.png linguist-generated=true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+# Style/quality gate for the repository's tooling. Fast and dependency-light.
+# (C++ formatting via clang-format is tracked separately — adopting it needs a
+# one-time reformat — so it is not enforced here yet.)
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: Python tools (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install ruff
+        run: pip install ruff
+      - name: Lint
+        run: ruff check ns3/tools

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,63 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers by opening a GitHub issue, or — for
+sensitive matters — by contacting the maintainer ([@danieljoppi](https://github.com/danieljoppi))
+directly. All complaints will be reviewed and investigated promptly and fairly.
+Maintainers are obligated to respect the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to AntHocNet
+
+Thanks for your interest. This is a research/educational implementation of the
+AntHocNet MANET routing protocol with a simulator-agnostic core and thin NS-2 /
+NS-3 adapters. Please read this before opening a PR.
+
+## Architecture invariant (do not break)
+
+```
+core/   simulator-agnostic algorithm. No NS-2/NS-3 headers. Pure: returns
+        RouteDecisions, performs no I/O. Time & randomness come via ports
+        (IClock, IRng). THIS is where protocol logic lives.
+ns2/    thin Agent adapter + source patch. Translates header <-> AntMessage,
+        executes RouteDecisions, owns timers + link-failure callback.
+ns3/    native Ipv4RoutingProtocol module. Same responsibilities as ns2.
+```
+
+**If a change affects routing decisions, it belongs in `core/`** and must be
+covered by a `core/tests/` unit test. Adapters change only to feed the core new
+inputs or carry out a new `RouteAction`. See `CONTEXT.md` and
+[`docs/improvements/README.md`](docs/improvements/README.md) for the deeper map.
+
+## Building & testing
+
+```bash
+# core library + unit tests (fast, no simulator needed)
+make test
+
+# NS-2 source patch self-test
+bash ns2/patch/selftest.sh
+
+# NS-3 module (needs an ns-3 tree)
+make install-ns3 NS3DIR=/path/to/ns-3-dev
+cd /path/to/ns-3-dev && ./ns3 configure --enable-examples --enable-tests && ./ns3 build
+./test.py -s anthocnet
+```
+
+`make test` must stay green, and any new behaviour needs a test. CI runs the
+core tests (incl. ASan/UBSan), the codec fuzzer, the NS-2 patch + compile + e2e
+delivery smoke, and the NS-3 build/test matrix across ns-3.36–3.48.
+
+## Code style
+
+- **C++14.** Match the surrounding code: 4-space indent, `lowerCamelCase`
+  members with a trailing `_`, `namespace anthocnet::core`. An `.editorconfig`
+  encodes the whitespace rules.
+- Comment **non-obvious intent**, not the obvious; don't add narrating comments.
+- Prefer extending `Config` over new magic constants.
+- **Python tooling** (`ns3/tools/*.py`) is linted with [ruff](https://docs.astral.sh/ruff/);
+  run `ruff check ns3/tools` before pushing (CI enforces it).
+
+## Wire format
+
+Any new `AntMessage` field must be added to **all** of: the struct
+(`core/include/anthocnet/core/ant_message.h`), the codec
+(`core/src/ant_message_codec.cpp`), both adapter headers, and
+`core/tests/test_codec.cpp` — and the round-trip test must still pass. Bump the
+wire-version byte per [`docs/wire-format.md`](docs/wire-format.md) (ADR-0006).
+
+## Pull requests
+
+- Branch from `main`; keep PRs focused.
+- Make sure CI is green. New tunables get NS-2 TCL binds and NS-3 `TypeId`
+  attributes; update `CONTEXT.md` / `docs/porting-notes.md` if behaviour or the
+  wire format changed.
+- Picking up work? The backlog lives in GitHub issues and
+  [`docs/improvements/`](docs/improvements/) (each numbered spec is a
+  self-contained, implementable item with acceptance criteria).
+
+## Reporting issues
+
+Bugs and parser/security concerns: see [`SECURITY.md`](SECURITY.md). For
+behaviour questions, open a GitHub issue with the scenario and observed output
+(the `--diag` flag on `anthocnet-compare` and the trace sources help).
+
+By contributing you agree your work is licensed under the repository's
+[LICENSE](LICENSE) (GPL-2.0), and to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/ns3/tools/make-charts.py
+++ b/ns3/tools/make-charts.py
@@ -16,7 +16,6 @@ Re-plotting reads only the CSV, so it never re-runs ns-3. Deterministic output.
 import argparse
 import csv
 import os
-import sys
 from collections import defaultdict
 
 import matplotlib

--- a/ns3/tools/run-comparison.sh
+++ b/ns3/tools/run-comparison.sh
@@ -4,8 +4,13 @@
 #
 # Runs the anthocnet-compare benchmark inside an ns-3 tree that already has the
 # AntHocNet module installed and the comparison modules enabled, and writes the
-# averaged results to stdout as CSV. Used locally and by the benchmark CI
-# pipeline.
+# averaged results to stdout as CSV.
+#
+# Scope: this is the lightweight *single-scenario* CSV helper. The per-merge
+# benchmark pipeline and the full scenario taxonomy/sweeps + charts are driven
+# by ns3/tools/run-scenarios.py (which emits a classified CSV that
+# make-charts.py plots); use that for the matrix. This script remains handy for
+# a quick one-off comparison.
 #
 # The ns-3 tree must have been configured with:
 #   ./ns3 configure --enable-examples \


### PR DESCRIPTION
Repository-health pass from the project review — none of this was in the `docs/improvements/` backlog.

## Changes

- **`.gitattributes`** — mark the 30 generated ns-2 scenario files (`ns2/tcl/scenario*/sim-*.tcl`, ~160k lines of `setdest`/`cbrgen` output) and the auto-generated benchmark PNGs as `linguist-generated`. **Fixes the repo being labelled "Tcl"** (those files were ~96% of tracked lines, drowning the ~7k-line C++ project) and collapses them in diffs.
- **`CONTRIBUTING.md`** — architecture invariant (core vs adapters), build/test commands, code style, the wire-format "update all of struct+codec+adapters+test" rule, and PR expectations.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1 (reporting mirrors `SECURITY.md`).
- **`.editorconfig`** — encodes the existing whitespace style (C++/Python 4-space — verified against the source, not the README's stale "2-space" note; YAML 2-space; Makefile tabs).
- **`.github/workflows/lint.yml`** — `ruff check ns3/tools` on push/PR. Also fixes one real issue ruff flagged (unused `import sys` in `make-charts.py`).
- **`run-comparison.sh`** — header note clarifying it's the lightweight single-scenario helper; `run-scenarios.py` drives the taxonomy/sweeps + charts.

## Validation (local)

- `ruff check ns3/tools` → all checks pass.
- `make-charts.py` still renders after the import removal.
- No code/behaviour changes — pure hygiene; the C++/NS-2/NS-3 build paths are untouched, so the existing CI matrix is unaffected.

## Deliberately deferred

C++ `clang-format` enforcement: a candidate config produces a **~1,400-line reformat across 46/54 files**, so adopting it is a separate one-time PR rather than a check bolted onto this one. I'll file a follow-up issue for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GczoAwKTzys91p5wQ4WehK)_