### PR TITLE
docs: add Zenodo DOI to CITATION.cff and README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,11 +11,11 @@ authors:
     given-names: Daniel Henrique
     # orcid: "https://orcid.org/0000-0000-0000-0000"  # add if available
 version: 0.1.1
-date-released: "2026-06-27"
+date-released: "2026-06-28"
 license: GPL-2.0-only
 repository-code: "https://github.com/danieljoppi/AntHocNet"
 url: "https://github.com/danieljoppi/AntHocNet"
-# doi: "10.5281/zenodo.XXXXXXX"   # added after the first Zenodo-archived release
+doi: "10.5281/zenodo.20981980"
 keywords:
   - MANET
   - ad hoc networks

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/danieljoppi/AntHocNet/actions/workflows/ci.yml/badge.svg)](https://github.com/danieljoppi/AntHocNet/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/danieljoppi/AntHocNet?sort=semver&cacheSeconds=1800)](https://github.com/danieljoppi/AntHocNet/releases)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20981980.svg)](https://doi.org/10.5281/zenodo.20981980)
 [![Cite](https://img.shields.io/badge/cite-CITATION.cff-blue)](CITATION.cff)
 [![License: GPL v2](https://img.shields.io/badge/license-GPL--2.0-blue)](LICENSE)
 [![C++14](https://img.shields.io/badge/C%2B%2B-14-blue?logo=cplusplus)](CONTRIBUTING.md)


### PR DESCRIPTION
The repo is now archived on Zenodo (DOI **`10.5281/zenodo.20981980`**). Wires it into the citation metadata + adds the DOI badge.

- `CITATION.cff`: set `doi:` (replaces the placeholder); fix `date-released` to the v0.1.1 date. Validated as well-formed CFF.
- `README.md`: add the Zenodo **DOI badge** next to the release badge.

**Closes #39.**

Note: this DOI is the one you pasted (the version DOI for v0.1.1, or the concept DOI). If Zenodo also gave you a separate **concept DOI** (the "always-latest" one), that's the preferred value for `CITATION.cff` — say the word and I'll swap it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GczoAwKTzys91p5wQ4WehK)_