### PR TITLE
feat(core): bound proactive broadcasts and add repair wait/discard timer

### DIFF
--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -62,7 +62,10 @@ public:
     /// Periodic liveness/maintenance tick (driven by the adapter hello timer):
     /// expire neighbours not heard from within helloInterval*allowedHelloLoss
     /// (the portable, NS-3-mandatory detector — ADR-0008) and return any
-    /// link-failure notifications to broadcast.
+    /// link-failure notifications to broadcast. Also expires timed-out local
+    /// repairs ([1] §3.5, D6): a repair with no backward ant within its wait
+    /// window yields a DiscardPending for the destination's buffered packets
+    /// plus a LinkFail notification.
     std::vector<RouteDecision> onMaintenanceTick();
 
     /// Remove neighbour `n` and, for every destination whose best path it
@@ -171,6 +174,7 @@ private:
     std::map<NodeAddress, double> lastSeen_;        ///< neighbor -> last reception time
     std::map<NodeAddress, double> lastReactive_;    ///< dest -> last reactive-ant time
     std::map<NodeAddress, double> lastRepair_;      ///< dest -> last repair-ant time
+    std::map<NodeAddress, double> repairDeadline_;  ///< dest -> repair wait expiry (D6)
     std::map<NodeAddress, int>    txFailures_;      ///< next hop -> consecutive MAC tx-failures (detector D debounce)
     double lastEvaporation_ = 0.0;                  ///< last evaporateAll time
 

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -78,6 +78,21 @@ struct Config {
     /// Max times a reactive forward ant may be (re)broadcast in a region with no
     /// pheromone, so route setup doesn't flood ([1] §3.2).
     int reactiveMaxBroadcasts = 2;
+    /// Max times a proactive forward ant may be (re)broadcast — covering both the
+    /// per-hop exploratory broadcast ([1] §3.3) and a route gap en route. Proactive
+    /// ants monitor known paths; an unbounded budget let them flood any region of
+    /// missing routes, amplifying route churn into control storms (issue #45).
+    int proactiveMaxBroadcasts = 2;
+
+    /// Local repair wait ([1] §3.5): after launching a repair ant, wait
+    /// repairWaitFactor × the estimated end-to-end delay of the lost path for a
+    /// backward repair ant; if none arrives, discard the buffered packets for
+    /// that destination and send a link-failure notification (spec D6). The
+    /// paper sets the factor empirically to 5.
+    double repairWaitFactor = 5.0;
+    /// Flat repair wait (seconds) used when the lost path has no usable delay
+    /// estimate (e.g. its pheromone was already gone).
+    double repairTimeout = 1.0;
 
     /// Conservative upper bound on path length for the expanding-ring search.
     int networkDiameter = 30;

--- a/core/include/anthocnet/core/route_decision.h
+++ b/core/include/anthocnet/core/route_decision.h
@@ -22,6 +22,8 @@ enum class RouteAction {
     Queue,      ///< Hold the data packet pending a route to `nextHop`/dst.
     Deliver,    ///< Destination reached: hand to the local transport.
     Drop,       ///< Discard (loop, TTL, no route).
+    DiscardPending,  ///< Local repair timed out ([1] §3.5, D6): discard the
+                     ///< data packets queued for destination `nextHop`.
 };
 
 struct RouteDecision {

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -57,6 +57,32 @@ std::vector<RouteDecision> AntRouterLogic::onMaintenanceTick() {
         std::vector<RouteDecision> notes = reportNeighborLoss(n);
         out.insert(out.end(), notes.begin(), notes.end());
     }
+
+    // Local-repair wait/discard ([1] §3.5, D6): a repair that got no backward
+    // ant within its window has failed — tell the adapter to discard the
+    // packets buffered for that destination (the paper trades PDR for a bounded
+    // delay tail here) and send the deferred link-failure notification. If a
+    // route reappeared some other way (reactive ant, diffusion), just forget
+    // the deadline; the normal flush path handles the queue.
+    for (auto it = repairDeadline_.begin(); it != repairDeadline_.end();) {
+        if (now < it->second) { ++it; continue; }
+        const NodeAddress dest = it->first;
+        it = repairDeadline_.erase(it);
+        if (table_.bestRegular(dest) > config_.minPheromone) continue;
+
+        out.push_back({RouteAction::DiscardPending, dest, false, {}});
+
+        AntMessage note;
+        note.type            = AntType::LinkFail;
+        note.direction       = AntDirection::Up;
+        note.src             = address_;
+        note.dst             = kInvalidAddress;
+        note.seqNum          = nextSeq();
+        note.timeStart       = now;
+        note.broadcastBudget = config_.repairMaxBroadcasts;
+        note.helloDests.push_back({dest, 0.0});  // repair failed: no path left
+        out.push_back(broadcastForward(note));
+    }
     return out;
 }
 
@@ -134,6 +160,16 @@ std::vector<RouteDecision> AntRouterLogic::reportTxFailure(NodeAddress next,
     if (++txFailures_[next] < config_.txFailureThreshold) return {};
     txFailures_.erase(next);
 
+    // Estimated end-to-end delay of the path we are about to lose, for the
+    // repair wait window ([1] §3.5: wait ~5× that delay). Pheromone is inverse
+    // goodness in time units (item 03), so delay ≈ 1/pheromone; captured before
+    // the prune below removes the entry.
+    double lostPathDelay = 0.0;
+    if (dataDest != kInvalidAddress) {
+        const double best = table_.bestRegular(dataDest);
+        if (best > config_.minPheromone) lostPathDelay = 1.0 / best;
+    }
+
     // Real break: prune `next` and emit any LinkFail notifications (detector A
     // and D converge on this path).
     std::vector<RouteDecision> out = reportNeighborLoss(next);
@@ -152,6 +188,12 @@ std::vector<RouteDecision> AntRouterLogic::reportTxFailure(NodeAddress next,
             AntMessage rrfa = createForwardAnt(AntType::Repair, dataDest);
             rrfa.lifeAnt = config_.lifeAnt;
             out.push_back(broadcastForward(rrfa));
+            // Arm the wait/discard window (D6): a backward ant from dataDest
+            // cancels it; onMaintenanceTick fires it.
+            const double wait = lostPathDelay > 0.0
+                                    ? config_.repairWaitFactor * lostPathDelay
+                                    : config_.repairTimeout;
+            repairDeadline_[dataDest] = now + wait;
         }
     }
     return out;
@@ -234,11 +276,12 @@ AntMessage AntRouterLogic::createForwardAnt(AntType type, NodeAddress dest) {
     m.dst       = dest;
     m.seqNum    = nextSeq();
     m.timeStart = clock_.now();
-    // Reactive and repair ants cap their broadcasts ([1] §3.2/§3.5); proactive
-    // ants are untracked (their per-hop explore prob + dedup bound them).
+    // Every forward-ant type caps its broadcasts: reactive/repair per
+    // [1] §3.2/§3.5, and proactive too (issue #45) — an unbounded proactive
+    // budget let route gaps turn the path monitor into a network-wide flood.
     if (type == AntType::Repair)        m.broadcastBudget = config_.repairMaxBroadcasts;
     else if (type == AntType::Reactive) m.broadcastBudget = config_.reactiveMaxBroadcasts;
-    else                                m.broadcastBudget = -1;
+    else                                m.broadcastBudget = config_.proactiveMaxBroadcasts;
     m.visited.push_back({address_, 0.0});  // source node enters the stack
     return m;
 }
@@ -400,12 +443,14 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
 
         NodeAddress next = selectNextHop(ant.dst, proactive);
         if (next == kInvalidAddress) {
-            return {broadcastForward(ant)};  // bounded for repair ants
+            return {broadcastForward(ant)};  // bounded per type (drop at budget 0)
         }
         // A proactive ant with a route is normally unicast, but with a small
         // per-hop probability it is broadcast instead to explore new paths
-        // ([1] §3.3). Gated by the proactive master switch (ADR-0007).
-        if (proactive && config_.enableProactive &&
+        // ([1] §3.3). Gated by the proactive master switch (ADR-0007). With the
+        // broadcast budget spent, keep following pheromone rather than dropping
+        // a routable ant.
+        if (proactive && config_.enableProactive && ant.broadcastBudget != 0 &&
             rng_.uniform() < config_.proactiveBroadcastProb) {
             return {broadcastForward(ant)};
         }
@@ -416,6 +461,9 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
     // transient fields are off the wire now, ADR-0009), reinforce, then retrace.
     computeBackAntState(ant);
     reinforceFromBackAnt(ant);
+    // A backward ant from `src` just restored a route to it, so any local
+    // repair waiting on that destination has succeeded ([1] §3.5, D6).
+    repairDeadline_.erase(ant.src);
 
     if (ant.dst == address_) {
         // Back at the origin: the adapter should flush any pending data for

--- a/core/tests/test_link_failure.cpp
+++ b/core/tests/test_link_failure.cpp
@@ -240,5 +240,95 @@ int main() {
         CHECK(router.table().getPheromoneRegular(9, 6) > 0.0);  // alternate intact
     }
 
+    // 11. Repair wait/discard ([1] §3.5, D6): a repair that gets no backward
+    //     ant within repairWaitFactor × the lost path's delay estimate makes
+    //     the maintenance tick emit DiscardPending for the destination plus a
+    //     LinkFail notification.
+    {
+        Config cfg1 = cfg; cfg1.txFailureThreshold = 1;
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 0, cfg1, clock, rng);
+        router.learnNeighbor(5);
+        router.table().setPheromoneRegular(/*dest*/ 9, /*neighbor*/ 5, 0.8);
+
+        router.reportTxFailure(/*next*/ 5, /*dataDest*/ 9);  // launches the repair
+        CHECK_EQ(router.antsSent(AntType::Repair), static_cast<std::uint64_t>(1));
+
+        // Before the deadline (5 × 1/0.8 = 6.25 s) nothing fires.
+        clock.advance(1.0);
+        for (const RouteDecision& d : router.onMaintenanceTick()) {
+            CHECK(d.action != RouteAction::DiscardPending);
+        }
+
+        // Past the deadline, still no route: discard + notify.
+        clock.advance(cfg1.repairWaitFactor / 0.8);
+        bool discard = false, notified = false;
+        for (const RouteDecision& d : router.onMaintenanceTick()) {
+            if (d.action == RouteAction::DiscardPending) {
+                discard = true;
+                CHECK_EQ(d.nextHop, static_cast<NodeAddress>(9));
+            }
+            if (d.action == RouteAction::Broadcast && d.message.type == AntType::LinkFail) {
+                for (const HelloDest& a : d.message.helloDests) {
+                    if (a.node == 9) { notified = true; CHECK_NEAR(a.pheromone, 0.0, 1e-12); }
+                }
+            }
+        }
+        CHECK(discard);
+        CHECK(notified);
+
+        // The deadline is one-shot: a later tick does not re-fire it.
+        clock.advance(1.0);
+        for (const RouteDecision& d : router.onMaintenanceTick()) {
+            CHECK(d.action != RouteAction::DiscardPending);
+        }
+    }
+
+    // 12. A backward ant from the destination within the window cancels the
+    //     pending discard (the repair succeeded).
+    {
+        Config cfg1 = cfg; cfg1.txFailureThreshold = 1;
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 0, cfg1, clock, rng);
+        router.learnNeighbor(5);
+        router.table().setPheromoneRegular(/*dest*/ 9, /*neighbor*/ 5, 0.8);
+        router.reportTxFailure(/*next*/ 5, /*dataDest*/ 9);
+
+        AntMessage back;  // backward repair ant retracing 9 -> 0
+        back.type = AntType::Repair;
+        back.direction = AntDirection::Down;
+        back.src = 9;
+        back.dst = 0;
+        back.seqNum = 7;
+        back.visited = {{0, 0.0}};
+        back.history = {{9, 0.05}};
+        auto decs = router.onReceiveAnt(back, /*prevHop*/ 9);
+        CHECK_EQ(decs.size(), static_cast<std::size_t>(1));
+        CHECK(decs[0].action == RouteAction::Deliver);  // route to 9 restored
+
+        clock.advance(cfg1.repairWaitFactor / 0.8 + 1.0);  // well past the deadline
+        for (const RouteDecision& d : router.onMaintenanceTick()) {
+            CHECK(d.action != RouteAction::DiscardPending);
+        }
+    }
+
+    // 13. A route restored by other means (reactive ant, diffusion) also
+    //     defuses the deadline: it lapses without a discard or notification.
+    {
+        Config cfg1 = cfg; cfg1.txFailureThreshold = 1;
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 0, cfg1, clock, rng);
+        router.learnNeighbor(5);
+        router.table().setPheromoneRegular(/*dest*/ 9, /*neighbor*/ 5, 0.8);
+        router.reportTxFailure(/*next*/ 5, /*dataDest*/ 9);
+
+        router.table().setPheromoneRegular(9, 6, 0.5);  // route reappeared via 6
+        clock.advance(cfg1.repairWaitFactor / 0.8 + 1.0);
+        CHECK(router.onMaintenanceTick().empty());
+    }
+
     return RUN_TESTS();
 }

--- a/core/tests/test_proactive.cpp
+++ b/core/tests/test_proactive.cpp
@@ -1,10 +1,8 @@
 // Item 04 — proactive ants target active sessions and explore via a per-hop
 // broadcast probability. Regression for deviation D4 (random-destination /
-// fixed-timer proactive ants with no exploratory broadcast).
-//
-// Note: the broadcast-budget cap (acceptance criterion 5) needs an on-wire
-// AntMessage::broadcastBudget field, which is added with item 05's wire pass;
-// it is not exercised here.
+// fixed-timer proactive ants with no exploratory broadcast), plus the
+// broadcast-budget cap (issue #45): a proactive ant that exhausts
+// proactiveMaxBroadcasts is dropped on a route gap instead of flooding.
 #include "anthocnet/core/ant_router_logic.h"
 #include "anthocnet/core/config.h"
 #include "test_support.h"
@@ -108,6 +106,55 @@ int main() {
         auto d = router.onReceiveAnt(inTransit(AntType::Proactive, 3, 9), 3);
         CHECK_EQ(d.size(), static_cast<std::size_t>(1));
         CHECK(d[0].action == RouteAction::Unicast);
+    }
+
+    // 7. Proactive ants originate with a bounded broadcast budget (issue #45).
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        AntRouterLogic router(/*addr*/ 0, cfg, clock, rng);
+        router.noteDataSession(5);
+        std::vector<AntMessage> ants = router.createProactiveAnts();
+        CHECK_EQ(ants.size(), static_cast<std::size_t>(1));
+        CHECK_EQ(ants[0].broadcastBudget, cfg.proactiveMaxBroadcasts);
+    }
+
+    // 8. Budget accounting on a route gap: each hop with no route decrements;
+    //    a budget-exhausted proactive ant is dropped, not re-broadcast.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        AntMessage ant = inTransit(AntType::Proactive, 3, 9);
+        ant.broadcastBudget = 1;
+
+        AntRouterLogic hop1(/*addr*/ 4, cfg, clock, rng);  // no route to 9
+        auto d1 = hop1.onReceiveAnt(ant, /*prevHop*/ 3);
+        CHECK_EQ(d1.size(), static_cast<std::size_t>(1));
+        CHECK(d1[0].action == RouteAction::Broadcast);
+        CHECK_EQ(d1[0].message.broadcastBudget, 0);
+
+        AntRouterLogic hop2(/*addr*/ 5, cfg, clock, rng);  // no route either
+        auto d2 = hop2.onReceiveAnt(d1[0].message, /*prevHop*/ 4);
+        CHECK_EQ(d2.size(), static_cast<std::size_t>(1));
+        CHECK(d2[0].action == RouteAction::Drop);
+    }
+
+    // 9. A budget-exhausted proactive ant that still HAS a route keeps
+    //    following pheromone (the explore branch is skipped, never a drop).
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.05});  // < proactiveBroadcastProb: would explore
+        Config cfg;
+        AntRouterLogic router(/*addr*/ 4, cfg, clock, rng);
+        router.table().setPheromoneRegular(9, 5, 0.8);
+        AntMessage ant = inTransit(AntType::Proactive, 3, 9);
+        ant.broadcastBudget = 0;
+        auto d = router.onReceiveAnt(ant, /*prevHop*/ 3);
+        CHECK_EQ(d.size(), static_cast<std::size_t>(1));
+        CHECK(d[0].action == RouteAction::Unicast);
+        CHECK_EQ(d[0].nextHop, 5);
     }
 
     return RUN_TESTS();

--- a/docs/improvements/04-proactive-ant-sessions.md
+++ b/docs/improvements/04-proactive-ant-sessions.md
@@ -152,6 +152,9 @@ Add `double proactiveBroadcastProb = 0.1;` to `Config`. To bound exploration cos
 (the spec limits proliferation), also cap the number of broadcasts a single
 proactive ant may undergo — reuse the bounded-broadcast counter introduced in
 item 05 (`AntMessage::broadcastBudget`), defaulting e.g. to 2 for proactive ants.
+*(Done — issue #45: `Config::proactiveMaxBroadcasts = 2` initialises the budget
+in `createForwardAnt`; a budget-exhausted proactive ant is dropped on a route
+gap, and with a route it keeps following pheromone instead of exploring.)*
 
 ### 4. Source-originated proactive ants follow combined pheromone
 

--- a/docs/improvements/05-link-failure-detection-and-repair.md
+++ b/docs/improvements/05-link-failure-detection-and-repair.md
@@ -193,6 +193,14 @@ On receiving a `LinkFail` ant in `onReceiveAnt`:
    yet). If no backward repair ant arrives by then, **discard** the buffered
    packets for that destination and emit a `LinkFail` notification. Implement in
    both adapters (they own the pending queue + timers).
+   *(Done — issue #49: the deadline lives in the core (`repairDeadline_`,
+   armed by `reportTxFailure` at `repairWaitFactor × 1/bestPheromone` — item-03
+   units make pheromone ≈ inverse delay — or the flat `repairTimeout`), a
+   backward ant from the destination cancels it, and `onMaintenanceTick`
+   fires it as a `RouteAction::DiscardPending` plus a deferred `LinkFail`
+   notification. Both adapters execute the discard against their pending
+   queue, so the logic stays in `core/` per the invariant. The wait is
+   quantised to the hello-tick cadence rather than a dedicated timer.)*
 
 ### D. MAC transmit-failure — the fast-path accelerator (both adapters) — DONE
 

--- a/ns2/src/ahn_router.cc
+++ b/ns2/src/ahn_router.cc
@@ -182,6 +182,7 @@ void AntHocNetAgent::handleAnt(Packet* p) {
                 break;
             case RouteAction::None:
             case RouteAction::Queue:
+            case RouteAction::DiscardPending:  // maintenance-tick only
                 break;
         }
     }
@@ -336,6 +337,23 @@ void AntHocNetAgent::flushQueue(nsaddr_t dest) {
     }
 }
 
+void AntHocNetAgent::discardQueue(nsaddr_t dest) {
+    // Local repair timed out ([1] §3.5, D6): the paper discards the packets
+    // buffered for the unreachable destination instead of delivering them at
+    // huge delay once some route eventually reappears.
+    std::map<nsaddr_t, std::list<AhnQueued> >::iterator it = queue_.find(dest);
+    if (it == queue_.end()) return;
+
+    std::list<AhnQueued> pending;
+    pending.swap(it->second);
+    queue_.erase(it);
+    queueCount_ -= static_cast<int>(pending.size());
+
+    for (std::list<AhnQueued>::iterator pit = pending.begin(); pit != pending.end(); ++pit) {
+        drop(pit->pkt, DROP_RTR_NO_ROUTE);
+    }
+}
+
 void AntHocNetAgent::purgeQueue() {
     const double now = Scheduler::instance().clock();
     for (std::map<nsaddr_t, std::list<AhnQueued> >::iterator it = queue_.begin();
@@ -391,9 +409,13 @@ void AntHocNetAgent::sendHello() {
     if (!logic_) return;
     purgeQueue();  // expire pending packets that waited too long for a route (B1)
     // Liveness/maintenance tick (ADR-0008 detector A) before beaconing a hello.
+    // The tick returns LinkFail broadcasts and, when a local repair waited past
+    // its window with no backward ant, DiscardPending for that destination (D6).
     for (const RouteDecision& d : logic_->onMaintenanceTick()) {
         if (d.action == RouteAction::Broadcast) {
             sendAnt(d.message, anthocnet::core::kInvalidAddress, /*broadcast=*/true);
+        } else if (d.action == RouteAction::DiscardPending) {
+            discardQueue(d.nextHop);
         }
     }
     AntMessage hello = logic_->createHelloAnt();

--- a/ns2/src/ahn_router.h
+++ b/ns2/src/ahn_router.h
@@ -87,6 +87,7 @@ protected:
     void enqueue(Packet* p, nsaddr_t dest);
     void flushQueue(nsaddr_t dest);
     void purgeQueue();  // drop entries older than AHN_QUEUE_TIMEOUT
+    void discardQueue(nsaddr_t dest);  // repair wait expired ([1] §3.5, D6)
 
     // timer actions
     void sendHello();

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -413,6 +413,10 @@ void RoutingProtocol::ExecuteDecisions(const std::vector<RouteDecision>& decisio
             case RouteAction::Deliver:
                 // handled by caller (FlushQueue), nothing to send
                 break;
+            case RouteAction::DiscardPending:
+                // Local repair timed out (D6): release the buffered packets.
+                DiscardQueue(d.nextHop);
+                break;
             case RouteAction::Queue:
             case RouteAction::Drop:
             case RouteAction::None:
@@ -465,17 +469,22 @@ void RoutingProtocol::FlushQueue(NodeAddress coreDest) {
     }
 }
 
+void RoutingProtocol::DiscardQueue(NodeAddress coreDest) {
+    std::vector<QueueEntry> pending;
+    m_queue.DequeueAll(ToIpv4(coreDest), pending);
+    for (QueueEntry& e : pending) {
+        if (!e.ecb.IsNull()) e.ecb(e.packet, e.header, Socket::ERROR_NOROUTETOHOST);
+    }
+}
+
 // --- timers -----------------------------------------------------------------
 
 void RoutingProtocol::HelloTimerExpire() {
     if (m_logic) {
         // Liveness/maintenance tick first (ADR-0008 detector A) — the only way
-        // NS-3 detects neighbour loss — then beacon a hello.
-        for (RouteDecision& d : m_logic->onMaintenanceTick()) {
-            if (d.action == RouteAction::Broadcast) {
-                SendAnt(d.message, Ipv4Address("255.255.255.255"));
-            }
-        }
+        // NS-3 detects neighbour loss — then beacon a hello. The tick returns
+        // LinkFail broadcasts and repair-timeout DiscardPending actions (D6).
+        ExecuteDecisions(m_logic->onMaintenanceTick(), kInvalidAddress);
         AntMessage hello = m_logic->createHelloAnt();
         SendAnt(hello, Ipv4Address("255.255.255.255"));
     }

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -131,6 +131,9 @@ private:
     void DeferredRouteOutput(Ptr<const Packet> p, const Ipv4Header& header,
                              UnicastForwardCallback ucb, ErrorCallback ecb);
     void FlushQueue(::anthocnet::core::NodeAddress coreDest);
+    /// Repair wait expired ([1] §3.5, D6): drop the packets queued for
+    /// `coreDest`, firing their error callbacks.
+    void DiscardQueue(::anthocnet::core::NodeAddress coreDest);
 
     // timers
     void HelloTimerExpire();


### PR DESCRIPTION
Implements the two open concrete `[protocol]` tickets: #45 and #49.

## #45 — bound proactive forward-ant broadcasts

Proactive forward ants were created with an unbounded broadcast budget (`-1`), so on a region of missing routes they re-broadcast until `(src,seq)` dedup stopped them — the dominant amplifier of the detector-D regression investigated in #19 (proactive antTx +177%).

- New `Config::proactiveMaxBroadcasts` (default **2**, matching `reactiveMaxBroadcasts`/`repairMaxBroadcasts`), initialised in `createForwardAnt`.
- A budget-exhausted proactive ant is **dropped** on a route gap instead of flooding.
- A budget-exhausted proactive ant that still has a route **keeps following pheromone** (the per-hop explore broadcast is skipped rather than dropping a routable ant).

## #49 — spec D6: repair wait/discard timer + post-repair notification ([1] §3.5)

The last unimplemented spec mechanism in failure recovery. After a local repair ant is launched, the core now:

- arms a per-destination deadline of `repairWaitFactor` (**5**) × the estimated end-to-end delay of the lost path (pheromone is inverse delay in item-03 units, so the estimate is `1/bestPheromone`; flat `repairTimeout` = 1 s when no estimate);
- cancels it when a backward ant from that destination arrives (repair succeeded), or lets it lapse silently if a route reappears by other means;
- on timeout with still no route, `onMaintenanceTick` emits a new **`RouteAction::DiscardPending`** plus the deferred `LinkFail` notification the spec requires.

Adapters only execute the discard against the pending queue they own (NS-3 fires the queued entries' error callbacks; NS-2 drops with `DROP_RTR_NO_ROUTE`), keeping the logic in `core/` per the architecture invariant. Buffered packets are no longer held up to the generic 30 s queue TTL and delivered extremely late — the candidate lever for the delay tail in #21.

No wire change: `broadcastBudget` was already carried, and `RouteAction` is not serialized.

## Tests

`make test` green (17/17). New coverage:
- proactive ants originate with the bounded budget; per-hop decrement on route gaps; drop at budget 0; unicast fallback when routable;
- repair timeout emits `DiscardPending` + `LinkFail` (one-shot); backward-ant cancellation; silent lapse when a route is restored by other means.

Docs: status notes updated in `docs/improvements/04` and `05` (sub-step C now done).

Related: #19 #20 #21 #22 (symptom tickets these feed), #26 epic (item 04 budget cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf)_