### PR TITLE
fix(ns3): read AC_BE_NQOS so A2 has a queue signal — re-land --qdiag + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+**Project specifics live in [`AGENTS.md`](AGENTS.md) (golden rules, build/verify,
+where-to-look) and [`CONTEXT.md`](CONTEXT.md) — read those first.** The
+guidelines below are general behavioural defaults layered on top.
+
+<!-- Vendored from https://github.com/forrestchang/andrej-karpathy-skills (CLAUDE.md).
+     Kept as a reviewed, version-pinned copy rather than fetched at runtime. -->
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -103,7 +103,10 @@ static uint32_t NodeMacBacklog(Ptr<Node> node) {
         if (!w) continue;
         Ptr<WifiMac> mac = w->GetMac();
         if (!mac) continue;
-        for (AcIndex ac : {AC_BE, AC_BK, AC_VI, AC_VO}) {
+        // AC_BE_NQOS first: the non-QoS AdhocWifiMac keeps its single DCF queue
+        // there, not under AC_BE — omitting it makes the backlog always read 0
+        // (issue #73, the reason the first qdiag pass saw maxQ=0 everywhere).
+        for (AcIndex ac : {AC_BE_NQOS, AC_BE, AC_BK, AC_VI, AC_VO}) {
             Ptr<WifiMacQueue> q = mac->GetTxopQueue(ac);
             if (q) total += q->GetNPackets();
         }

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -86,6 +86,44 @@ void DiagSinkRx(Ptr<const Packet>, const Address&) {
     if (g_firstDeliveryS < 0.0) g_firstDeliveryS = Simulator::Now().GetSeconds();
 }
 
+// --- queue diagnostics (--qdiag): does the A2 congestion signal exist? --------
+// A2 (item 10) keys off the WiFi MAC queue depth Q_mac. If 802.11 loss under
+// load is collision-dominated (frames lost on-air, shallow queues) rather than
+// queue-dominated, Q_mac stays ~0 even at low PDR and A2 has nothing to act on.
+// Sample every node's MAC backlog periodically and report the distribution to
+// settle that empirically before pursuing A2 further (issue #73).
+bool g_qdiag = false;
+uint64_t g_qCount = 0, g_qNonzero = 0, g_qMax = 0;
+double   g_qSum = 0.0;
+
+static uint32_t NodeMacBacklog(Ptr<Node> node) {
+    uint32_t total = 0;
+    for (uint32_t d = 0; d < node->GetNDevices(); ++d) {
+        Ptr<WifiNetDevice> w = node->GetDevice(d)->GetObject<WifiNetDevice>();
+        if (!w) continue;
+        Ptr<WifiMac> mac = w->GetMac();
+        if (!mac) continue;
+        for (AcIndex ac : {AC_BE, AC_BK, AC_VI, AC_VO}) {
+            Ptr<WifiMacQueue> q = mac->GetTxopQueue(ac);
+            if (q) total += q->GetNPackets();
+        }
+    }
+    return total;
+}
+
+void SampleQueues(NodeContainer nodes, double period, double until) {
+    for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+        const uint32_t q = NodeMacBacklog(nodes.Get(i));
+        g_qCount += 1;
+        g_qSum += q;
+        if (q > 0) g_qNonzero += 1;
+        if (q > g_qMax) g_qMax = q;
+    }
+    if (Simulator::Now().GetSeconds() + period < until) {
+        Simulator::Schedule(Seconds(period), &SampleQueues, nodes, period, until);
+    }
+}
+
 struct Params {
     uint32_t nNodes;
     double   simTime;
@@ -120,6 +158,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_antTx.clear();
     g_antRx.clear();
     g_firstDeliveryS = -1.0;
+    g_qCount = g_qNonzero = g_qMax = 0;
+    g_qSum = 0.0;
 
     NodeContainer nodes;
     nodes.Create(P.nNodes);
@@ -266,6 +306,13 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         }
     }
 
+    // Queue-depth sampler (#73): start after a 10% warm-up so convergence
+    // transients don't dominate, sample every 0.5 s until the run ends.
+    if (g_qdiag) {
+        Simulator::Schedule(Seconds(P.simTime * 0.1), &SampleQueues, nodes, 0.5,
+                            P.simTime);
+    }
+
     FlowMonitorHelper fmHelper;
     Ptr<FlowMonitor> monitor = fmHelper.InstallAll();
 
@@ -346,6 +393,18 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         std::cout << "\n";
     }
 
+    // Queue-depth summary (#73): the distribution of per-node MAC backlog seen
+    // over the run. High maxQ / pctNonzero => the A2 signal is present; ~0 even
+    // at low PDR => loss is collision-dominated and A2 is structurally inert.
+    if (g_qdiag) {
+        const double mean = g_qCount ? g_qSum / g_qCount : 0.0;
+        const double pct = g_qCount ? 100.0 * g_qNonzero / g_qCount : 0.0;
+        std::cout << std::fixed << std::setprecision(2)
+                  << "# qdiag " << proto << " seed=" << seed
+                  << " pdr=" << r.pdr << " meanQ=" << mean << " maxQ=" << g_qMax
+                  << " pctNonzero=" << pct << " samples=" << g_qCount << "\n";
+    }
+
     Simulator::Destroy();
     return r;
 }
@@ -382,6 +441,9 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
     cmd.AddValue("protocols", "Comma-separated list", protocols);
     cmd.AddValue("diag", "Emit per-run '# diag' lines (ant tallies, first delivery)", g_diag);
+    cmd.AddValue("qdiag", "Emit per-run '# qdiag' lines: per-node MAC queue depth "
+                          "distribution (meanQ/maxQ/pctNonzero) — does A2 have a "
+                          "signal? (#73)", g_qdiag);
     std::string propagation = "range";
     cmd.AddValue("propagation", "Propagation loss model: 'range' (disk) or 'tworay'", propagation);
     cmd.Parse(argc, argv);

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -183,7 +183,11 @@ int RoutingProtocol::macQueueLength() const {
     // on non-wifi devices, so the metric degrades to the unloaded hop time.
     if (!m_wifiMac) return 0;
     uint32_t total = 0;
-    for (AcIndex ac : {AC_BE, AC_BK, AC_VI, AC_VO}) {
+    // AC_BE_NQOS is essential: a non-QoS mac (AdhocWifiMac, the MANET default)
+    // keeps its single DCF queue under AC_BE_NQOS, not AC_BE — without it
+    // GetTxopQueue returns nullptr and the backlog always reads 0, so the whole
+    // A2 signal was silently absent (issue #73).
+    for (AcIndex ac : {AC_BE_NQOS, AC_BE, AC_BK, AC_VI, AC_VO}) {
         Ptr<WifiMacQueue> q = m_wifiMac->GetTxopQueue(ac);
         if (q) total += q->GetNPackets();
     }


### PR DESCRIPTION
Three commits.

## The headline: A2 was never actually exercised (#73)
The `--qdiag` pass reported `meanQ = maxQ = 0` across **27,000 samples/seed at ~10% PDR** — in *both* uniform saturation and a 30-flow **convergence sink**. A real queue at a converging bottleneck cannot be empty at every sample. Cause found:

`macQueueLength()` (and the qdiag sampler) summed the **QoS** access categories (`AC_BE/BK/VI/VO`), but the MANET `AdhocWifiMac` is **non-QoS** and keeps its single DCF queue under **`AC_BE_NQOS`** — `GetTxopQueue(AC_BE)` returns `nullptr` there, so the backlog **always read 0**.

**Consequence:** the A2 metric's `Q_mac` was always 0, so `(Q+1)·T̂ == T̂` in every run. **A2 was never actually tested** — the four "neutral" rounds (#67/#68/#71) measured a metric whose congestion input was structurally absent. This reframes the whole A2 thread: not "A2 doesn't help," but "A2's signal was never wired up." (No production impact — `EnableMacMetric` is default-off.)

**Fix:** add `AC_BE_NQOS` to the accessor in the adapter *and* the sampler. A `--qdiag` re-run (dispatched) confirms whether queues now register under load; if they do, the A2 A/B (#68/#71) is finally worth re-running for real.

## Also here
- **Re-lands `--qdiag`** — it was dropped from `main` in a #74 merge race (the merge took the skills-only commit); cherry-picked back.
- **`CLAUDE.md`** — vendors the karpathy behavioural guidelines (reviewed, version-pinned copy), with a header pointing at `AGENTS.md`/`CONTEXT.md`. (Your "Install" request — done the reviewable way; I did **not** run the caveman `curl|bash` installer — unreviewed third-party code into an ephemeral container; details in chat.)

`make test` unaffected (no core change). CI compiles the ns-3 changes.

Refs #73, #55/#67/#68/#71 (the A2 rounds this invalidates + re-enables), #74 (merge race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf)_