### PR TITLE
chore: fix bench_parse verdict + delay99, correct A2 docs (validated), install caveman

### DIFF
--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -41,9 +41,13 @@ within each load pair and, if the PDR deltas disagree in sign across pairs,
 prints the **NOISE** call (the exact trap hit in #47/#68/#71 — opposite
 directions at low run counts mean noise, bump `--runs`).
 
-Verdict per pair: `NOISE` (|dPDR|<1pp and |d_delay|<10% and |d_NRL|<10%),
-else `IMPROVED` / `WORSE` by PDR direction. Treat a single pair's IMPROVED/WORSE
-at <5 runs with suspicion — confirm with more runs before concluding.
+Each delta line shows `dPDR / d_delay / d_d99 / d_NRL` (d_d99 = 99th-pct delay,
+often the real signal — e.g. A2's win was flat PDR but −20% d99). Verdict is
+multi-signal over the material deltas (PDR up good; d99 and NRL down good):
+`NOISE` if none are material, `IMPROVED`/`WORSE` if they agree, `MIXED` if they
+conflict. So a flat-PDR run whose tail and overhead both drop reads IMPROVED, not
+MIXED. Treat a single pair's verdict at <5 runs with suspicion — confirm with
+more runs before concluding.
 
 ## Dispatching runs (not scriptable here)
 

--- a/.claude/skills/benchmark-results/bench_parse.py
+++ b/.claude/skills/benchmark-results/bench_parse.py
@@ -71,13 +71,29 @@ def fmt(v):
 
 def verdict(base, cur):
     dp = cur["pdr"] - base["pdr"]
-    dd = (cur["delay"] - base["delay"]) / base["delay"] * 100 if base["delay"] else 0
-    dn = (cur["nrl"] - base["nrl"]) / base["nrl"] * 100 if base["nrl"] else 0
-    if abs(dp) < 1.0 and abs(dd) < 10 and abs(dn) < 10:
-        return "NOISE", dp, dd, dn
-    # PDR up and delay/NRL not materially worse -> improvement (and vice versa).
-    good = (dp > 0) - (dp < 0)
-    return ("IMPROVED" if good > 0 else "WORSE" if good < 0 else "MIXED"), dp, dd, dn
+
+    def pct(k):
+        return (cur[k] - base[k]) / base[k] * 100 if base.get(k) else 0.0
+
+    dd = pct("delay")
+    dd99 = pct("delay99")   # the paper's QoS/jitter metric — often the real signal
+    dn = pct("nrl")
+    # Per-metric "good" direction, only counted past a materiality threshold:
+    # PDR up is good; delay99 and NRL down are good. A flat-PDR run whose tail and
+    # overhead both drop is an IMPROVEMENT, not "MIXED" (the A2 hotspot case).
+    sig = []
+    if abs(dp) >= 1.0:  sig.append(1 if dp > 0 else -1)
+    if abs(dd99) >= 10: sig.append(1 if dd99 < 0 else -1)
+    if abs(dn) >= 10:   sig.append(1 if dn < 0 else -1)
+    if not sig:
+        v = "NOISE"
+    elif all(s > 0 for s in sig):
+        v = "IMPROVED"
+    elif all(s < 0 for s in sig):
+        v = "WORSE"
+    else:
+        v = "MIXED"
+    return v, dp, dd, dd99, dn
 
 
 def main():
@@ -119,10 +135,10 @@ def main():
             on_lbl, on = cells[i + 1][0], cells[i + 1][1].get(p)
             if not off or not on:
                 continue
-            v, dp, dd, dn = verdict(off, on)
+            v, dp, dd, dd99, dn = verdict(off, on)
             signs.append((dp > 0) - (dp < 0))
             print(f"  {off_lbl} -> {on_lbl:<20} dPDR={dp:+5.1f}pp  "
-                  f"d_delay={dd:+6.1f}%  d_NRL={dn:+6.1f}%   {v}")
+                  f"d_delay={dd:+6.1f}%  d_d99={dd99:+6.1f}%  d_NRL={dn:+6.1f}%   {v}")
         if len({s for s in signs if s}) > 1:
             print("\n  ! cross-pair PDR deltas disagree in sign -> run-to-run "
                   "NOISE, not a real effect (cf. issue #47). Bump --runs.")
@@ -135,9 +151,9 @@ def main():
             cur = rows.get(p)
             if not cur:
                 continue
-            v, dp, dd, dn = verdict(base, cur)
+            v, dp, dd, dd99, dn = verdict(base, cur)
             print(f"  {lbl:<26} dPDR={dp:+5.1f}pp  d_delay={dd:+6.1f}%  "
-                  f"d_NRL={dn:+6.1f}%   {v}")
+                  f"d_d99={dd99:+6.1f}%  d_NRL={dn:+6.1f}%   {v}")
 
 
 if __name__ == "__main__":

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,21 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+---
+
+## Response style — caveman (token economy)
+
+<!-- Vendored from https://github.com/JuliusBrussee/caveman — adapted for this repo.
+     "why use many token when few do trick." -->
+
+Answer in tight, low-filler prose: drop hedging, pleasantries, and preamble; keep
+the substance. Fewer output tokens on every reply, same information.
+
+**Carve-out (this repo's record stays full).** Keep byte-for-byte exact — code,
+commands, file paths, error text, benchmark numbers. And keep the *durable
+record* detailed, never terse: commit messages, PR bodies, ADRs, `docs/`, and
+issue / finding threads. This project's cross-session traceability
+([ADR-0013](docs/adr/0013-track-bugs-and-findings-as-issues.md)) depends on those
+being complete — the AC_BE_NQOS / A2 investigation was only recoverable because
+the issue threads were thorough. Caveman the chat, not the record.

--- a/docs/improvements/10-data-loops-multipath-and-mac-metric.md
+++ b/docs/improvements/10-data-loops-multipath-and-mac-metric.md
@@ -118,41 +118,40 @@ flood independently of TTL/dedup.
 
 ## A2 — MAC-aware per-hop cost (deepens item 02)
 
-**Status: core mechanism + NS-3 signal shipped (#55/#67), gated off by default,
-and empirically NEUTRAL so far.** The core records a congestion-aware per-hop
-cost `(Q_mac + 1) · T̂_mac` when `Config::enableMacMetric` is set and an
-`ILinkState` is injected, via the single `localHopCost` choke point
-(`core/src/ant_router_logic.cpp`); NS-3 supplies the measured MAC queue length
-through `ILinkState` (`EnableMacMetric` attribute).
+**Status: shipped (#55/#67) and VALIDATED (#73) — a real QoS win once the signal
+was measured correctly; gated off by default pending a paper-base confirmation.**
+The core records a congestion-aware per-hop cost `(Q_mac + 1) · T̂_mac` when
+`Config::enableMacMetric` is set and an `ILinkState` is injected, via the single
+`localHopCost` choke point (`core/src/ant_router_logic.cpp`); NS-3 supplies the
+measured MAC queue length through `ILinkState` (`EnableMacMetric` attribute).
 
-**Benchmark finding (why it's still off): a load sweep found no effect across the
-whole offered-load spectrum** (512 → 8000 → 32000 bps; on/off deltas within noise
-— [#68](https://github.com/danieljoppi/AntHocNet/issues/68#issuecomment-4886573017)).
-The cause is topological, not signal quality: the uniform random-waypoint /
-`i→(n-1-i)`-flow taxonomy produces congestion that is either *absent* (low load,
-`Q≈0`) or *uniform* (saturation — every node's queue is full, so `(Q+1)` is high
-everywhere and no less-congested path exists to shift onto). A2 can only pay with
-**localized hotspots + detours**.
+**The four early "A2 is neutral" rounds (#67/#68/#71) were a measurement bug, not
+a property of A2.** `macQueueLength()` summed the QoS access categories
+(`AC_BE/BK/VI/VO`), but the MANET `AdhocWifiMac` is non-QoS and keeps its single
+DCF queue under `AC_BE_NQOS` — so `GetTxopQueue` returned `nullptr` and the
+backlog **always read 0**. `Q_mac ≡ 0` made `(Q+1)·T̂ ≡ T̂` in every run: A2 was
+never actually exercised. The `--qdiag` instrument (#73) exposed this
+(`maxQ=0, pctNonzero=0` across 27k samples even at a converging sink), and #75
+fixed the accessor (`AC_BE_NQOS`). With the fix the same scenario shows a strong
+live signal (`maxQ≈88, pctNonzero≈65%`).
 
-A gateway-convergence hotspot (harness `--sink`, 30 flows onto one node, #71) was
-then tested on/off at two loads: the result was **mixed and within noise** — at
-`cbrBps=3000` the metric was slightly worse (PDR −2 pp), at `8000` slightly
-better (PDR +0.9 pp, delay −10%), i.e. opposite directions at 3 runs. Gateway
-convergence isn't an ideal test (the congestion sits *at the destination*, so
-detours are limited), but combined with the neutral paper and load-sweep results
-this is **four benchmark rounds with no consistent A2 benefit**. The one untested
-case is a relay bottleneck with a genuine parallel detour; absent that showing a
-win, A2 stays shipped-but-off and is a candidate to retire rather than extend.
+**Result with the live signal** (hotspot `--sink=25 --flows=30 --cbrBps=8000`,
+`EnableMacMetric` on vs off, 5 runs —
+[#73](https://github.com/danieljoppi/AntHocNet/issues/73#issuecomment-4888229451)):
+same PDR (17.3%), **mean delay −11%, 99th-pct delay −20%, NRL −8%.** That is the
+paper's load-balancing / lower-jitter behaviour: when the metric can see the
+queue backlog it steers ants and data off the hot nodes onto peripheral detours,
+cutting the delay tail at no delivery cost (PDR is contention-limited here). A2 is
+a genuine lever for the delay tail (#21).
 
-Open follow-ups: (a) `T̂_mac` is the nominal `hopTimeSec`, not a measured tx-time
-EWMA — but measuring it better won't help while the bottleneck is topological, so
-**#68 is blocked on #71**; if resumed, the scale-correct quantity is the full MAC
-sojourn (tens of ms), not per-frame airtime (~0.1–1.5 ms, which is ≪ `T_hop` and
-would only weaken the signal); (b) NS-2 does not yet source an `ILinkState` (#69),
-so A2 is NS-3-only. **The exact `(Q+1)·T̂_mac` form follows the §3.2 interpretation
-here plus a queue-occupancy refinement; the primary source (Ducatelle thesis /
-ETT 2005) was network-blocked at implementation time and is flagged for a
-maintainer cross-check (#70) — isolated in `localHopCost` for a one-line fix.**
+Open follow-ups: (a) flip `EnableMacMetric` on by default after a paper-base /
+high-mobility confirmation with the fixed accessor (the "no measured benefit"
+rationale for default-off is now void); (b) **#68** — replace the nominal
+`hopTimeSec` `T̂_mac` with a measured MAC-sojourn estimate (scale-correct: tens of
+ms, *not* per-frame airtime ~0.1–1.5 ms which is ≪ `T_hop`); could sharpen the
+win; (c) **#69** — NS-2 `ILinkState` (which must query `AC_BE_NQOS` too if it goes
+via the wifi queue); (d) **#70** — cross-check the exact `(Q+1)·T̂_mac` form
+against the Ducatelle thesis (isolated in `localHopCost` for a one-line fix).
 
 ### Spec basis
 


### PR DESCRIPTION
Follow-ups from the A2 validation (#73) and from dogfooding the new skills.

## `bench_parse.py` (2 gaps found while parsing the A2 A/B)
- Show the **`delay99` delta** (`d_d99`) — it was the metric that mattered most for A2 and wasn't printed.
- **Multi-signal verdict** (PDR up / delay99 down / NRL down) instead of PDR-only. A flat-PDR run whose tail + overhead both drop now reads **IMPROVED**, not "MIXED". Verified: the A2 hotspot A/B → `dPDR +0.0pp  d_delay −10.8%  d_d99 −20.3%  d_NRL −8.3%  IMPROVED`; the old noisy case still flags cross-pair NOISE. SKILL.md updated.

## `docs/improvements/10` A2 — correctness fix
The status still read "empirically neutral / candidate to retire" — **now false.** Rewritten to the validated story: the four neutral rounds were the `AC_BE_NQOS` measurement bug (`Q_mac ≡ 0`, so A2 was never exercised); with #75's fix the live signal (`maxQ≈88`) gives **delay99 −20%, mean delay −11%, NRL −8% at flat PDR**. A2 is validated and a real lever for #21. Open follow-ups restated (default-on after paper-base confirm; #68 measured `T̂_mac`; #69 NS-2 signal must also read `AC_BE_NQOS`; #70 formula check).

## `CLAUDE.md` — install caveman
Vendored (adapted): terse chat to save output tokens, with an explicit **carve-out** keeping code/commands/numbers byte-exact and the durable record (ADRs, PR bodies, `docs/`, issue threads) detailed — this repo's cross-session traceability (ADR-0013) depends on it, and that traceability is exactly what let us recover the AC_BE_NQOS bug. Installed the reviewable way (vendored, not `curl|bash`).

No core/adapter change; `make test` unaffected.

Refs #73 (A2 validated), #21 (delay-tail lever), #68/#69/#70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf)_