### PR TITLE
feat(bench): gateway-hotspot scenario (--sink) to give the A2 metric a verdict

### DIFF
--- a/docs/improvements/10-data-loops-multipath-and-mac-metric.md
+++ b/docs/improvements/10-data-loops-multipath-and-mac-metric.md
@@ -132,9 +132,17 @@ The cause is topological, not signal quality: the uniform random-waypoint /
 `i→(n-1-i)`-flow taxonomy produces congestion that is either *absent* (low load,
 `Q≈0`) or *uniform* (saturation — every node's queue is full, so `(Q+1)` is high
 everywhere and no less-congested path exists to shift onto). A2 can only pay with
-**localized hotspots + detours**, which no current scenario creates. **#71** adds
-a gateway-convergence scenario (harness `--sink`) to give A2 a verdict — justify
-or retire.
+**localized hotspots + detours**.
+
+A gateway-convergence hotspot (harness `--sink`, 30 flows onto one node, #71) was
+then tested on/off at two loads: the result was **mixed and within noise** — at
+`cbrBps=3000` the metric was slightly worse (PDR −2 pp), at `8000` slightly
+better (PDR +0.9 pp, delay −10%), i.e. opposite directions at 3 runs. Gateway
+convergence isn't an ideal test (the congestion sits *at the destination*, so
+detours are limited), but combined with the neutral paper and load-sweep results
+this is **four benchmark rounds with no consistent A2 benefit**. The one untested
+case is a relay bottleneck with a genuine parallel detour; absent that showing a
+win, A2 stays shipped-but-off and is a candidate to retire rather than extend.
 
 Open follow-ups: (a) `T̂_mac` is the nominal `hopTimeSec`, not a measured tx-time
 EWMA — but measuring it better won't help while the bottleneck is topological, so

--- a/docs/improvements/10-data-loops-multipath-and-mac-metric.md
+++ b/docs/improvements/10-data-loops-multipath-and-mac-metric.md
@@ -118,20 +118,33 @@ flood independently of TTL/dedup.
 
 ## A2 — MAC-aware per-hop cost (deepens item 02)
 
-**Status (#55): core mechanism + NS-3 signal shipped, gated off by default.** The
-core records a congestion-aware per-hop cost `(Q_mac + 1) · T̂_mac` when
-`Config::enableMacMetric` is set and an `ILinkState` is injected, via the single
-`localHopCost` choke point (`core/src/ant_router_logic.cpp`); NS-3 supplies the
-measured MAC queue length through `ILinkState` (`EnableMacMetric` attribute).
-Two documented simplifications remain as follow-ups: (a) `T̂_mac` is the nominal
-`hopTimeSec` reference, not yet a measured tx-time EWMA — congestion currently
-enters only through the measured queue occupancy `Q_mac`; (b) NS-2 does not yet
-source an `ILinkState` (its ifq-backed signal is pending), so A2 is NS-3-only for
-now (anticipated by the "ship A1+A3, gate A2" note below). **The exact
-`(Q+1)·T̂_mac` expression follows the §3.2 interpretation here plus a
-queue-occupancy refinement; the primary source (Ducatelle thesis / ETT 2005) was
-network-blocked at implementation time and the expression is flagged for a
-maintainer cross-check — it is isolated in `localHopCost` for a one-line fix.**
+**Status: core mechanism + NS-3 signal shipped (#55/#67), gated off by default,
+and empirically NEUTRAL so far.** The core records a congestion-aware per-hop
+cost `(Q_mac + 1) · T̂_mac` when `Config::enableMacMetric` is set and an
+`ILinkState` is injected, via the single `localHopCost` choke point
+(`core/src/ant_router_logic.cpp`); NS-3 supplies the measured MAC queue length
+through `ILinkState` (`EnableMacMetric` attribute).
+
+**Benchmark finding (why it's still off): a load sweep found no effect across the
+whole offered-load spectrum** (512 → 8000 → 32000 bps; on/off deltas within noise
+— [#68](https://github.com/danieljoppi/AntHocNet/issues/68#issuecomment-4886573017)).
+The cause is topological, not signal quality: the uniform random-waypoint /
+`i→(n-1-i)`-flow taxonomy produces congestion that is either *absent* (low load,
+`Q≈0`) or *uniform* (saturation — every node's queue is full, so `(Q+1)` is high
+everywhere and no less-congested path exists to shift onto). A2 can only pay with
+**localized hotspots + detours**, which no current scenario creates. **#71** adds
+a gateway-convergence scenario (harness `--sink`) to give A2 a verdict — justify
+or retire.
+
+Open follow-ups: (a) `T̂_mac` is the nominal `hopTimeSec`, not a measured tx-time
+EWMA — but measuring it better won't help while the bottleneck is topological, so
+**#68 is blocked on #71**; if resumed, the scale-correct quantity is the full MAC
+sojourn (tens of ms), not per-frame airtime (~0.1–1.5 ms, which is ≪ `T_hop` and
+would only weaken the signal); (b) NS-2 does not yet source an `ILinkState` (#69),
+so A2 is NS-3-only. **The exact `(Q+1)·T̂_mac` form follows the §3.2 interpretation
+here plus a queue-occupancy refinement; the primary source (Ducatelle thesis /
+ETT 2005) was network-blocked at implementation time and is flagged for a
+maintainer cross-check (#70) — isolated in `localHopCost` for a one-line fix.**
 
 ### Spec basis
 

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -97,6 +97,8 @@ struct Params {
     double   cbrBps;
     double   startWindow;
     std::string propagation;  // "range" (disk, default) | "tworay" (two-ray ground, #24)
+    int32_t  sink;            // >=0: all flows converge on this node (gateway
+                              // hotspot, #71); <0: default i->(n-1-i) pairing.
 };
 
 struct Result {
@@ -212,9 +214,16 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     rate << static_cast<uint64_t>(P.cbrBps) << "bps";
     uint16_t port = kDataPort;
     ApplicationContainer apps, sinks;
-    for (uint32_t i = 0; i < P.nFlows && i < P.nNodes / 2; ++i) {
+    // Gateway hotspot (#71): all flows converge on one sink so nodes near it are
+    // congested while peripheral approach paths stay idle — the localized
+    // congestion + detour regime where load-aware routing can pay. Sources can
+    // then span up to n-1 nodes; the default 1:1 pairing caps them at n/2.
+    const bool converge = (P.sink >= 0);
+    const uint32_t maxFlows = converge ? (P.nNodes - 1) : (P.nNodes / 2);
+    for (uint32_t i = 0; i < P.nFlows && i < maxFlows; ++i) {
         uint32_t src = i;
-        uint32_t dst = P.nNodes - 1 - i;
+        uint32_t dst = converge ? static_cast<uint32_t>(P.sink) : (P.nNodes - 1 - i);
+        if (src == dst) continue;  // source coincides with the gateway: skip
         OnOffHelper onoff("ns3::UdpSocketFactory",
                           InetSocketAddress(ifs.GetAddress(dst), port));
         onoff.SetAttribute("DataRate", StringValue(rate.str()));
@@ -223,9 +232,18 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         onoff.SetAttribute("StopTime", TimeValue(Seconds(P.simTime - 1.0)));
         apps.Add(onoff.Install(nodes.Get(src)));
 
+        // In converge mode every flow shares one sink node/port, so install its
+        // PacketSink exactly once (a second bind on the same port would fail).
+        if (!converge) {
+            PacketSinkHelper sink("ns3::UdpSocketFactory",
+                                  InetSocketAddress(Ipv4Address::GetAny(), port));
+            sinks.Add(sink.Install(nodes.Get(dst)));
+        }
+    }
+    if (converge && P.sink >= 0 && static_cast<uint32_t>(P.sink) < P.nNodes) {
         PacketSinkHelper sink("ns3::UdpSocketFactory",
                               InetSocketAddress(Ipv4Address::GetAny(), port));
-        sinks.Add(sink.Install(nodes.Get(dst)));
+        sinks.Add(sink.Install(nodes.Get(P.sink)));
     }
     sinks.Start(Seconds(0.0));
 
@@ -341,6 +359,7 @@ int main(int argc, char* argv[]) {
     double   simTime = -1, area = -1, areaX = -1, areaY = -1;
     double   speed = -1, pause = -1, range = -1, cbrBps = -1;
     int32_t  nFlows = 0;
+    int32_t  sink = -1;
     uint32_t runs = 1;
     bool csv = false;
     std::string protocols = "anthocnet,aodv,olsr,dsdv";
@@ -357,6 +376,8 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("range", "Transmission range (m); 0 = ns-3 default channel", range);
     cmd.AddValue("flows", "Number of CBR flows", nFlows);
     cmd.AddValue("cbrBps", "Per-flow CBR rate (bits/s)", cbrBps);
+    cmd.AddValue("sink", "If >=0, all flows converge on this node (gateway "
+                         "hotspot, #71) instead of i->(n-1-i) pairing", sink);
     cmd.AddValue("runs", "Number of RNG runs to average (seeds 1..runs)", runs);
     cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
     cmd.AddValue("protocols", "Comma-separated list", protocols);
@@ -379,6 +400,7 @@ int main(int argc, char* argv[]) {
     P.cbrBps  = cbrBps >= 0 ? cbrBps : (paper ? 512.0 : 8000.0);
     P.startWindow = paper ? 180.0 : 5.0;
     P.propagation = propagation;
+    P.sink = sink;
 
     // 1 ms delay bins for the 99th-percentile computation.
     Config::SetDefault("ns3::FlowMonitor::DelayBinWidth", DoubleValue(0.001));
@@ -431,7 +453,8 @@ int main(int argc, char* argv[]) {
     std::cout << "AntHocNet protocol comparison (mean of " << runs << " run(s))\n"
               << "  nodes=" << P.nNodes << " time=" << P.simTime << "s area="
               << P.areaX << "x" << P.areaY << "m maxSpeed=" << P.speed
-              << "m/s pause=" << P.pause << "s flows=" << P.nFlows << "\n\n";
+              << "m/s pause=" << P.pause << "s flows=" << P.nFlows
+              << (P.sink >= 0 ? " sink=" + std::to_string(P.sink) : "") << "\n\n";
     std::cout << std::left << std::setw(12) << "protocol"
               << std::right << std::setw(8) << "PDR%" << std::setw(11) << "delay(ms)"
               << std::setw(13) << "delay99(ms)" << std::setw(13) << "thrput(kbps)"


### PR DESCRIPTION
Implements #71. Adds the missing scenario needed to justify or retire the item-10/A2 congestion metric (#55/#67).

## Why

A load sweep of A2 ([#68](https://github.com/danieljoppi/AntHocNet/issues/68#issuecomment-4886573017)) found it **neutral across the whole offered-load spectrum** (512→8000→32000 bps). The cause is topological: the uniform random-waypoint / `i→(n-1-i)`-flow taxonomy produces congestion that's either *absent* (Q≈0) or *uniform* (saturation) — never the **localized hotspot + detour** regime where load-aware routing can pay. No scenario could demonstrate or falsify A2.

## What

- `--sink=<node>` in `anthocnet-compare`: all flows converge on one gateway node instead of 1:1 pairing, so nodes near the sink congest while peripheral approach paths stay idle. Sources span up to `n-1` (pairing caps at `n/2`); the shared sink gets one `PacketSink`; the config line reports `sink=<id>`. Drivable via the `paper-benchmark` `extraArgs` input — no workflow change.
- Records the A2 load-sweep finding in `docs/improvements/10` (A2 neutral, blocked on this scenario; #68 measured-`T̂` blocked too; airtime is the wrong scale for `T̂_mac`).

No core/module change — example + docs only; `make test` green (18/18).

## Validation

CI + a hotspot A/B (`EnableMacMetric` on/off at two loads, converging on a central sink) are running; results will decide A2's fate and post here. **Binary outcome:** either the metric shows a measurable gain under localized congestion (justifying A2, unblocking #68), or it doesn't even here — and A2 gets retired.

Related: #71, #68 (blocked on this), #55/#67 (the metric), #56/#57 (also want a non-uniform-flow scenario), #28 (taxonomy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf)_