### PR TITLE
ci: adopt commitizen for automated versioning + conventional-commit PR titles

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,18 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+# Current version. Commitizen bumps this and the files below from the
+# Conventional-Commit history; keep it in sync with the VERSION file.
+version = "0.1.0"
+version_scheme = "semver"
+tag_format = "v$version"
+# Pre-1.0: a breaking change bumps the MINOR, not the MAJOR.
+major_version_zero = true
+update_changelog_on_bump = true
+changelog_incremental = true
+# Files whose version string cz rewrites on bump. Patterns are matched per line
+# so we do NOT clobber `cff-version:` or `cmake_minimum_required(VERSION ...)`.
+version_files = [
+    "VERSION",
+    "CITATION.cff:^version:",
+    "core/CMakeLists.txt:project",
+]

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,37 @@
+name: PR title
+
+# We squash-merge, so the PR title becomes the commit on main and is what
+# Commitizen reads to compute the next version. Enforce the Conventional
+# Commits format (https://www.conventionalcommits.org) on PR titles so the
+# release bump is always computable.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed types (Conventional Commits + a couple we use).
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: "The subject must start lowercase, e.g. 'feat: add the DSR baseline'."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,50 +1,77 @@
 name: Release
 
-# On a vX.Y.Z tag: sanity-build, assemble a lean install bundle (the source you
-# need to install onto your own ns-2 / ns-3 tree, minus the ~160k lines of
-# generated scenario files), and publish a GitHub Release. Once the repo is
-# linked to Zenodo, each published release is archived and gets a DOI
-# automatically — no workflow change needed; just add the DOI to CITATION.cff.
+# Manual, Commitizen-driven release. You trigger it; Commitizen computes the
+# next SemVer from the Conventional-Commit history since the last tag (feat ->
+# minor, fix -> patch, breaking -> minor while 0.x), rewrites the version in
+# VERSION / CITATION.cff / core CMake, regenerates CHANGELOG.md, commits + tags,
+# then this same job builds the lean install bundle and publishes the GitHub
+# Release. Bump + release live in one job on purpose: a tag pushed with the
+# default GITHUB_TOKEN does NOT trigger other workflows, so we don't rely on the
+# tag event (and need no PAT). Once the repo is linked to Zenodo, each published
+# release is archived + gets a DOI; add it to CITATION.cff afterwards.
 on:
-  push:
-    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "bump = cz computes next version from commits; baseline = release the current VERSION as-is (use once, for v0.1.0)"
+        type: choice
+        options: [bump, baseline]
+        default: bump
 
 permissions:
-  contents: write   # create the release
+  contents: write   # push the bump commit/tag and create the release
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags for cz to compute the bump
 
-      - name: Check tag matches VERSION
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install tools
         run: |
-          tag="${GITHUB_REF_NAME}"          # e.g. v0.1.0
-          ver="${tag#v}"
-          file_ver="$(tr -d '[:space:]' < VERSION)"
-          if [ "$ver" != "$file_ver" ]; then
-            echo "::error::tag $tag (=$ver) does not match VERSION file ($file_ver)"
-            exit 1
+          pip install commitizen
+          sudo apt-get update && sudo apt-get install -y cmake g++
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute version (bump or baseline)
+        run: |
+          if [ "${{ inputs.mode }}" = "baseline" ]; then
+            ver="$(tr -d '[:space:]' < VERSION)"
+            git tag -a "v${ver}" -m "v${ver}"
+          else
+            cz bump --yes --changelog
+            ver="$(tr -d '[:space:]' < VERSION)"
           fi
-          echo "VER=$ver" >> "$GITHUB_ENV"
+          echo "VER=${ver}" >> "$GITHUB_ENV"
+          echo "TAG=v${ver}" >> "$GITHUB_ENV"
 
       - name: Sanity build + test (core)
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ && make test
+        run: make test
+
+      - name: Push commit + tag
+        run: |
+          git push origin HEAD:main
+          git push origin "${TAG}"
 
       - name: Assemble install bundle
         run: |
           name="anthocnet-${VER}"
           dest="dist/${name}"
           mkdir -p "$dest"
-          # Top-level files (only those that exist).
           for f in Makefile README.md LICENSE CHANGELOG.md CITATION.cff \
                    CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md CONTEXT.md AGENTS.md; do
             [ -e "$f" ] && cp "$f" "$dest/"
           done
           cp -r core ns3 docs ns2 "$dest/"
-          # Drop the generated ns-2 scenario data (~160k lines) and any build
-          # output from the bundle.
           rm -rf "$dest"/ns2/tcl/scenario*
           find "$dest" -type d -name build -prune -exec rm -rf {} +
           ( cd dist && zip -qr "${name}.zip" "${name}" )
@@ -53,10 +80,11 @@ jobs:
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.TAG }}
           files: dist/anthocnet-${{ env.VER }}.zip
           generate_release_notes: true
           body: |
-            AntHocNet ${{ github.ref_name }}. See [CHANGELOG.md](CHANGELOG.md).
+            AntHocNet ${{ env.TAG }}. See [CHANGELOG.md](CHANGELOG.md).
 
             **Install bundle** (`anthocnet-${{ env.VER }}.zip`) — the source to
             drop onto your own simulator tree:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,28 @@ Any new `AntMessage` field must be added to **all** of: the struct
 `core/tests/test_codec.cpp` — and the round-trip test must still pass. Bump the
 wire-version byte per [`docs/wire-format.md`](docs/wire-format.md) (ADR-0006).
 
+## Commit / PR titles (Conventional Commits)
+
+PRs are **squash-merged**, so the **PR title becomes the commit on `main`** and
+drives release versioning. Titles must follow
+[Conventional Commits](https://www.conventionalcommits.org) — CI enforces this:
+
+```
+<type>: <lowercase summary>      e.g.  feat: add the DSR baseline
+                                       fix: stop the linkfail broadcast storm
+```
+
+Types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci`
+`chore` `revert`. A `feat:` bumps the minor, `fix:` the patch; a
+`BREAKING CHANGE:` footer (or a `!` after the type) bumps the minor while
+pre-1.0.
+
+Releases are cut by running the **Release** workflow (manual dispatch):
+[Commitizen](https://commitizen-tools.github.io/commitizen/) computes the next
+version from the commit history, updates `VERSION` / `CITATION.cff` / the CMake
+version + `CHANGELOG.md`, tags it, and publishes the install bundle. Don't bump
+the version by hand.
+
 ## Pull requests
 
 - Branch from `main`; keep PRs focused.


### PR DESCRIPTION
Answers "will the version auto-bump?" — now **yes**, driven by the commit history, with a manual release trigger (your choice).

## What changes
- **`.cz.toml`** — Commitizen config. `cz bump` computes the next SemVer from Conventional Commits since the last tag and rewrites the version in `VERSION`, `CITATION.cff`, and the core CMake `project()`. `major_version_zero` → pre-1.0 breaking changes bump the *minor*.
- **`release.yml`** — reworked to a **manual `workflow_dispatch`**:
  - `mode=bump` (default) → `cz bump --changelog` (updates versions + `CHANGELOG.md`, commits, tags) → builds the bundle → publishes the Release.
  - `mode=baseline` → tags the current `VERSION` as-is — **use this once to cut `v0.1.0`**.
  - Bump + release run in **one job**, so no PAT is needed (a `GITHUB_TOKEN`-pushed tag wouldn't trigger a separate release workflow — the documented gotcha).
- **`pr-title.yml`** — enforces Conventional Commit PR titles (we squash-merge, so the title is what `cz` reads). This PR's own title (`ci: …`) satisfies it.
- **`CONTRIBUTING.md`** — documents the convention + release flow.

## Validation (local)
On a scratch repo with the same `version_files`, `cz bump` correctly took **0.1.0 → 0.2.0** for a `feat:` and updated **exactly** the right strings — `cff-version: 1.2.0` and `cmake_minimum_required(VERSION 3.10)` were left untouched. Workflow YAML + `.cz.toml` parse clean.

## How you'll release from now on
1. **First time:** run the **Release** workflow with `mode=baseline` → publishes `v0.1.0`.
2. **After that:** merge PRs with Conventional Commit titles, then run **Release** with `mode=bump` whenever you want to cut a version — `cz` picks the number, updates everything, tags, and publishes. (Once Zenodo is linked, each release gets a DOI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GczoAwKTzys91p5wQ4WehK)_