### PR TITLE
feat(core): congestion-aware per-hop metric from MAC queue occupancy

### DIFF
--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -32,9 +32,12 @@ namespace core {
 class AntRouterLogic {
 public:
     /// `metric` selects the pheromone formula (item 16); nullptr uses the
-    /// canonical ClassicMetric, so existing adapter call sites are unchanged.
+    /// canonical ClassicMetric. `linkState` supplies MAC-layer congestion
+    /// signals for the item-10/A2 metric (nullptr => wall-clock per-hop time).
+    /// Both default to null, so existing adapter call sites are unchanged.
     AntRouterLogic(NodeAddress address, const Config& config, IClock& clock, IRng& rng,
-                   const ILinkMetric* metric = nullptr);
+                   const ILinkMetric* metric = nullptr,
+                   const ILinkState* linkState = nullptr);
 
     NodeAddress address() const { return address_; }
     const Config& config() const { return config_; }
@@ -112,8 +115,9 @@ public:
     /// Pick a random known destination for a proactive ant (or kInvalidAddress).
     NodeAddress randomDestination();
 
-    /// Append this node to a forward ant's visited stack (trip time since the
-    /// ant was generated). Bounded by Config::maxPathLength.
+    /// Append this node to a forward ant's visited stack, recording this hop's
+    /// cost (congestion-aware MAC estimate when enabled, else wall-clock delta).
+    /// Bounded by Config::maxPathLength.
     void stampForward(AntMessage& ant) const;
 
     /// Advance a backward ant by one hop: move this node from the visited stack
@@ -160,6 +164,11 @@ private:
     /// received backward ant from its `history`, before reinforcement.
     void computeBackAntState(AntMessage& ant) const;
 
+    /// This node's contribution to a forward ant's path-time estimate: the
+    /// congestion-aware MAC cost (Q_mac+1)*T̂_mac when enabled and available,
+    /// else the ant's wall-clock transit delta since the previous stamp.
+    double localHopCost(const AntMessage& ant) const;
+
     NodeAddress     address_;
     Config          config_;
     IClock&         clock_;
@@ -168,6 +177,7 @@ private:
     PheromoneEngine engine_;
     ClassicMetric   defaultMetric_;        ///< used when no metric is injected
     const ILinkMetric* metric_;            ///< pheromone strategy (item 16)
+    const ILinkState* linkState_;          ///< MAC congestion signals (item 10/A2), optional
     AntHistoryTracker history_;
     std::uint32_t   seqNum_ = 0;
     std::map<NodeAddress, double> activeSessions_;  ///< dest -> last data-send time

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -29,6 +29,14 @@ struct Config {
     /// IClock, so it is comparable in magnitude to the measured path time.
     double hopTimeSec = 0.05;  ///< HOP_TIME (50 ms)
 
+    /// Congestion-aware per-hop cost (item 10/A2, [1] §3.2): when on and an
+    /// ILinkState is injected, a forward ant records each node's expected
+    /// send time (Q_mac+1)*T̂_mac instead of its own wall-clock transit delta,
+    /// so the path-time term T̂_d reflects sustained MAC load. Gated + default
+    /// off so the simpler item-02 metric stays the shipped default until a
+    /// benchmark justifies the switch.
+    bool enableMacMetric = false;
+
     /// Links whose pheromone drops below this are pruned.
     double minPheromone = 0.00001;  ///< MIN_PHEROMONE
 

--- a/core/include/anthocnet/core/ports.h
+++ b/core/include/anthocnet/core/ports.h
@@ -50,6 +50,26 @@ public:
     virtual void schedule(Time delay, std::function<void()> callback) = 0;
 };
 
+/// Node-local MAC-layer signals for the congestion-aware per-hop metric
+/// (item 10/A2, [1] §3.2). Advisory *measurement* only: the adapter owns the
+/// MAC, so it measures; the core turns these into a per-hop cost. Optional —
+/// when no ILinkState is injected (or the feature is gated off) the core falls
+/// back to the forward ant's wall-clock transit time, i.e. unchanged behaviour.
+class ILinkState {
+public:
+    virtual ~ILinkState() = default;
+    /// Packets currently queued for transmission at this node's interface (those
+    /// a newly-enqueued packet would wait behind). Returns >= 0; negative is
+    /// treated as 0.
+    virtual int macQueueLength() const = 0;
+    /// Smoothed per-packet MAC service time (seconds): a running average of the
+    /// time from a packet reaching the head of the interface queue to a
+    /// successful transmission, including contention/retransmission. Returns
+    /// <= 0 when no sample has been observed yet (the core then uses the
+    /// unloaded reference hop time for that hop).
+    virtual Time macServiceTime() const = 0;
+};
+
 /// Optional observer the core notifies of routing events (item 15). It only
 /// *reports* — it never makes routing decisions or does I/O, so the core stays
 /// pure. Adapters implement it to fan events out to their native trace

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -6,13 +6,15 @@ namespace anthocnet {
 namespace core {
 
 AntRouterLogic::AntRouterLogic(NodeAddress address, const Config& config, IClock& clock,
-                               IRng& rng, const ILinkMetric* metric)
+                               IRng& rng, const ILinkMetric* metric,
+                               const ILinkState* linkState)
     : address_(address),
       config_(config),
       clock_(clock),
       rng_(rng),
       engine_(config_),
       metric_(metric ? metric : &defaultMetric_),
+      linkState_(linkState),
       history_(config_.maxHistory) {}
 
 // --- neighbour learning -----------------------------------------------------
@@ -345,14 +347,39 @@ NodeAddress AntRouterLogic::randomDestination() {
 
 void AntRouterLogic::stampForward(AntMessage& ant) const {
     if (ant.visited.size() >= config_.maxPathLength) return;
-    // Record this hop's *delta* (seconds since the previous stamp), not the
-    // cumulative time since the ant was generated: the back-ant metric sums
-    // these to recover the true path time. Derive the delta from the elapsed
-    // time minus the deltas already on the stack (timeStart is on the wire).
+    ant.visited.push_back({address_, localHopCost(ant)});
+}
+
+double AntRouterLogic::localHopCost(const AntMessage& ant) const {
+    // Congestion-aware per-hop cost (item 10/A2, [1] §3.2): when the MAC metric
+    // is enabled and a link-state signal is available, this node contributes its
+    // *expected time to send one packet given its current queue* — (Q_mac+1) *
+    // T̂_mac — so the summed path time T̂_d reflects sustained MAC load and data
+    // shifts off congested nodes. The h*T_hop term in ClassicMetric stays the
+    // unloaded-reference regulariser, so this only changes the T̂_d term.
+    //
+    // NOTE(#55): the exact (Q+1)*T̂_mac expression follows the repo's §3.2
+    // interpretation in docs/improvements/10 plus a queue-occupancy refinement;
+    // the primary source (Ducatelle thesis / ETT 2005) was network-blocked at
+    // implementation time, so it is isolated here and flagged for a maintainer
+    // cross-check. Any correction is a one-line change in this function.
+    if (config_.enableMacMetric && linkState_) {
+        const double tmac = linkState_->macServiceTime();
+        if (tmac > 0.0) {
+            const int q = linkState_->macQueueLength();
+            return (static_cast<double>(q > 0 ? q : 0) + 1.0) * tmac;
+        }
+        return config_.hopTimeSec;  // no MAC sample yet: unloaded reference hop
+    }
+
+    // Fallback (unchanged, item 02): the ant's own wall-clock transit — this
+    // hop's *delta* (seconds since the previous stamp), derived from the elapsed
+    // time since generation minus the deltas already on the stack. The back-ant
+    // metric sums these to recover the path time.
     const double cumulative = clock_.now() - ant.timeStart;
     double prior = 0.0;
     for (const AntHop& h : ant.visited) prior += h.time;
-    ant.visited.push_back({address_, cumulative - prior});
+    return cumulative - prior;
 }
 
 NodeAddress AntRouterLogic::advanceBackAnt(AntMessage& ant) const {

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(ANTHOCNET_TESTS
   test_evaporation_backoff
   test_data_routing
   test_link_metric
+  test_mac_metric
   test_properties
   test_observability
 )

--- a/core/tests/test_mac_metric.cpp
+++ b/core/tests/test_mac_metric.cpp
@@ -1,0 +1,155 @@
+// Item 10/A2 (#55) — congestion-aware per-hop cost. With the MAC metric enabled
+// and an ILinkState injected, a forward ant records (Q_mac+1)*T̂_mac at each node
+// instead of its own wall-clock transit delta, so the summed path time T̂_d
+// reflects sustained MAC load and data shifts off congested nodes. Default off
+// (no ILinkState) preserves the item-02 wall-clock behaviour.
+#include "anthocnet/core/ant_router_logic.h"
+#include "anthocnet/core/config.h"
+#include "anthocnet/core/link_metric.h"
+#include "anthocnet/core/ports.h"
+#include "test_support.h"
+
+using namespace anthocnet::core;
+using anthocnet::test::FakeClock;
+using anthocnet::test::ScriptedRng;
+
+namespace {
+
+// Scriptable MAC signals for the node under test.
+struct FakeLinkState : ILinkState {
+    int    q    = 0;
+    double tmac = 0.0;
+    int  macQueueLength() const override { return q; }
+    Time macServiceTime() const override { return tmac; }
+};
+
+// An in-transit forward ant that has just left `src` heading to `dst`.
+AntMessage inTransit(NodeAddress src, NodeAddress dst) {
+    AntMessage a;
+    a.type      = AntType::Reactive;
+    a.direction = AntDirection::Up;
+    a.src       = src;
+    a.dst       = dst;
+    a.seqNum    = 1;
+    a.timeStart = 0.0;
+    a.visited   = {{src, 0.0}};
+    return a;
+}
+
+}  // namespace
+
+int main() {
+    // 1. Default (no ILinkState / gate off): the wall-clock delta is recorded,
+    //    exactly as before this change.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;  // enableMacMetric = false
+        AntRouterLogic r(/*addr*/ 1, cfg, clock, rng);
+        AntMessage a = inTransit(/*src*/ 0, /*dst*/ 9);
+        clock.advance(0.3);
+        r.stampForward(a);
+        CHECK_EQ(a.visited.size(), static_cast<std::size_t>(2));
+        CHECK_NEAR(a.visited.back().time, 0.3, 1e-9);
+    }
+
+    // 2. MAC metric on: records (Q+1)*T̂_mac and ignores wall-clock entirely.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        cfg.enableMacMetric = true;
+        FakeLinkState ls;
+        ls.q = 3;
+        ls.tmac = 0.02;
+        AntRouterLogic r(1, cfg, clock, rng, /*metric*/ nullptr, &ls);
+        AntMessage a = inTransit(0, 9);
+        clock.advance(5.0);  // large wall-clock: must not leak into the cost
+        r.stampForward(a);
+        CHECK_NEAR(a.visited.back().time, (3 + 1) * 0.02, 1e-9);  // 0.08
+    }
+
+    // 3. Empty queue degrades to the plain smoothed service time.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        cfg.enableMacMetric = true;
+        FakeLinkState ls;
+        ls.q = 0;
+        ls.tmac = 0.02;
+        AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
+        AntMessage a = inTransit(0, 9);
+        r.stampForward(a);
+        CHECK_NEAR(a.visited.back().time, 0.02, 1e-9);
+    }
+
+    // 4. No MAC sample yet (T̂_mac <= 0): fall back to the unloaded reference hop
+    //    time rather than a zero-cost hop.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        cfg.enableMacMetric = true;
+        FakeLinkState ls;
+        ls.q = 5;
+        ls.tmac = 0.0;  // no sample observed
+        AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
+        AntMessage a = inTransit(0, 9);
+        r.stampForward(a);
+        CHECK_NEAR(a.visited.back().time, cfg.hopTimeSec, 1e-9);
+    }
+
+    // 5. A negative queue length is clamped to 0 (defensive).
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        cfg.enableMacMetric = true;
+        FakeLinkState ls;
+        ls.q = -7;
+        ls.tmac = 0.02;
+        AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
+        AntMessage a = inTransit(0, 9);
+        r.stampForward(a);
+        CHECK_NEAR(a.visited.back().time, 0.02, 1e-9);  // (0+1)*0.02
+    }
+
+    // 6. Effect: a congested relay raises the summed path time, which lowers the
+    //    pheromone ClassicMetric deposits (monotone-decreasing in path time), so
+    //    the congested path becomes less preferred.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        cfg.enableMacMetric = true;
+
+        auto relayPathTime = [&](int q, double tmac) {
+            FakeLinkState ls;
+            ls.q = q;
+            ls.tmac = tmac;
+            AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
+            AntMessage a = inTransit(0, 9);
+            r.stampForward(a);
+            double t = 0.0;
+            for (const AntHop& h : a.visited) t += h.time;
+            return t;
+        };
+        const double idle = relayPathTime(0, 0.02);  // 0.02
+        const double busy = relayPathTime(8, 0.02);  // 0.18
+        CHECK(busy > idle);
+
+        ClassicMetric m;
+        LinkObservation oIdle;
+        oIdle.hops = 1;
+        oIdle.hopTime = cfg.hopTimeSec;
+        oIdle.pathTime = idle;
+        LinkObservation oBusy;
+        oBusy.hops = 1;
+        oBusy.hopTime = cfg.hopTimeSec;
+        oBusy.pathTime = busy;
+        CHECK(m.pheromone(oBusy) < m.pheromone(oIdle));
+    }
+
+    return RUN_TESTS();
+}

--- a/docs/improvements/10-data-loops-multipath-and-mac-metric.md
+++ b/docs/improvements/10-data-loops-multipath-and-mac-metric.md
@@ -118,6 +118,21 @@ flood independently of TTL/dedup.
 
 ## A2 — MAC-aware per-hop cost (deepens item 02)
 
+**Status (#55): core mechanism + NS-3 signal shipped, gated off by default.** The
+core records a congestion-aware per-hop cost `(Q_mac + 1) · T̂_mac` when
+`Config::enableMacMetric` is set and an `ILinkState` is injected, via the single
+`localHopCost` choke point (`core/src/ant_router_logic.cpp`); NS-3 supplies the
+measured MAC queue length through `ILinkState` (`EnableMacMetric` attribute).
+Two documented simplifications remain as follow-ups: (a) `T̂_mac` is the nominal
+`hopTimeSec` reference, not yet a measured tx-time EWMA — congestion currently
+enters only through the measured queue occupancy `Q_mac`; (b) NS-2 does not yet
+source an `ILinkState` (its ifq-backed signal is pending), so A2 is NS-3-only for
+now (anticipated by the "ship A1+A3, gate A2" note below). **The exact
+`(Q+1)·T̂_mac` expression follows the §3.2 interpretation here plus a
+queue-occupancy refinement; the primary source (Ducatelle thesis / ETT 2005) was
+network-blocked at implementation time and the expression is flagged for a
+maintainer cross-check — it is isolated in `localHopCost` for a one-line fix.**
+
 ### Spec basis
 
 > Per-hop estimate is a running average of the measured MAC queue+transmit delay:

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -12,6 +12,8 @@
 #include "ns3/simulator.h"
 #include "ns3/trace-source-accessor.h"
 #include "ns3/wifi-net-device.h"
+#include "ns3/wifi-mac-queue.h"
+#include "ns3/qos-utils.h"
 #include "ns3/ipv4-interface.h"
 #include "ns3/arp-cache.h"
 #include "ns3/llc-snap-header.h"
@@ -50,7 +52,8 @@ RoutingProtocol::RoutingProtocol()
       m_txFailureThreshold(3),
       m_enableMacFailureDetector(true),
       m_repairWaitFactor(5.0),
-      m_repairTimeout(1.0) {}
+      m_repairTimeout(1.0),
+      m_enableMacMetric(false) {}
 
 RoutingProtocol::~RoutingProtocol() = default;
 
@@ -129,6 +132,13 @@ TypeId RoutingProtocol::GetTypeId() {
                           DoubleValue(1.0),
                           MakeDoubleAccessor(&RoutingProtocol::m_repairTimeout),
                           MakeDoubleChecker<double>())
+            .AddAttribute("EnableMacMetric",
+                          "Congestion-aware per-hop cost (item 10/A2): forward ants "
+                          "record (MAC-queue+1)*hop-time instead of wall-clock "
+                          "transit, so paths shift off loaded nodes.",
+                          BooleanValue(false),
+                          MakeBooleanAccessor(&RoutingProtocol::m_enableMacMetric),
+                          MakeBooleanChecker())
             .AddTraceSource("Tx",
                             "An ant control packet was put on the medium by this "
                             "node (type, direction, broadcast).",
@@ -164,6 +174,30 @@ void RoutingProtocol::onRouteChanged(::anthocnet::core::NodeAddress dest,
     m_routeChangedTrace(static_cast<uint32_t>(dest), static_cast<uint32_t>(nb), added);
 }
 
+// --- item 10/A2: MAC congestion signals (core::ILinkState) ------------------
+
+int RoutingProtocol::macQueueLength() const {
+    // Packets currently backlogged at the wifi MAC across all access categories
+    // — the queue a newly-forwarded packet would wait behind. Summed over the
+    // per-AC txop queues (unified since ns-3.36, the CI-matrix floor). Returns 0
+    // on non-wifi devices, so the metric degrades to the unloaded hop time.
+    if (!m_wifiMac) return 0;
+    uint32_t total = 0;
+    for (AcIndex ac : {AC_BE, AC_BK, AC_VI, AC_VO}) {
+        Ptr<WifiMacQueue> q = m_wifiMac->GetTxopQueue(ac);
+        if (q) total += q->GetNPackets();
+    }
+    return static_cast<int>(total);
+}
+
+::anthocnet::core::Time RoutingProtocol::macServiceTime() const {
+    // Nominal per-packet MAC service time. The congestion signal in this pass is
+    // the *measured queue occupancy* (macQueueLength); the service-time unit is
+    // the unloaded reference hop time, so per-hop cost = (Q+1)*hopTime. Upgrading
+    // this to a measured tx-time EWMA is a follow-up (see #55 / item 10/A2).
+    return m_config.hopTimeSec;
+}
+
 // --- lifecycle --------------------------------------------------------------
 
 void RoutingProtocol::SetIpv4(Ptr<Ipv4> ipv4) {
@@ -185,6 +219,7 @@ void RoutingProtocol::DoInitialize() {
     m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
     m_config.repairWaitFactor = m_repairWaitFactor;
     m_config.repairTimeout = m_repairTimeout;
+    m_config.enableMacMetric = m_enableMacMetric;
     Ipv4RoutingProtocol::DoInitialize();
 }
 
@@ -235,8 +270,10 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
         m_config.repairWaitFactor = m_repairWaitFactor;
         m_config.repairTimeout = m_repairTimeout;
+        m_config.enableMacMetric = m_enableMacMetric;
         m_logic.reset(new ::anthocnet::core::AntRouterLogic(
-            ToCore(iface.GetLocal()), m_config, m_clock, m_rng));
+            ToCore(iface.GetLocal()), m_config, m_clock, m_rng,
+            /*metric*/ nullptr, /*linkState*/ this));
         m_logic->setObserver(this);  // fan core events to the trace sources
     }
 
@@ -276,6 +313,8 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         if (wmac) {
             wmac->TraceConnectWithoutContext(
                 "DroppedMpdu", MakeCallback(&RoutingProtocol::NotifyTxError, this));
+            // Keep the first wifi MAC for the item-10/A2 queue-occupancy signal.
+            if (!m_wifiMac) m_wifiMac = wmac;
         }
     }
 

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -56,7 +56,8 @@ namespace anthocnet {
 // comparison harness can read ant-level diagnostics. The interface is all
 // no-op-default virtuals, so this adds no state to the core.
 class RoutingProtocol : public Ipv4RoutingProtocol,
-                        public ::anthocnet::core::IRouterObserver
+                        public ::anthocnet::core::IRouterObserver,
+                        public ::anthocnet::core::ILinkState
 {
 public:
     static TypeId GetTypeId();
@@ -77,6 +78,12 @@ public:
                        ::anthocnet::core::AntDirection dir) override;
     void onRouteChanged(::anthocnet::core::NodeAddress dest,
                         ::anthocnet::core::NodeAddress nb, bool added) override;
+
+    // core::ILinkState (item 10/A2): supply MAC congestion signals for the
+    // congestion-aware per-hop metric. Only meaningful when EnableMacMetric is
+    // set; the core queries these while stamping a forward ant.
+    int macQueueLength() const override;
+    ::anthocnet::core::Time macServiceTime() const override;
 
     // Ipv4RoutingProtocol
     Ptr<Ipv4Route> RouteOutput(Ptr<Packet> p, const Ipv4Header& header,
@@ -183,6 +190,11 @@ private:
     bool m_enableMacFailureDetector;
     double m_repairWaitFactor;
     double m_repairTimeout;
+    bool m_enableMacMetric;  ///< item 10/A2 congestion-aware per-hop metric
+
+    // WifiMac handle for the item-10/A2 queue-occupancy signal (null on non-wifi
+    // devices, where the metric falls back to the unloaded reference hop time).
+    Ptr<WifiMac> m_wifiMac;
 
     // L3 forwarding callbacks cached from RouteInput (Ipv4L3Protocol passes the
     // same bound callbacks on every call). NotifyTxError needs them to re-inject


### PR DESCRIPTION
Implements #55 / item 10-A2: make the forward-ant path-time term congestion-aware.

## What changed

The metric is `((T̂_d + h·T_hop)/2)^-1`. `T_hop` (`hopTimeSec`) is correct as a constant (unloaded reference); the deviation was in **`T̂_d`**, which was built from the ant's own **wall-clock transit deltas** — a noisy single sample that only weakly tracks load. Now, when enabled, each node contributes its **expected time to send one packet given its queue**: `(Q_mac + 1) · T̂_mac`, summed along the path, so `T̂_d` reflects sustained MAC load and data/ants shift off congested nodes.

- **Core**: single `localHopCost()` choke point in `stampForward`; new optional `ILinkState` port (queue length + smoothed service time). No wire change (`AntHop` stays `{node, cost}`). Gated behind `Config::enableMacMetric`, **default off**, and inert without an injected `ILinkState`, so all existing call sites/behaviour are unchanged.
- **NS-3**: `RoutingProtocol` implements `ILinkState` — `macQueueLength()` sums the per-AC `WifiMac` txop queues (unified since ns-3.36, the CI-matrix floor); `EnableMacMetric` attribute gates it.
- **Test**: `test_mac_metric` covers the formula, empty-queue/no-sample fallbacks, queue clamping, and the congested-node-lowers-pheromone effect. `make test` green (18/18 locally).

## Documented follow-ups (not in this PR)

- `T̂_mac` is the nominal `hopTimeSec` for now — congestion enters via the **measured queue occupancy** `Q_mac`; a measured tx-time EWMA for `T̂_mac` is a follow-up.
- **NS-2** doesn't yet source an `ILinkState` (ifq-backed signal pending) — A2 is NS-3-only for now, as the item anticipates ("ship A1+A3, gate A2"). NS-2 behaviour is unchanged (new Config field defaults false).

## ⚠️ Fidelity caveat (needs maintainer confirmation)

The exact `(Q+1)·T̂_mac` expression follows the repo's own `docs/improvements/10` §3.2 interpretation plus a queue-occupancy refinement. The **primary source (Ducatelle 2007 thesis / ETT 2005 §3.2) was network-blocked from this environment** (proxy denies `people.idsia.ch`/citeseerx), so I could not verify the exact form against it. It's isolated in `localHopCost()` for a one-line correction. **Please confirm against the thesis before relying on the benchmark numbers.**

## Validation plan

CI matrix (this is the real test — the `WifiMac` queue API is the version-drift risk), then a benchmark A/B with `EnableMacMetric` on vs off on `paper-base` and `heavy-load` (where congestion-awareness should pay). Results will be posted here.

Related: #55, #33 (metric-selection seam this rides toward), #21 (delay tail — candidate lever), #26 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf)_