### PR TITLE
feat(ns3): re-inject MAC-failed data packets and expose detector-D tuning

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: A defect, regression, or wrong result (protocol behaviour, adapter, harness).
+title: "[area] "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: >
+        Apply the matching area label(s) to the issue as well (dropdown choices
+        are not auto-applied as labels).
+      options:
+        - protocol (core algorithm)
+        - adapter (NS-2/NS-3 translation layer)
+        - ns3
+        - ns2
+        - benchmark / harness
+        - observability
+        - packaging / CI
+    validations:
+      required: true
+  - type: dropdown
+    id: model
+    attributes:
+      label: Recommended model
+      description: >
+        Which Claude model class should implement this (see the labelling
+        convention in ADR-0013). Apply the matching `model:*` label too.
+      options:
+        - "model:haiku-4.5 — mechanical / chore"
+        - "model:sonnet-5 — well-specified plumbing, tooling, docs"
+        - "model:opus-4.8 — protocol semantics, root-cause work, CI-validated adapter changes"
+        - "model:fable-5 — architectural / greenfield"
+    validations:
+      required: false
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Symptom + evidence
+      description: >
+        Benchmark numbers, `--diag` lines, CI/job links — enough to act on
+        without the chat (ADR-0013 §3).
+    validations:
+      required: true
+  - type: textarea
+    id: rootcause
+    attributes:
+      label: Root cause (if known)
+      description: Code references as `file:line`.
+  - type: textarea
+    id: refs
+    attributes:
+      label: Related issues / PRs / ADRs / runs

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,29 @@
+name: Chore / verification
+description: Mechanical maintenance (formatting, CI, packaging) or a benchmark verification task.
+title: "[chore] "
+labels: ["chore"]
+body:
+  - type: dropdown
+    id: model
+    attributes:
+      label: Recommended model
+      description: >
+        Which Claude model class should implement this (see the labelling
+        convention in ADR-0013). Apply the matching `model:*` label too. Use
+        `verification` instead of `chore` for benchmark re-run tasks.
+      options:
+        - "model:haiku-4.5 — mechanical / chore"
+        - "model:sonnet-5 — well-specified plumbing, tooling, docs"
+        - "model:opus-4.8 — protocol semantics, root-cause work, CI-validated adapter changes"
+    validations:
+      required: false
+  - type: textarea
+    id: task
+    attributes:
+      label: Task
+    validations:
+      required: true
+  - type: textarea
+    id: refs
+    attributes:
+      label: Related issues / PRs

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue-tracking policy (ADR-0013)
+    url: https://github.com/danieljoppi/AntHocNet/blob/main/docs/adr/0013-track-bugs-and-findings-as-issues.md
+    about: How findings, evidence, and labels are recorded in this repo.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,64 @@
+name: Enhancement
+description: A new mechanism, spec-fidelity item, adapter capability, or harness feature.
+title: "[area] "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: >
+        Apply the matching area label(s) to the issue as well (dropdown choices
+        are not auto-applied as labels). Add `epic` for umbrella issues.
+      options:
+        - protocol (core algorithm)
+        - adapter (NS-2/NS-3 translation layer)
+        - ns3
+        - ns2
+        - benchmark / harness
+        - observability
+        - packaging / CI
+        - documentation
+    validations:
+      required: true
+  - type: dropdown
+    id: model
+    attributes:
+      label: Recommended model
+      description: >
+        Which Claude model class should implement this (see the labelling
+        convention in ADR-0013). Apply the matching `model:*` label too.
+      options:
+        - "model:haiku-4.5 — mechanical / chore"
+        - "model:sonnet-5 — well-specified plumbing, tooling, docs"
+        - "model:opus-4.8 — protocol semantics, root-cause work, CI-validated adapter changes"
+        - "model:fable-5 — architectural / greenfield"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / spec reference
+      description: >
+        Why this matters; paper/spec section or `docs/improvements/` item if
+        applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Code references as `file:line`; which layer (`core/` vs adapters).
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria / how to test
+      description: >
+        Core unit test expectations, CI validation, and (for behaviour changes)
+        the benchmark comparison that decides success.
+  - type: textarea
+    id: refs
+    attributes:
+      label: Related issues / PRs / ADRs

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -43,6 +43,9 @@ on:
       harness:
         description: 'Binary: compare (AntHocNet vs baselines) | baselines (stock ns-3 only, #24 control)'
         default: 'compare'
+      extraArgs:
+        description: 'Extra args appended verbatim (e.g. --ns3::anthocnet::RoutingProtocol::EnableMacFailureDetector=false for the #46 detector sweep)'
+        default: ''
 
 permissions:
   contents: read
@@ -82,6 +85,10 @@ jobs:
             --range=${{ github.event.inputs.range }}"
           if [ -n "${{ github.event.inputs.areaY }}" ]; then
             common="$common --areaY=${{ github.event.inputs.areaY }}"
+          fi
+          if [ -n "${{ github.event.inputs.extraArgs }}" ]; then
+            # e.g. ns-3 attribute overrides for the #46 detector-D sweep.
+            common="$common ${{ github.event.inputs.extraArgs }}"
           fi
           if [ "${{ github.event.inputs.harness }}" = "baselines" ]; then
             # #24 control: stock ns-3 baselines only, no AntHocNet in the binary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,13 @@ results.
 - Namespace `anthocnet::core` for shared code.
 - Make minimal, reviewable changes; update the relevant doc/ADR when you change
   a documented decision.
+- When you open or update an issue, apply the label taxonomy from
+  [ADR-0013](docs/adr/0013-track-bugs-and-findings-as-issues.md#labelling-convention):
+  one type label (`bug`/`enhancement`/`chore`/`documentation`/`verification`,
+  plus `epic` for umbrellas), area label(s) (`protocol`/`adapter`/`ns2`/`ns3`/
+  `benchmark`/`observability`/`packaging`), and one `model:*` recommendation.
+  The `.github/ISSUE_TEMPLATE/` forms preset the type label for issues filed
+  from the GitHub UI.
 - Do not open a pull request unless explicitly asked.
 
 ## Git workflow

--- a/docs/adr/0013-track-bugs-and-findings-as-issues.md
+++ b/docs/adr/0013-track-bugs-and-findings-as-issues.md
@@ -53,6 +53,30 @@ the session ends** — as a new issue, or as a comment on the relevant existing 
 This formalises, rather than replaces, the existing "pick up open work from
 issues" guidance in `AGENTS.md`.
 
+### Labelling convention
+
+Every issue carries three kinds of labels so the backlog can be scanned and
+delegated without opening each ticket (`.github/ISSUE_TEMPLATE/` presets the
+type; the creator applies the rest — template dropdowns are informational, they
+do not auto-apply labels):
+
+1. **Type** (exactly one): `bug` (defect/regression/wrong result),
+   `enhancement` (new mechanism/capability), `chore` (mechanical maintenance),
+   `documentation`, `verification` (benchmark re-run / noise confirmation).
+   Umbrella issues add `epic` alongside their type.
+2. **Area** (one or more): `protocol` (core algorithm, `core/`), `adapter`
+   (translation layer), `ns2`, `ns3`, `benchmark` (harness/workflows),
+   `observability`, `packaging`.
+3. **Recommended model** (`model:*`, one): which Claude model class should
+   implement it, chosen by what failure costs, not code volume:
+   - `model:haiku-4.5` — mechanical chores (reformat, packaging, config).
+   - `model:sonnet-5` — well-specified plumbing, harness/tooling, docs.
+   - `model:opus-4.8` — protocol semantics, root-cause investigation, and
+     adapter work validated only by slow CI loops (a wrong first pass costs a
+     full matrix run).
+   - `model:fable-5` — architectural / greenfield work (e.g. a new simulator
+     adapter).
+
 ## Alternatives considered
 
 - **Rely on chat history / commit messages only.** Chats are stateless across

--- a/docs/improvements/05-link-failure-detection-and-repair.md
+++ b/docs/improvements/05-link-failure-detection-and-repair.md
@@ -222,11 +222,16 @@ the origin, not only on re-broadcasts.
   such trace, so detector A remains their sole, mandatory path. The newer
   `DroppedMpdu`/`WifiMpdu` trace is used (not the pre-3.36 `TxErrHeader`), so the
   hook works across the CI matrix (ns-3.36–3.48).
-- **NS-3 limitation vs NS-2:** NS-2 re-enqueues the failed data packet for
-  retransmission; the NS-3 trace fires post-drop without the routing callbacks,
-  so that specific packet is not re-injected — the repair ant plus the session's
-  subsequent packets recover the route. (Follow-up: re-injection via the pending
-  queue.)
+- **NS-3 limitation vs NS-2 — resolved (issue #46):** NS-2 re-enqueues the failed
+  data packet for retransmission; the NS-3 trace fires post-drop without the
+  routing callbacks. NS-3 now re-injects too: `RouteInput` caches the L3
+  forwarding callbacks (`Ipv4L3Protocol` passes the same bound callbacks on
+  every call), and `NotifyTxError` rebuilds a pending-queue entry from the
+  dropped MPDU (packet minus its IP header, per the queue convention) and
+  flushes immediately so an alternate surviving route retries at once. Detector
+  D and its aggressiveness are runtime-tunable (`EnableMacFailureDetector`,
+  `TxFailureThreshold`, `RepairWaitFactor`, `RepairTimeout` attributes; matching
+  NS-2 TCL binds).
 
 Because A is mandatory and authoritative, D is a latency optimisation: it never
 changes *what* is detected, only *how fast*.

--- a/ns2/src/ahn_router.cc
+++ b/ns2/src/ahn_router.cc
@@ -62,6 +62,10 @@ AntHocNetAgent::AntHocNetAgent(nsaddr_t id)
       enable_diffusion_(1),
       proactive_bcast_prob_(0.1),
       session_ttl_(5.0),
+      tx_failure_threshold_(3),
+      enable_mac_failure_detector_(1),
+      repair_wait_factor_(5.0),
+      repair_timeout_(1.0),
       queueCount_(0) {
     bind("num_nodes_", &num_nodes_);
     bind("num_nodes_x_", &num_nodes_x_);
@@ -74,6 +78,10 @@ AntHocNetAgent::AntHocNetAgent(nsaddr_t id)
     bind_bool("enable_diffusion_", &enable_diffusion_);
     bind("proactive_bcast_prob_", &proactive_bcast_prob_);
     bind("session_ttl_", &session_ttl_);
+    bind("tx_failure_threshold_", &tx_failure_threshold_);
+    bind_bool("enable_mac_failure_detector_", &enable_mac_failure_detector_);
+    bind("repair_wait_factor_", &repair_wait_factor_);
+    bind("repair_timeout_", &repair_timeout_);
 }
 
 AntHocNetAgent::~AntHocNetAgent() {
@@ -93,6 +101,9 @@ void AntHocNetAgent::startProtocol() {
     config_.enableDiffusion   = enable_diffusion_ != 0;
     config_.proactiveBroadcastProb = proactive_bcast_prob_;
     config_.sessionTtl        = session_ttl_;
+    config_.txFailureThreshold = tx_failure_threshold_;
+    config_.repairWaitFactor  = repair_wait_factor_;
+    config_.repairTimeout     = repair_timeout_;
 
     delete logic_;
     logic_ = new anthocnet::core::AntRouterLogic(id_, config_, clock_, rng_);
@@ -386,7 +397,9 @@ void AntHocNetAgent::linkFailed(Packet* p) {
     // neighbour (emitting any LinkFail notifications) and, for a failed data
     // packet, broadcast a bounded local-repair ant toward the lost destination.
     // The core counts/bounds the repair ant; both adapters share this path.
-    if (logic_) {
+    // Gated for the detector-D ablation (issue #46); the data re-enqueue below
+    // stays either way — losing the detector must not also lose the packet.
+    if (logic_ && enable_mac_failure_detector_) {
         for (const RouteDecision& d :
              logic_->reportTxFailure(broken,
                                      isData ? dest : anthocnet::core::kInvalidAddress)) {

--- a/ns2/src/ahn_router.h
+++ b/ns2/src/ahn_router.h
@@ -120,6 +120,10 @@ private:
     int    enable_diffusion_;
     double proactive_bcast_prob_;
     double session_ttl_;
+    int    tx_failure_threshold_;
+    int    enable_mac_failure_detector_;  // detector D gate (issue #46)
+    double repair_wait_factor_;
+    double repair_timeout_;
 
     std::map<nsaddr_t, std::list<AhnQueued> > queue_;
     int queueCount_;  // total pending packets across all destinations

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -46,7 +46,11 @@ RoutingProtocol::RoutingProtocol()
       m_enableProactive(true),
       m_enableDiffusion(true),
       m_proactiveBroadcastProb(0.1),
-      m_sessionTtl(5.0) {}
+      m_sessionTtl(5.0),
+      m_txFailureThreshold(3),
+      m_enableMacFailureDetector(true),
+      m_repairWaitFactor(5.0),
+      m_repairTimeout(1.0) {}
 
 RoutingProtocol::~RoutingProtocol() = default;
 
@@ -99,6 +103,31 @@ TypeId RoutingProtocol::GetTypeId() {
                           "Seconds a data session stays active for proactive probing.",
                           DoubleValue(5.0),
                           MakeDoubleAccessor(&RoutingProtocol::m_sessionTtl),
+                          MakeDoubleChecker<double>())
+            .AddAttribute("TxFailureThreshold",
+                          "Consecutive MAC transmit-failures to the same next hop "
+                          "before detector D treats the link as broken (issue #19 "
+                          "debounce).",
+                          UintegerValue(3),
+                          MakeUintegerAccessor(&RoutingProtocol::m_txFailureThreshold),
+                          MakeUintegerChecker<uint32_t>(1))
+            .AddAttribute("EnableMacFailureDetector",
+                          "Enable the WifiMac transmit-failure detector (ADR-0008 "
+                          "detector D). The hello-timeout detector (A) always runs.",
+                          BooleanValue(true),
+                          MakeBooleanAccessor(&RoutingProtocol::m_enableMacFailureDetector),
+                          MakeBooleanChecker())
+            .AddAttribute("RepairWaitFactor",
+                          "Local-repair wait as a multiple of the lost path's "
+                          "estimated end-to-end delay ([1] section 3.5, D6).",
+                          DoubleValue(5.0),
+                          MakeDoubleAccessor(&RoutingProtocol::m_repairWaitFactor),
+                          MakeDoubleChecker<double>())
+            .AddAttribute("RepairTimeout",
+                          "Flat local-repair wait (s) when the lost path has no "
+                          "usable delay estimate.",
+                          DoubleValue(1.0),
+                          MakeDoubleAccessor(&RoutingProtocol::m_repairTimeout),
                           MakeDoubleChecker<double>())
             .AddTraceSource("Tx",
                             "An ant control packet was put on the medium by this "
@@ -153,6 +182,9 @@ void RoutingProtocol::DoInitialize() {
     m_config.sessionTtl = m_sessionTtl;
     m_config.helloInterval = m_helloInterval.GetSeconds();
     m_config.proactiveInterval = m_proactiveInterval.GetSeconds();
+    m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
+    m_config.repairWaitFactor = m_repairWaitFactor;
+    m_config.repairTimeout = m_repairTimeout;
     Ipv4RoutingProtocol::DoInitialize();
 }
 
@@ -200,6 +232,9 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.sessionTtl = m_sessionTtl;
         m_config.helloInterval = m_helloInterval.GetSeconds();
         m_config.proactiveInterval = m_proactiveInterval.GetSeconds();
+        m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
+        m_config.repairWaitFactor = m_repairWaitFactor;
+        m_config.repairTimeout = m_repairTimeout;
         m_logic.reset(new ::anthocnet::core::AntRouterLogic(
             ToCore(iface.GetLocal()), m_config, m_clock, m_rng));
         m_logic->setObserver(this);  // fan core events to the trace sources
@@ -327,6 +362,11 @@ bool RoutingProtocol::RouteInput(Ptr<const Packet> p, const Ipv4Header& header,
                                  AHN_RI_CB(LocalDeliverCallback) lcb,
                                  AHN_RI_CB(ErrorCallback) ecb) {
     if (!m_logic || m_socketAddresses.empty()) return false;
+
+    // Ipv4L3Protocol passes the same bound callbacks on every call; cache them
+    // so NotifyTxError can re-inject a MAC-dropped data packet (issue #46).
+    m_cachedUcb = ucb;
+    m_cachedEcb = ecb;
 
     Ipv4Address dst = header.GetDestination();
 
@@ -510,6 +550,9 @@ void RoutingProtocol::ProactiveTimerExpire() {
 // --- MAC transmit-failure hook (ADR-0008 detector D) ------------------------
 
 void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI_MPDU> mpdu) {
+    // Detector D is a latency optimisation over the mandatory hello-timeout
+    // detector A (ADR-0008); it can be gated off for ablation (issue #46).
+    if (!m_enableMacFailureDetector) return;
     if (!m_logic || m_socketAddresses.empty() || !mpdu) return;
     // Only a retry-limit drop is a real broken link; other drop reasons
     // (queue full, lifetime expiry) are congestion, not topology.
@@ -527,6 +570,8 @@ void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI
     // so we still prune the dead neighbour even when the payload is opaque.
     NodeAddress dataDest = kInvalidAddress;
     Ptr<Packet> pkt = mpdu->GetPacket()->Copy();
+    Ipv4Header ipHeader;   // kept for re-injection (#46)
+    bool haveData = false;
     LlcSnapHeader llc;
     if (pkt->GetSize() >= llc.GetSerializedSize()) {
         pkt->RemoveHeader(llc);
@@ -542,7 +587,11 @@ void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI
                         isAnt = (udp.GetDestinationPort() == ANT_PORT);
                     }
                 }
-                if (!isAnt) dataDest = ToCore(ip.GetDestination());
+                if (!isAnt) {
+                    dataDest = ToCore(ip.GetDestination());
+                    ipHeader = ip;
+                    haveData = true;
+                }
             }
         }
     }
@@ -550,6 +599,24 @@ void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI
     // Converge on the shared core path: prune + LinkFail notifications + (for
     // data) a bounded, counted repair ant. ExecuteDecisions broadcasts them.
     ExecuteDecisions(m_logic->reportTxFailure(next, dataDest), kInvalidAddress);
+
+    // NS-2 parity (issue #46): re-inject the failed data packet through the
+    // pending queue so it is retransmitted once a route exists, instead of
+    // being lost with only the *route* recovering. The MAC trace fires without
+    // the routing callbacks, so resume it with the ones cached from RouteInput;
+    // queue entries hold the packet without its IP header, matching RouteInput's
+    // convention. The immediate flush retries right away when an alternate
+    // route survived the prune (FlushQueue re-queues if none did). The retry
+    // costs one extra TTL decrement, like any real retransmission path.
+    if (haveData && ipHeader.GetTtl() > 1 && !m_cachedUcb.IsNull()) {
+        QueueEntry entry;
+        entry.packet = pkt;
+        entry.header = ipHeader;
+        entry.ucb = m_cachedUcb;
+        entry.ecb = m_cachedEcb;
+        m_queue.Enqueue(entry);
+        FlushQueue(dataDest);
+    }
 }
 
 bool RoutingProtocol::MapMacToCore(const Mac48Address& mac, NodeAddress& out) const {

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -179,6 +179,16 @@ private:
     bool m_enableDiffusion;
     double m_proactiveBroadcastProb;
     double m_sessionTtl;
+    uint32_t m_txFailureThreshold;
+    bool m_enableMacFailureDetector;
+    double m_repairWaitFactor;
+    double m_repairTimeout;
+
+    // L3 forwarding callbacks cached from RouteInput (Ipv4L3Protocol passes the
+    // same bound callbacks on every call). NotifyTxError needs them to re-inject
+    // a MAC-dropped data packet it only sees as a raw MPDU (issue #46).
+    UnicastForwardCallback m_cachedUcb;
+    ErrorCallback m_cachedEcb;
 
     // trace sources (item 15): ant sent/received and route add/remove.
     TracedCallback<uint8_t, uint8_t, bool> m_txAntTrace;


### PR DESCRIPTION
Implements #46 (both parts), per the [pre-implementation review](https://github.com/danieljoppi/AntHocNet/issues/46#issuecomment-4866023040). Also carries the ADR-0013 label-taxonomy issue forms and an `extraArgs` benchmark-workflow input used for the detector sweep below.

## Part 1 — failed-packet re-injection (NS-2 parity)

The WifiMac `DroppedMpdu` trace fires post-drop without the routing callbacks, so the failed data packet was lost and only the *route* recovered. Now:

- `RouteInput` caches the L3 forwarding callbacks (`Ipv4L3Protocol` passes the same bound pair on every call) in `m_cachedUcb`/`m_cachedEcb`;
- `NotifyTxError` rebuilds a pending-queue entry from the dropped MPDU (packet minus its IP header, matching the queue convention) and **flushes immediately**, so an alternate route that survived the prune retries at once; otherwise the entry waits for the repair's backward ant, and the D6 timer (#49) discards it if the repair fails — the mechanisms compose;
- guards: skipped at TTL ≤ 1 and before any callbacks are cached; a retry costs one extra TTL decrement, like any real retransmission path.

## Part 2 — detector-D tuning without rebuilds

- ns-3 attributes: `TxFailureThreshold`, `EnableMacFailureDetector` (gates the whole hook; off reproduces the detector-A-only baseline for ablation), `RepairWaitFactor`, `RepairTimeout` (the D6 window) — mirrored into the core config at both copy sites.
- matching NS-2 TCL binds (`tx_failure_threshold_`, `enable_mac_failure_detector_`, `repair_wait_factor_`, `repair_timeout_`). The NS-2 gate disables only prune/repair — its native data re-enqueue stays, so disabling the detector never loses the packet.

No `core/` changes; no wire change.

## Validation

- `make test` green (17/17); CI matrix already dispatched green on `68aa9ae` ([run 28594293242](https://github.com/danieljoppi/AntHocNet/actions/runs/28594293242)).
- Benchmark A/B + detector sweep (paper-base and high-mobility, D on/off, vs `main` controls) running; results will be posted here and drive the #46 keep-D-on-by-default decision.

Related: #46 (closes both sub-items), #21/#22 (the regimes this targets), #49 (the D6 discard it composes with), ADR-0008, ADR-0013 (label taxonomy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf)_