### PR TITLE
docs: refresh AGENTS/CONTEXT for clean session handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,27 @@ NS-2/NS-3 build needs an external simulator tree and is **not** possible from
 this repo alone. **Always run `make test` before committing a core change**, and
 `bash ns2/patch/selftest.sh` before touching `ns2/patch/`.
 
+### Validating adapter (NS-2 / NS-3) changes — use CI
+
+Because you cannot build a simulator here, the **CI matrix is how you validate
+an adapter change**: develop, push a branch, open a PR, and read the job
+results.
+
+- `ci.yml` builds the **NS-3 module against the prebuilt GHCR images across
+  ns-3.36–3.48** (e2e delivery smoke) and **compiles + runs the NS-2 adapter on
+  real ns-2.34 / 2.35 trees**. Iterate on failures from the job logs —
+  cross-version API drift is the usual cause (e.g. ns-3.36's non-`const`
+  `Histogram` accessors, `RouteInput` by-value vs const-ref, scoped TestSuite
+  enums). The `AHN_*`/`ANTHOCNET_NS3_*` macros in the NS-3 headers + CMake
+  already gate several of these by version — extend that pattern, don't fork.
+- Validate the **core** half locally first (`make test`); only the adapter/build
+  half needs CI.
+- Heavier, manual workflows: `paper-benchmark` and `scenario-matrix` (taxonomy +
+  charts), `release.yml` (Commitizen bump + install-bundle), `images.yml`
+  (republish simulator images). Releases are version-bumped by Commitizen from
+  Conventional-Commit history; **PR titles must be Conventional Commits** (CI
+  enforces it — see `CONTRIBUTING.md`).
+
 ## Golden rules (invariants — do not break)
 
 1. **`core/` must never include an NS-2 or NS-3 header.** Time comes through
@@ -78,8 +99,11 @@ this repo alone. **Always run `make test` before committing a core change**, and
 
 ## Git workflow
 
-- Active development branch: `claude/anthocnet-protocol-review-wu1huq`.
-- Commit with a descriptive message; push with `git push -u origin <branch>`.
+- Branch from `main` (`claude/<short-topic>`), one focused change per PR.
+- **PR titles are Conventional Commits** (`feat:`/`fix:`/`docs:`/…) — CI enforces
+  it, and since PRs are squash-merged the title is the commit on `main` and
+  drives the next version bump. See `CONTRIBUTING.md`.
+- Push with `git push -u origin <branch>`; open a PR; merge when CI is green.
 
 ## Where to look
 
@@ -87,6 +111,7 @@ this repo alone. **Always run `make test` before committing a core change**, and
 |--------------|-------|
 | Understand the design & decision flow | `docs/architecture.md` |
 | Understand a structural decision / its "why" | `docs/adr/` |
+| **Pick up open work** | GitHub issues (epics #26–#31; defects #19–#25) + `docs/improvements/` |
 | Maintain the NS-2 patch / wire format | `docs/porting-notes.md`, `ns2/patch/` |
 | Change the algorithm | `core/src/`, `core/include/anthocnet/core/` |
 | Change routing policy / decision flow | `core/src/ant_router_logic.cpp` |
@@ -94,4 +119,7 @@ this repo alone. **Always run `make test` before committing a core change**, and
 | Change the wire format | `docs/wire-format.md` → `core/include/.../ant_message_codec.h` (+ both adapters; bump `kWireVersion`) |
 | Work on the NS-2 adapter | `ns2/src/`, `ns2/tcl/` |
 | Work on the NS-3 adapter | `ns3/model/`, `ns3/helper/`, `ns3/examples/` |
+| Run / read benchmarks | `docs/benchmarks.md`, `ns3/tools/run-scenarios.py` + `make-charts.py`, `anthocnet-compare --diag` |
+| Inspect protocol internals | NS-3 `Tx`/`Rx`/`RouteChanged` trace sources; core counters via `IRouterObserver` |
+| Cut a release | run the `Release` workflow (Commitizen); see `CONTRIBUTING.md` |
 | Tune defaults | `core/include/anthocnet/core/config.h` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,6 +134,19 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 - The **codec decode path is fuzzed** (libFuzzer, 60 s, `codec-fuzz` job).
 - Container images for every supported simulator version are published to GHCR
   on merge to the default branch (`.github/workflows/images.yml`).
+- **Observability**: the core exposes ant/route counters + an optional
+  `IRouterObserver`; the NS-3 module surfaces `Tx`/`Rx`/`RouteChanged` trace
+  sources, read by `anthocnet-compare --diag` (item 15).
+- **Benchmarks run on every merge**: a classified scenario taxonomy across all
+  baselines (AODV/OLSR/DSDV) with the table + a chart auto-committed to
+  `docs/benchmarks*`; the paper's area/pause/scale sweeps + charts are the
+  manual `scenario-matrix` workflow (items 07/08).
+- **Versioned, citable, releasable**: SemVer tags, `VERSION` + `CITATION.cff` +
+  `CHANGELOG.md`, a Commitizen-driven `Release` workflow that builds an
+  install-bundle zip (Zenodo-ready); Conventional-Commit PR titles are
+  CI-enforced (item 14).
+- **Open work is tracked in GitHub issues** — per-area epics #26–#31 and the
+  benchmark-found defects #19–#25 (see §10).
 
 ## 8. What is missing / caveats
 
@@ -171,10 +184,24 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 
 ## 10. Open questions for future work
 
-- What scenario + metrics (delivery ratio, delay, overhead vs. AODV) define
-  "working", and on which simulator are they the reference?
-- Should there be an automated end-to-end smoke test against a pinned NS-3
-  checkout in CI (beyond the current build job)?
+> **Start here:** live work is tracked in GitHub issues, grouped into per-area
+> epics — #26 fidelity · #27 adapter · #28 benchmark · #29 observability · #30
+> packaging · #31 positioning — plus the benchmark-found defects #19–#25 and the
+> OMNeT++/INET adapter proposal #32. Each ticket has evidence, a fix sketch, and
+> acceptance criteria, and links the relevant `docs/improvements/` spec.
+
+- **Highest-leverage next item — #19 (NS-3 MAC repair hook).** The NS-3 adapter
+  has no MAC transmit-failure callback, so broken links are only caught by
+  hello-timeout and route-repair ants never fire (`repair=0`). The benchmark
+  taxonomy shows this as a 99th-delay-tail (#21) + high-mobility (#22)
+  regression vs AODV. **NS-2 already implements it** — port
+  `ns2/src/ahn_router.cc::linkFailed` (the MAC `xmit_failure_` callback +
+  bounded repair ant).
+- **What defines "working"** is now partly answered: the scenario taxonomy +
+  paper sweeps (`docs/benchmarks.md`, `ns3/tools/run-scenarios.py`) define the
+  metrics. Caveat: absolute PDR is low across *all* protocols pending PHY/channel
+  fidelity work (#24) — relative comparisons are valid, absolute numbers aren't
+  yet paper-like.
 - Are the `Config` defaults (`alpha`/`betaAnts`/`betaData`/`gamma`, intervals, `maxPathLength`,
   `maxHistory`) the right operating point, or should they be tuned per
-  simulator?
+  simulator? (See #23 convergence, #26 fidelity.)


### PR DESCRIPTION
Makes the agent-facing docs a complete brief so a **fresh session can pick up the issue backlog cold**, without rediscovering this session's working knowledge.

## Changes
- **`AGENTS.md`**
  - New **"Validating adapter (NS-2/NS-3) changes — use CI"** section: the one thing not written down — you can't build a simulator from this repo, so you push a branch and let the `ns3-build` matrix + ns2 jobs compile it, iterating on cross-version API drift (the macros already gate the known ones).
  - Replaced the **stale active-branch line** with the real workflow (Conventional-Commit PR titles, squash, green-CI merge).
  - Extended **"Where to look"** with backlog / benchmark / observability / release rows.
- **`CONTEXT.md`**
  - §7 current-state refreshed (observability, auto-published benchmark taxonomy, versioning/release).
  - §10 now points at the **GitHub issue backlog** (epics #26–#31, defects #19–#25) and names **#19 (NS-3 MAC repair hook)** as the highest-leverage next item — with the NS-2 reference (`ahn_router.cc::linkFailed`) to mirror.

## Also (tracker, not in the diff)
Wired the **sub-issue hierarchy**: epics own their items (#33→#26, #19→#27, #24/#25→#28, #32→#31) and **root-cause #19 owns its symptom issues** (#20/#21), so progress rolls up. Confirmed the `.gitattributes` from #34 took effect — the repo now reports **`language: C++`**.

## Net
After this, a new session's brief is: read `AGENTS.md` + `CONTEXT.md` → open the issues → start on **#19**. Docs-only; no CI-path impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GczoAwKTzys91p5wQ4WehK)_