### PR TITLE
fix: correct and expand README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # AntHocNet
 
-[![Release](https://img.shields.io/github/v/release/danieljoppi/AntHocNet?sort=semver)](https://github.com/danieljoppi/AntHocNet/releases)
+[![CI](https://github.com/danieljoppi/AntHocNet/actions/workflows/ci.yml/badge.svg)](https://github.com/danieljoppi/AntHocNet/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/danieljoppi/AntHocNet?sort=semver&cacheSeconds=1800)](https://github.com/danieljoppi/AntHocNet/releases)
 [![Cite](https://img.shields.io/badge/cite-CITATION.cff-blue)](CITATION.cff)
 [![License: GPL v2](https://img.shields.io/badge/license-GPL--2.0-blue)](LICENSE)
+[![C++14](https://img.shields.io/badge/C%2B%2B-14-blue?logo=cplusplus)](CONTRIBUTING.md)
+[![Simulators](https://img.shields.io/badge/simulators-ns--2%20%C2%B7%20ns--3-informational)](#)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow)](https://www.conventionalcommits.org)
+[![Top language](https://img.shields.io/github/languages/top/danieljoppi/AntHocNet)](#)
 
 An ant-colony-optimization routing protocol for mobile ad-hoc networks,
 implemented once as a **simulator-agnostic algorithm core** with thin adapters


### PR DESCRIPTION
Fixes the misleading `release | no releases found` badge (stale shields.io/Camo cache from before v0.1.0 existed) and expands the badge row with accurate signals. **Closes #40.**

## Added
- **CI** build status (`ci.yml`) — real matrix signal.
- **C++14**, **simulators (ns-2 · ns-3)**, **Conventional Commits** — accurate static facts.
- **Top language** — resolves to C++ after the `.gitattributes` fix (#34).
- `cacheSeconds=1800` on the release badge to refresh the stale cache sooner.

No coverage/fake badges (nothing backs them).

## Why `fix:` (and what happens next)
This is a user-facing fix (a wrong badge), so it's a `fix:` → patch bump. After merge I'll run the **Release** workflow (`mode=bump`) to cut **v0.1.1**, which — now that the repo is linked to Zenodo (#39, toggle ON) — gets archived and **mints the DOI**. Then the DOI lands in `CITATION.cff` + a DOI badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GczoAwKTzys91p5wQ4WehK)_