### PR TITLE
fix(core): debounce detector D to stop the link-failure storm (#19)

### DIFF
--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -170,6 +170,8 @@ private:
     std::map<NodeAddress, double> activeSessions_;  ///< dest -> last data-send time
     std::map<NodeAddress, double> lastSeen_;        ///< neighbor -> last reception time
     std::map<NodeAddress, double> lastReactive_;    ///< dest -> last reactive-ant time
+    std::map<NodeAddress, double> lastRepair_;      ///< dest -> last repair-ant time
+    std::map<NodeAddress, int>    txFailures_;      ///< next hop -> consecutive MAC tx-failures (detector D debounce)
     double lastEvaporation_ = 0.0;                  ///< last evaporateAll time
 
     IRouterObserver* observer_ = nullptr;           ///< optional, item 15

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -68,6 +68,13 @@ struct Config {
     /// Max times a repair / link-failure ant may be (re)broadcast before being
     /// dropped, so local repair and failure notifications can't storm ([1] §3.5).
     int repairMaxBroadcasts = 2;
+    /// Consecutive MAC transmit-failures to the same next hop (with no reception
+    /// from it in between) before the adapter's fast-path detector (ADR-0008
+    /// detector D) treats the link as broken. Debounces transient congestion
+    /// drops: a single retry-limit drop in a dense/contended network is usually a
+    /// collision, not a topology change, and evicting the neighbour on it
+    /// destroys valid routes and triggers rediscovery floods (issue #19).
+    int txFailureThreshold = 3;
     /// Max times a reactive forward ant may be (re)broadcast in a region with no
     /// pheromone, so route setup doesn't flood ([1] §3.2).
     int reactiveMaxBroadcasts = 2;

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -24,6 +24,7 @@ void AntRouterLogic::learnNeighbor(NodeAddress neighbor) {
     // Seed an equal-weight regular entry, as the legacy recvAHN did.
     engine_.updateRegular(table_, neighbor, neighbor, 1.0);
     lastSeen_[neighbor] = clock_.now();  // liveness: any reception refreshes it
+    txFailures_.erase(neighbor);         // a reception clears the tx-failure streak (#19)
     if (isNew && observer_) observer_->onRouteChanged(neighbor, neighbor, true);
 }
 
@@ -31,6 +32,7 @@ void AntRouterLogic::loseNeighbor(NodeAddress neighbor) {
     const bool had = lastSeen_.find(neighbor) != lastSeen_.end();
     engine_.cleanNeighbor(table_, neighbor);
     lastSeen_.erase(neighbor);
+    txFailures_.erase(neighbor);
     if (had && observer_) observer_->onRouteChanged(neighbor, neighbor, false);
 }
 
@@ -120,19 +122,37 @@ std::vector<RouteDecision> AntRouterLogic::reportNeighborLoss(NodeAddress n) {
 
 std::vector<RouteDecision> AntRouterLogic::reportTxFailure(NodeAddress next,
                                                           NodeAddress dataDest) {
-    // Detector D and detector A converge here: prune `next` and emit any
-    // LinkFail notifications its loss triggers.
+    if (next == kInvalidAddress) return {};
+
+    // Debounce (issue #19): a single retry-limit drop in a dense/contended
+    // network is usually a collision, not a topology change. Evicting the
+    // neighbour on it destroys valid routes and triggers rediscovery floods
+    // (proactive ants re-broadcast unbounded when no route survives), which add
+    // contention and cause more drops — a positive-feedback storm. So only treat
+    // the link as broken after txFailureThreshold consecutive failures with no
+    // intervening reception (any reception resets the counter via learnNeighbor).
+    if (++txFailures_[next] < config_.txFailureThreshold) return {};
+    txFailures_.erase(next);
+
+    // Real break: prune `next` and emit any LinkFail notifications (detector A
+    // and D converge on this path).
     std::vector<RouteDecision> out = reportNeighborLoss(next);
 
-    // Bounded local repair ([1] §3.5): for a failed *data* packet, broadcast a
-    // repair ant toward the lost destination instead of waiting for the next
-    // reactive/proactive ant. broadcastForward counts it (so --diag shows
-    // repair>0) and honours broadcastBudget (= repairMaxBroadcasts), capping
-    // re-broadcasts network-wide.
-    if (dataDest != kInvalidAddress && dataDest != address_) {
-        AntMessage rrfa = createForwardAnt(AntType::Repair, dataDest);
-        rrfa.lifeAnt = config_.lifeAnt;
-        out.push_back(broadcastForward(rrfa));
+    // Bounded local repair ([1] §3.5): only "if there is no other path
+    // available" — after the loss, if a route to dataDest survives via another
+    // neighbour, skip the repair ant. Rate-limit per destination so a burst of
+    // failures to one dest can't spawn a stream of repair ants. broadcastForward
+    // counts the ant (--diag repair>0) and caps re-broadcasts (repairMaxBroadcasts).
+    if (dataDest != kInvalidAddress && dataDest != address_ &&
+        table_.bestRegular(dataDest) <= config_.minPheromone) {
+        const double now = clock_.now();
+        auto it = lastRepair_.find(dataDest);
+        if (it == lastRepair_.end() || now - it->second >= config_.reactiveRetryInterval) {
+            lastRepair_[dataDest] = now;
+            AntMessage rrfa = createForwardAnt(AntType::Repair, dataDest);
+            rrfa.lifeAnt = config_.lifeAnt;
+            out.push_back(broadcastForward(rrfa));
+        }
     }
     return out;
 }

--- a/core/tests/test_link_failure.cpp
+++ b/core/tests/test_link_failure.cpp
@@ -154,13 +154,15 @@ int main() {
         CHECK(d3[0].action == RouteAction::Drop);
     }
 
-    // 7. reportTxFailure (detector D): losing the data next hop prunes it, emits
-    //    a LinkFail notification, and broadcasts a counted bounded Repair ant
-    //    toward the failed data destination.
+    // 7. reportTxFailure (detector D): once the consecutive-failure threshold is
+    //    reached, losing the data next hop prunes it, emits a LinkFail
+    //    notification, and broadcasts a counted bounded Repair ant toward the
+    //    failed data destination (no alternate path survives).
     {
+        Config cfg1 = cfg; cfg1.txFailureThreshold = 1;  // act on the first failure
         FakeClock clock;
         ScriptedRng rng({0.5});
-        AntRouterLogic router(/*addr*/ 0, cfg, clock, rng);
+        AntRouterLogic router(/*addr*/ 0, cfg1, clock, rng);
         router.learnNeighbor(5);
         router.table().setPheromoneRegular(/*dest*/ 9, /*neighbor*/ 5, 0.8);
 
@@ -173,7 +175,7 @@ int main() {
             if (d.message.type == AntType::Repair) {
                 repair = true;
                 CHECK_EQ(d.message.dst, static_cast<NodeAddress>(9));
-                CHECK_EQ(d.message.broadcastBudget, cfg.repairMaxBroadcasts - 1);
+                CHECK_EQ(d.message.broadcastBudget, cfg1.repairMaxBroadcasts - 1);
             }
         }
         CHECK(linkFail);
@@ -185,9 +187,10 @@ int main() {
     // 8. reportTxFailure for a failed *ant* (no dataDest) cleans up but sends no
     //    repair ant.
     {
+        Config cfg1 = cfg; cfg1.txFailureThreshold = 1;
         FakeClock clock;
         ScriptedRng rng({0.5});
-        AntRouterLogic router(/*addr*/ 0, cfg, clock, rng);
+        AntRouterLogic router(/*addr*/ 0, cfg1, clock, rng);
         router.learnNeighbor(5);
 
         auto decs = router.reportTxFailure(/*next*/ 5);
@@ -196,6 +199,45 @@ int main() {
         }
         CHECK_EQ(router.antsSent(AntType::Repair), static_cast<std::uint64_t>(0));
         CHECK_EQ(router.table().numNeighbors(), static_cast<std::size_t>(0));
+    }
+
+    // 9. Debounce (issue #19): failures below the threshold do NOT evict, and a
+    //    reception in between resets the streak so transient drops are absorbed.
+    {
+        Config cfg3 = cfg; cfg3.txFailureThreshold = 3;
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 0, cfg3, clock, rng);
+        router.learnNeighbor(5);
+
+        CHECK(router.reportTxFailure(5, 9).empty());   // 1
+        CHECK(router.reportTxFailure(5, 9).empty());   // 2 (still < 3)
+        CHECK_EQ(router.table().numNeighbors(), static_cast<std::size_t>(1));
+
+        router.learnNeighbor(5);                       // reception resets the streak
+        CHECK(router.reportTxFailure(5, 9).empty());   // 1 again
+        CHECK(router.reportTxFailure(5, 9).empty());   // 2
+        CHECK_EQ(router.table().numNeighbors(), static_cast<std::size_t>(1));
+
+        router.reportTxFailure(5, 9);                  // 3 -> evict
+        CHECK_EQ(router.table().numNeighbors(), static_cast<std::size_t>(0));
+    }
+
+    // 10. Repair guard ([1] §3.5 "no other path available"): if a route to the
+    //     destination survives via another neighbour, no repair ant is sent.
+    {
+        Config cfg1 = cfg; cfg1.txFailureThreshold = 1;
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 0, cfg1, clock, rng);
+        router.learnNeighbor(5);
+        router.learnNeighbor(6);
+        router.table().setPheromoneRegular(/*dest*/ 9, /*neighbor*/ 5, 0.8);
+        router.table().setPheromoneRegular(/*dest*/ 9, /*neighbor*/ 6, 0.5);  // alternate
+
+        router.reportTxFailure(/*next*/ 5, /*dataDest*/ 9);  // lose 5, but 6 remains
+        CHECK_EQ(router.antsSent(AntType::Repair), static_cast<std::uint64_t>(0));
+        CHECK(router.table().getPheromoneRegular(9, 6) > 0.0);  // alternate intact
     }
 
     return RUN_TESTS();

--- a/ns3/test/anthocnet-test-suite.cc
+++ b/ns3/test/anthocnet-test-suite.cc
@@ -243,8 +243,13 @@ public:
 
         Ptr<Socket> tx = Socket::CreateSocket(nodes.Get(0), UdpSocketFactory::GetTypeId());
         tx->Connect(InetSocketAddress(ifs.GetAddress(1), port));
-        // Send across the whole run so a live session exists before and after the break.
-        for (double t = 5.0; t < 28.0; t += 0.5) {
+        // Send densely so a live session exists before the break and, after it,
+        // detector D reaches Config::txFailureThreshold consecutive MAC drops
+        // (the #19 debounce) well before detector A's hello-timeout (~2 s) would
+        // evict the moved node — otherwise A removes it first and D never fires
+        // the repair. The simulation is deterministic (fixed seed/run), so this
+        // ordering is stable across ns-3 versions.
+        for (double t = 5.0; t < 28.0; t += 0.1) {
             Simulator::Schedule(Seconds(t), &RepairAntOnLinkBreakTestCase::Send, this, tx);
         }
 


### PR DESCRIPTION
Follow-up to #43 (issue #19). Full investigation in [this comment](https://github.com/danieljoppi/AntHocNet/issues/19#issuecomment-4826657475).

## Problem

#43 wired the NS-3 MAC tx-failure hook and `repair > 0` now fires, but a clean A/B on the **paper benchmark** (identical scenario; AODV/OLSR/DSDV columns byte-identical, so AntHocNet is the only variable) showed it **regressed** the protocol:

| metric | baseline `655e66d` | after #43 | Δ |
|---|---|---|---|
| PDR % | 22.7 | 19.7 | −3.0 pts |
| mean delay (ms) | 335 | 705 | +110% |
| delay99 (ms) | 8166 | 9172 | +12% |
| NRL | 167.9 | 274.2 | +63% |

## Root cause

`reportTxFailure` evicted the neighbour + all its pheromone on **every** `WIFI_MAC_DROP_REACHED_RETRY_LIMIT`. In a dense/contended network most retry-limit drops are transient collisions, not breaks; each false eviction destroys valid routes, so **proactive forward ants (`broadcastBudget = -1`, unbounded) flood-rebroadcast** when no route survives (+177% proactive ants), adding contention → more drops → more evictions (positive-feedback storm; ctrlTx +42%). Detector A (hello-timeout) already gave authoritative detection and AntHocNet was better with A alone.

## Fix (core, shared by both adapters)

1. **Debounce D** — `Config::txFailureThreshold` (=3): treat a next hop as broken only after N *consecutive* retry-limit failures with no reception in between; any reception (`learnNeighbor`) resets the streak.
2. **Repair guard** ([1] §3.5 *"no other path available"*): skip the repair ant if a route to the destination survives via another neighbour.
3. **Rate-limit** repair ants per destination (`reactiveRetryInterval`).

`repair > 0` is preserved (real breaks still detected, ~1s faster than A). Detector A remains authoritative.

## Testing

- `make test` 17/17 green; added debounce + repair-guard core cases.
- NS-3 build + the wifi `repair>0` test run in CI across ns-3.36–3.48.
- **Paper-benchmark validation in progress** ([run 28328113554](https://github.com/danieljoppi/AntHocNet/actions/runs/28328113554)); I'll post the A/B vs the `22.7 / 335 / 8166 / 167.9` baseline here. **Do not merge until it beats baseline** — if it can't, the alternative is to disable detector D by default (keep A authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmPv8qudiSeoXQj5Wf8Usx)_