### PR TITLE
docs: add ADR-0013 issue-tracking policy + detector-D handoff (#19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ results.
 | Understand the design & decision flow | `docs/architecture.md` |
 | Understand a structural decision / its "why" | `docs/adr/` |
 | **Pick up open work** | GitHub issues (epics #26–#31; defects #19–#25) + `docs/improvements/` |
+| Record a bug / finding, or hand off across sessions | [ADR-0013](docs/adr/0013-track-bugs-and-findings-as-issues.md) (always open/update an issue) + [`docs/handoffs/`](docs/handoffs/) |
 | Maintain the NS-2 patch / wire format | `docs/porting-notes.md`, `ns2/patch/` |
 | Change the algorithm | `core/src/`, `core/include/anthocnet/core/` |
 | Change routing policy / decision flow | `core/src/ant_router_logic.cpp` |

--- a/docs/adr/0013-track-bugs-and-findings-as-issues.md
+++ b/docs/adr/0013-track-bugs-and-findings-as-issues.md
@@ -1,0 +1,71 @@
+# ADR-0013: Track every bug and finding as a GitHub issue
+
+- **Status:** Accepted
+- **Date:** 2026-06-28
+
+## Context
+
+This repository is developed by a mix of human and LLM contributors, often across
+many short, **stateless** sessions (a new AI chat starts with no memory of the
+last). [`AGENTS.md`](../../AGENTS.md) already points contributors to "pick up open
+work" from GitHub issues, but it does not say how findings should be *recorded* as
+work proceeds.
+
+The #19 work made the cost of not having a rule concrete:
+
+- A change was implemented, merged (#43), and only **afterwards** found — via the
+  paper benchmark — to have **regressed** the protocol in its design regime (PDR
+  22.7→19.7%, NRL 167.9→274.2). See
+  [#19 root-cause comment](https://github.com/danieljoppi/AntHocNet/issues/19#issuecomment-4826657475).
+- The investigation that produced the fix (#44) surfaced **several distinct,
+  separable follow-ups** (a latent unbounded proactive broadcast; NS-2 data-reinject
+  parity; two noisy benchmark cells) that had nothing to do with finishing #19.
+
+If those findings live only in a chat transcript, they vanish when the session
+ends, and the next contributor re-discovers the same bug or loses the benchmark
+evidence that justified a decision.
+
+## Decision
+
+**Every bug, regression, or non-trivial finding becomes durable on GitHub before
+the session ends** — as a new issue, or as a comment on the relevant existing one.
+
+1. **New, separable problem → new issue.** Do not smuggle unrelated fixes into an
+   in-flight PR or let them expand its scope; open a focused issue and cross-link
+   it. (Examples from #19: #45, #46, #47.)
+2. **Finding that extends a known problem → comment on that issue.** The issue is
+   the **durable thread of record** for an investigation; append evidence as you
+   go rather than keeping it in chat. (Examples: the root-cause, fix, and taxonomy
+   comments on #19.)
+3. **Each issue carries enough to act on without the chat:**
+   - symptom + **evidence** (benchmark numbers, `--diag` lines, CI/job links);
+   - root cause when known;
+   - **code references** as `file:line`;
+   - links to related issues / PRs / ADRs / benchmark runs.
+4. **PRs reference the issue(s) they resolve**, and the squash-merge title is a
+   Conventional Commit (see [`CONTRIBUTING.md`](../../CONTRIBUTING.md)). A merged PR
+   is not the end of the record — post the post-merge outcome (e.g. benchmark
+   result) back to the issue.
+5. **Cross-session handoff** that spans several issues/PRs is captured under
+   [`docs/handoffs/`](../handoffs/) so a fresh AI chat (or human) can bootstrap
+   from one document with all the links, then drop into the issues for detail.
+
+This formalises, rather than replaces, the existing "pick up open work from
+issues" guidance in `AGENTS.md`.
+
+## Alternatives considered
+
+- **Rely on chat history / commit messages only.** Chats are stateless across
+  sessions and not searchable by the next contributor; commit messages describe a
+  change, not an open problem. Rejected — this is exactly what bit #19.
+- **One mega-issue per area.** Becomes an unreadable catch-all and can't be closed;
+  loses the one-focused-change-per-PR mapping. Rejected in favour of focused,
+  cross-linked issues.
+
+## Consequences
+
+- Findings and their evidence survive session boundaries and are discoverable.
+- A new AI chat can be primed from an issue (+ a handoff doc) instead of
+  re-deriving context.
+- Slightly more issue/comment bookkeeping per session — the cost the #19
+  regression showed is worth paying.

--- a/docs/handoffs/2026-06-28-detector-d-link-failure.md
+++ b/docs/handoffs/2026-06-28-detector-d-link-failure.md
@@ -1,0 +1,103 @@
+# Handoff — Issue #19: NS-3 MAC tx-failure detector (detector D)
+
+> **Purpose.** Prime a fresh session (AI or human) on the detector-D / link-failure
+> work without replaying the chat. Per [ADR-0013](../adr/0013-track-bugs-and-findings-as-issues.md),
+> the GitHub issues are the durable record; this file is the index + context.
+>
+> **Date:** 2026-06-28 · **Status:** #19 resolved on `main`; follow-ups #45/#46/#47 open.
+
+## TL;DR
+
+- **#19** asked to wire the NS-3 MAC transmit-failure repair hook (ADR-0008
+  **detector D**) so route-repair ants fire (`repair=0` → `repair>0`).
+- **#43** implemented it and was merged — then the paper benchmark showed it
+  **regressed** AntHocNet in its design regime (the repair/notification machinery
+  fired on every transient MAC drop → control-traffic storm).
+- **#44** root-caused and fixed it (debounce + repair guard + rate-limit),
+  **recovering** the regression while keeping `repair>0`. Merged.
+- **Honest conclusion:** detector D is **neutral**, not the hoped-for win, vs the
+  hello-timeout detector (A) that already existed. Net positive of the episode is
+  the debounce + the follow-ups below.
+
+## Timeline & artifacts
+
+| What | Where | Outcome |
+|---|---|---|
+| Ticket | [#19](https://github.com/danieljoppi/AntHocNet/issues/19) | open until follow-ups land |
+| Hook impl | PR [#43](https://github.com/danieljoppi/AntHocNet/pull/43) → `13e7d9a` | merged; **regressed** |
+| Debounce fix | PR [#44](https://github.com/danieljoppi/AntHocNet/pull/44) → `83dd759` | merged; **recovered** |
+| Root-cause writeup | [#19 comment](https://github.com/danieljoppi/AntHocNet/issues/19#issuecomment-4826657475) | — |
+| Fix A/B writeup | [#19 comment](https://github.com/danieljoppi/AntHocNet/issues/19#issuecomment-4826694839) | — |
+| Taxonomy A/B writeup | [#19 comment](https://github.com/danieljoppi/AntHocNet/issues/19#issuecomment-4826812073) | — |
+
+Benchmark runs (manual `paper-benchmark.yml`, 50 nodes / 1500×300 m / 20 m/s / pause 30 / 3 seeds):
+- baseline (pre-#43, `655e66d`): [run 28289586841](https://github.com/danieljoppi/AntHocNet/actions/runs/28289586841)
+- regression (#43, `f05df76`): [run 28322221683](https://github.com/danieljoppi/AntHocNet/actions/runs/28322221683)
+- fix (#44, `556193d`): [run 28328113554](https://github.com/danieljoppi/AntHocNet/actions/runs/28328113554)
+- post-merge taxonomy (`benchmarks.yml`, `83dd759`): [run 28328544294](https://github.com/danieljoppi/AntHocNet/actions/runs/28328544294)
+
+## The numbers (paper benchmark, mean of 3 seeds)
+
+| metric | baseline (A only) | regression (#43, A+D) | fix (#44, debounced D) | AODV |
+|---|---|---|---|---|
+| PDR % | 22.7 | 19.7 | 21.9 | 22.4 |
+| mean delay (ms) | 335 | 705 | 452 | 214 |
+| delay99 (ms) | 8166 | 9172 | 8693 | 3602 |
+| NRL | 167.9 | 274.2 | 175.8 | 220.7 |
+
+Ant volumes that explained it (`antTx`, mean of 3): proactive **8.9k → 24.7k**
+(+177%) and `antRx[linkfail]` 220k → 333k under #43; ctrlTx +42%.
+
+## Root cause (one paragraph)
+
+`AntRouterLogic::reportTxFailure` called `reportNeighborLoss` (full neighbour +
+pheromone eviction) on **every** `WIFI_MAC_DROP_REACHED_RETRY_LIMIT`. In a dense /
+contended network most retry-limit drops are transient collisions, not breaks, so
+valid routes were destroyed; the resulting route gaps made **proactive forward
+ants — which carry `broadcastBudget = -1` (unbounded) — flood-rebroadcast**, adding
+contention → more drops → more evictions (positive-feedback storm). Detector A
+(hello-timeout) already detected breaks authoritatively, and the protocol was
+better with A alone.
+
+## The fix (#44)
+
+Core, shared by both adapters:
+1. **Debounce D** — `Config::txFailureThreshold` (=3) consecutive failures with no
+   reception in between (any reception via `learnNeighbor` resets the streak).
+2. **Repair guard** — only repair if no alternate route survives ([1] §3.5).
+3. **Rate-limit** repair ants per destination (`reactiveRetryInterval`).
+
+## Key code locations
+
+- Core decision logic: `core/src/ant_router_logic.cpp`
+  — `reportTxFailure`, `reportNeighborLoss`, `loseNeighbor`/`learnNeighbor`
+  (debounce reset), `createForwardAnt` (the `broadcastBudget = -1` for proactive),
+  forward-ant dispatch / `broadcastForward`.
+- Core config: `core/include/anthocnet/core/config.h` (`txFailureThreshold`,
+  `repairMaxBroadcasts`, `allowedHelloLoss`).
+- Core tests: `core/tests/test_link_failure.cpp` (cases 7–10: tx-failure, debounce,
+  repair guard).
+- NS-3 adapter: `ns3/model/anthocnet-routing-protocol.cc`
+  — `NotifyTxError` (WifiMac `DroppedMpdu` hook), `MapMacToCore` (ARP), `NotifyInterfaceUp`.
+- NS-3 test: `ns3/test/anthocnet-test-suite.cc` (`RepairAntOnLinkBreakTestCase`).
+- NS-2 reference: `ns2/src/ahn_router.cc` (`linkFailed`).
+- Design: ADR-0008 (two detectors), `docs/improvements/05-link-failure-detection-and-repair.md` (sub-step D).
+
+## Open follow-ups
+
+- **#45** — bound the proactive forward-ant broadcast (`broadcastBudget = -1`); the
+  latent amplifier behind the storm. *P2, core.*
+- **#46** — detector D: re-inject the failed data packet (NS-2 parity) + expose
+  `txFailureThreshold` as an ns-3 attribute and decide whether D stays on by
+  default (it's currently neutral). *P2, core + NS-3.*
+- **#47** — confirm two noisy quick-taxonomy cells (dense-small mean delay,
+  heavy-load delay99) with a higher run count. *P3, bench.*
+
+## How to continue
+
+1. Read [#19](https://github.com/danieljoppi/AntHocNet/issues/19) top-to-bottom
+   (problem → root cause → fix → taxonomy), then the relevant follow-up issue.
+2. `make test` (core) before any core change; adapter changes are validated by the
+   CI matrix (ns-3.36–3.48) — see [`AGENTS.md`](../../AGENTS.md).
+3. Re-benchmark protocol changes with the manual `paper-benchmark` workflow and
+   post the A/B back to the issue (ADR-0013).


### PR DESCRIPTION
Documents the #19 detector-D episode and establishes a policy so findings survive across (stateless) sessions.

## What's here

- **`docs/adr/0013-track-bugs-and-findings-as-issues.md`** — ADR: always open a GitHub issue for a new bug/finding (or comment on the existing one); issues are the durable thread of record and must carry evidence + `file:line` references + cross-links; PRs reference their issue and post the post-merge outcome back; cross-session context lives in `docs/handoffs/`. Formalises the "pick up open work from issues" guidance already in `AGENTS.md`. Prompted by #19 — where #43 was merged and only afterwards found to regress benchmarks, and the fix investigation surfaced separable follow-ups (#45/#46/#47).
- **`docs/handoffs/2026-06-28-detector-d-link-failure.md`** — a single index to bootstrap a fresh session: the #19 → #43 → #44 → #45/#46/#47 arc, before/after benchmark tables, root cause, key code locations, and all issue/PR/commit/run links.
- **`AGENTS.md`** — one row pointing to ADR-0013 + `docs/handoffs/`.

Docs-only; no code changes.

## Related
- Issue #19 (resolved on `main` via #43 + #44); follow-ups #45 (bound proactive broadcast), #46 (detector-D re-inject / opt-in), #47 (benchmark noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmPv8qudiSeoXQj5Wf8Usx)_