### PR TITLE
chore(release): stamp CITATION.cff date-released automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
             ver="$(tr -d '[:space:]' < VERSION)"
             git tag -a "v${ver}" -m "v${ver}"
           else
+            # cz rewrites `version:` in CITATION.cff but not the release date, so
+            # stamp today's date first: cz then `git add`s the whole file and the
+            # bump commit (and its tag) carry the correct date-released.
+            sed -i -E "s/^date-released:.*/date-released: \"$(date -u +%Y-%m-%d)\"/" CITATION.cff
             cz bump --yes --changelog
             ver="$(tr -d '[:space:]' < VERSION)"
           fi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     given-names: Daniel Henrique
     # orcid: "https://orcid.org/0000-0000-0000-0000"  # add if available
 version: 0.3.0
-date-released: "2026-06-28"
+date-released: "2026-07-06"
 license: GPL-2.0-only
 repository-code: "https://github.com/danieljoppi/AntHocNet"
 url: "https://github.com/danieljoppi/AntHocNet"


### PR DESCRIPTION
## What

Fix the stale `date-released` in `CITATION.cff` and stop it from going stale on future releases.

## Why

Commitizen rewrites the `version:` line in `CITATION.cff` on `cz bump` (it's in `.cz.toml`'s `version_files`), but it never touches `date-released`. As a result the field drifted: at the **v0.3.0** release (published 2026-07-06) `CITATION.cff` still read `date-released: "2026-06-28"`. Anyone citing the software got the wrong release date.

## Changes

- **`CITATION.cff`** — correct `date-released` to the actual v0.3.0 release date, `2026-07-06`.
- **`.github/workflows/release.yml`** — in the `bump` path, `sed` the current UTC date into `date-released` **before** `cz bump`, so cz `git add`s the whole file and the bump commit (and its tag) carry the correct date. Stamping before the bump — rather than amending after — keeps the cz-created tag pointing at the right commit.

Result: `date-released` is stamped automatically on every future release; no manual step, no drift.

## Verification

- `sed -E "s/^date-released:.*/.../"` matches the existing line; the `version:` line is untouched (cz still owns it).
- Scope is limited to the two files; no core/adapter/protocol code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf)_