### PR TITLE
feat(release): release-pinned + :latest image tags, mirrored to Docker Hub (#77)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -6,8 +6,23 @@ name: Images
 # image builds (especially the legacy ns-2 tree) are slow and are refined
 # post-merge, so they never gate a PR. A manual dispatch on a branch builds
 # only (no push) for validation.
+#
+# `workflow_call` lets the Release workflow reuse this to publish immutable,
+# release-pinned tags. When `release` is set (e.g. `v0.3.0`) we check out that
+# tag and additionally push `<image>:<sim-version>-<release>` (e.g.
+# `anthocnet-ns3:3.42-v0.3.0`) alongside the rolling `<image>:<sim-version>`
+# tag. Reusing this via `workflow_call` (not a tag `push` event) is deliberate:
+# a tag pushed with the release job's default GITHUB_TOKEN does NOT trigger
+# other workflows, so a `push: tags` job would never fire — a direct job
+# dependency in the same run does, and needs no PAT.
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      release:
+        description: "Release tag to pin images to (e.g. v0.3.0); also the checkout ref"
+        type: string
+        default: ''
   push:
     branches: [main, master]
     paths: ['docker/**', '.github/workflows/images.yml', 'core/**', 'ns2/**', 'ns3/**']
@@ -17,7 +32,8 @@ permissions:
   packages: write
 
 env:
-  PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
+  # Push on default-branch pushes, or whenever a release pin is requested.
+  PUSH: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) || (inputs.release || '') != '' }}
 
 jobs:
   ns3:
@@ -31,6 +47,8 @@ jobs:
         version: ['3.36', '3.41', '3.42', '3.47', '3.48']
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release || '' }}   # release tag, else the triggering ref
       - name: Log in to GHCR
         if: ${{ env.PUSH == 'true' }}
         uses: docker/login-action@v3
@@ -45,7 +63,9 @@ jobs:
           file: docker/Dockerfile.ns3
           target: base
           build-args: NS3_VERSION=ns-${{ matrix.version }}
-          tags: ghcr.io/${{ github.repository_owner }}/ns3:${{ matrix.version }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ns3:${{ matrix.version }}
+            ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns3:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: ns-3 + AntHocNet
         uses: docker/build-push-action@v6
@@ -54,7 +74,9 @@ jobs:
           file: docker/Dockerfile.ns3
           target: anthocnet
           build-args: NS3_VERSION=ns-${{ matrix.version }}
-          tags: ghcr.io/${{ github.repository_owner }}/anthocnet-ns3:${{ matrix.version }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/anthocnet-ns3:${{ matrix.version }}
+            ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/anthocnet-ns3:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
 
   ns2:
@@ -66,6 +88,8 @@ jobs:
         version: ['2.34', '2.35']   # supported ns-2 releases
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release || '' }}   # release tag, else the triggering ref
       - name: Log in to GHCR
         if: ${{ env.PUSH == 'true' }}
         uses: docker/login-action@v3
@@ -80,7 +104,9 @@ jobs:
           file: docker/Dockerfile.ns2
           target: base
           build-args: NS2_VERSION=${{ matrix.version }}
-          tags: ghcr.io/${{ github.repository_owner }}/ns2:${{ matrix.version }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ns2:${{ matrix.version }}
+            ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns2:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: ns-2 + AntHocNet
         uses: docker/build-push-action@v6
@@ -89,5 +115,7 @@ jobs:
           file: docker/Dockerfile.ns2
           target: anthocnet
           build-args: NS2_VERSION=${{ matrix.version }}
-          tags: ghcr.io/${{ github.repository_owner }}/anthocnet-ns2:${{ matrix.version }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/anthocnet-ns2:${{ matrix.version }}
+            ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/anthocnet-ns2:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,7 +7,11 @@ name: Images
 # post-merge, so they never gate a PR. A manual dispatch on a branch builds
 # only (no push) for validation.
 #
-# Three tag tiers per image (e.g. anthocnet-ns3):
+# Published to two registries — GHCR (always) and Docker Hub (when the
+# DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets are set). docker/build-push-action
+# builds each image once and pushes it to every tag in the list regardless of
+# registry, so the mirror costs no extra build. Three tag tiers per image (e.g.
+# anthocnet-ns3):
 #   :<sim-version>            e.g. :3.42        — latest build for that ns version (rolling)
 #   :<sim-version>-<release>  e.g. :3.42-v0.3.0 — immutable, pinned to a release
 #   :latest                                     — newest ns version + latest AntHocNet
@@ -40,6 +44,8 @@ permissions:
 env:
   # Push on default-branch pushes, or whenever a release pin is requested.
   PUSH: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) || (inputs.release || '') != '' }}
+  # Docker Hub namespace; empty (secret unset) disables the Docker Hub mirror.
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
   ns3:
@@ -66,6 +72,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Plain ns-3 (no AntHocNet)
         uses: docker/build-push-action@v6
         with:
@@ -76,6 +88,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/ns3:${{ matrix.version }}
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns3:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/ns3:{1}', env.DOCKERHUB_USERNAME, matrix.version) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/ns3:{1}-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: ns-3 + AntHocNet
         uses: docker/build-push-action@v6
@@ -88,6 +102,9 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/anthocnet-ns3:${{ matrix.version }}
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/anthocnet-ns3:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
             ${{ matrix.version == env.NS_LATEST && format('ghcr.io/{0}/anthocnet-ns3:latest', github.repository_owner) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/anthocnet-ns3:{1}', env.DOCKERHUB_USERNAME, matrix.version) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/anthocnet-ns3:{1}-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && matrix.version == env.NS_LATEST && format('docker.io/{0}/anthocnet-ns3:latest', env.DOCKERHUB_USERNAME) || '' }}
           push: ${{ env.PUSH == 'true' }}
 
   ns2:
@@ -111,6 +128,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Plain ns-2 (no AntHocNet)
         uses: docker/build-push-action@v6
         with:
@@ -121,6 +144,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/ns2:${{ matrix.version }}
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns2:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/ns2:{1}', env.DOCKERHUB_USERNAME, matrix.version) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/ns2:{1}-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: ns-2 + AntHocNet
         uses: docker/build-push-action@v6
@@ -133,4 +158,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/anthocnet-ns2:${{ matrix.version }}
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/anthocnet-ns2:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
             ${{ matrix.version == env.NS_LATEST && format('ghcr.io/{0}/anthocnet-ns2:latest', github.repository_owner) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/anthocnet-ns2:{1}', env.DOCKERHUB_USERNAME, matrix.version) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/anthocnet-ns2:{1}-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && matrix.version == env.NS_LATEST && format('docker.io/{0}/anthocnet-ns2:latest', env.DOCKERHUB_USERNAME) || '' }}
           push: ${{ env.PUSH == 'true' }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,14 +7,20 @@ name: Images
 # post-merge, so they never gate a PR. A manual dispatch on a branch builds
 # only (no push) for validation.
 #
-# `workflow_call` lets the Release workflow reuse this to publish immutable,
+# Three tag tiers per image (e.g. anthocnet-ns3):
+#   :<sim-version>            e.g. :3.42        — latest build for that ns version (rolling)
+#   :<sim-version>-<release>  e.g. :3.42-v0.3.0 — immutable, pinned to a release
+#   :latest                                     — newest ns version + latest AntHocNet
+# The rolling and :latest tags move on every default-branch push; the
+# release-pinned tag is only written when `release` is set and never overwritten.
+#
+# `workflow_call` lets the Release workflow reuse this to publish the immutable
 # release-pinned tags. When `release` is set (e.g. `v0.3.0`) we check out that
-# tag and additionally push `<image>:<sim-version>-<release>` (e.g.
-# `anthocnet-ns3:3.42-v0.3.0`) alongside the rolling `<image>:<sim-version>`
-# tag. Reusing this via `workflow_call` (not a tag `push` event) is deliberate:
-# a tag pushed with the release job's default GITHUB_TOKEN does NOT trigger
-# other workflows, so a `push: tags` job would never fire — a direct job
-# dependency in the same run does, and needs no PAT.
+# tag and additionally push `<image>:<sim-version>-<release>`. Reusing this via
+# `workflow_call` (not a tag `push` event) is deliberate: a tag pushed with the
+# release job's default GITHUB_TOKEN does NOT trigger other workflows, so a
+# `push: tags` job would never fire — a direct job dependency in the same run
+# does, and needs no PAT.
 on:
   workflow_dispatch:
   workflow_call:
@@ -39,6 +45,10 @@ jobs:
   ns3:
     name: ns-3 images (${{ matrix.version }})
     runs-on: ubuntu-latest
+    # Newest ns-3 in the matrix — its build also gets the moving `:latest` tag
+    # (latest ns-3 version + latest AntHocNet). Bump when adding a newer version.
+    env:
+      NS_LATEST: '3.48'
     strategy:
       fail-fast: false
       matrix:
@@ -77,11 +87,15 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/anthocnet-ns3:${{ matrix.version }}
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/anthocnet-ns3:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
+            ${{ matrix.version == env.NS_LATEST && format('ghcr.io/{0}/anthocnet-ns3:latest', github.repository_owner) || '' }}
           push: ${{ env.PUSH == 'true' }}
 
   ns2:
     name: ns-2 images (${{ matrix.version }})
     runs-on: ubuntu-latest
+    # Newest ns-2 in the matrix — its build also gets the moving `:latest` tag.
+    env:
+      NS_LATEST: '2.35'
     strategy:
       fail-fast: false
       matrix:
@@ -118,4 +132,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/anthocnet-ns2:${{ matrix.version }}
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/anthocnet-ns2:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
+            ${{ matrix.version == env.NS_LATEST && format('ghcr.io/{0}/anthocnet-ns2:latest', github.repository_owner) || '' }}
           push: ${{ env.PUSH == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,6 +45,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Compute version (bump or baseline)
+        id: compute
         run: |
           if [ "${{ inputs.mode }}" = "baseline" ]; then
             ver="$(tr -d '[:space:]' < VERSION)"
@@ -57,6 +60,7 @@ jobs:
           fi
           echo "VER=${ver}" >> "$GITHUB_ENV"
           echo "TAG=v${ver}" >> "$GITHUB_ENV"
+          echo "tag=v${ver}" >> "$GITHUB_OUTPUT"   # for the images job
 
       - name: Sanity build + test (core)
         run: make test
@@ -93,4 +97,18 @@ jobs:
             **Install bundle** (`anthocnet-${{ env.VER }}.zip`) — the source to
             drop onto your own simulator tree:
             `make install-ns3 NS3DIR=…` or `make install-ns2 NS2DIR=…`.
-            Pre-built simulator images are on GHCR (see `docker/README.md`).
+            Pre-built simulator images are on GHCR (see `docker/README.md`),
+            including release-pinned tags `anthocnet-ns{2,3}:<sim-version>-${{ env.TAG }}`.
+
+  # Publish immutable, release-pinned container images (e.g.
+  # anthocnet-ns3:3.42-v0.3.0) once the tag exists. Reuses the Images workflow
+  # via workflow_call — a direct job dependency, so the tag the release job just
+  # pushed with GITHUB_TOKEN is picked up without a PAT.
+  images:
+    needs: release
+    uses: ./.github/workflows/images.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      release: ${{ needs.release.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ Current results, regenerated on every merge to the default branch, are in
 ### Container images
 
 Prefer not to install a simulator yourself? Pre-built images are published to
-GHCR — for **each supported version**, a plain simulator and the same simulator
-with AntHocNet built in (so you can compare against a clean baseline):
+GHCR (`ghcr.io/danieljoppi/…`) and mirrored to Docker Hub
+(`docker.io/danieljoppi/…`) — for **each supported version**, a plain simulator
+and the same simulator with AntHocNet built in (so you can compare against a
+clean baseline):
 
 ```bash
 docker run --rm ghcr.io/danieljoppi/anthocnet-ns3:3.42 ./ns3 run anthocnet-example

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ docker run --rm ghcr.io/danieljoppi/anthocnet-ns3:3.42 ./ns3 run anthocnet-examp
 docker run --rm -it ghcr.io/danieljoppi/anthocnet-ns2:2.35   # `ns` with the agent
 ```
 
+Each image has three tag tiers: `:<sim-version>` (e.g. `:3.42`, latest build for
+that simulator version), `:<sim-version>-<release>` (e.g. `:3.42-v0.3.0`,
+**immutable** — pin this for reproducible / citable runs), and `:latest` (newest
+simulator version + latest AntHocNet). The `:<sim-version>` and `:latest` tiers
+track the default branch; the `-<release>` tier is fixed to a release.
+
 **AntHocNet images** — the simulator with our protocol built in:
 
 | Image | Versions | Contents |

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,8 +13,19 @@ vendors ns-2 or ns-3.
 | `ns2` | `2.34`, `2.35` | Plain ns-allinone-2.3x built from source, **no AntHocNet**. |
 | `anthocnet-ns2` | `2.34`, `2.35` | The same ns-2 **plus** the AntHocNet patch applied and **compiled** (the only place the ns-2 adapter is actually built). |
 
-Published to GHCR on every merge to the default branch:
-`ghcr.io/danieljoppi/{ns3,anthocnet-ns3,ns2,anthocnet-ns2}:<version>`.
+Published to GHCR under `ghcr.io/danieljoppi/{ns3,anthocnet-ns3,ns2,anthocnet-ns2}`.
+Each image carries three tag tiers:
+
+| Tag | Example | Meaning | Mutability |
+|-----|---------|---------|------------|
+| `:<sim-version>` | `:3.42` | latest build for that simulator version | rolling — moves on every merge to the default branch |
+| `:<sim-version>-<release>` | `:3.42-v0.3.0` | pinned to an AntHocNet release | **immutable** — written once, never overwritten |
+| `:latest` | `:latest` | newest simulator version + latest AntHocNet | rolling — moves on every merge to the default branch |
+
+Use `:<sim-version>-<release>` when you need a reproducible image for a citation
+(the rolling tiers track the default branch and can change under you). The
+release-pinned tier is published by the `Release` workflow (which reuses
+`images.yml`); the rolling tiers are published on every default-branch merge.
 
 ## Build locally
 
@@ -57,5 +68,11 @@ earlier attempt to append one corrupted ns-2's continued `CCOPT` line).
   images on merges to the default branch (and on manual dispatch — a dispatch on
   a branch builds only, no push). It does **not** run on PRs, so the slow ns-2
   build never gates a PR; the image recipes are refined post-merge.
+- The `Release` workflow reuses `images.yml` via `workflow_call` to publish the
+  immutable `:<sim-version>-<release>` tags from the release tag. Reuse (not a
+  tag `push` event) is deliberate: a tag pushed with the release job's default
+  `GITHUB_TOKEN` does not trigger other workflows, so a `push: tags` job would
+  never fire — a `workflow_call` job dependency runs in the same release run and
+  needs no PAT.
 - ns-2.34 is the oldest supported tree; if its build needs extra fixes on the
   pinned base they go in `docker/Dockerfile.ns2` behind the `NS2_VERSION` arg.

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,8 +13,10 @@ vendors ns-2 or ns-3.
 | `ns2` | `2.34`, `2.35` | Plain ns-allinone-2.3x built from source, **no AntHocNet**. |
 | `anthocnet-ns2` | `2.34`, `2.35` | The same ns-2 **plus** the AntHocNet patch applied and **compiled** (the only place the ns-2 adapter is actually built). |
 
-Published to GHCR under `ghcr.io/danieljoppi/{ns3,anthocnet-ns3,ns2,anthocnet-ns2}`.
-Each image carries three tag tiers:
+Published to two registries — GHCR (`ghcr.io/danieljoppi/…`) and Docker Hub
+(`docker.io/danieljoppi/…`, when the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
+secrets are set) — for `{ns3,anthocnet-ns3,ns2,anthocnet-ns2}`. One build pushes
+to both registries. Each image carries three tag tiers:
 
 | Tag | Example | Meaning | Mutability |
 |-----|---------|---------|------------|
@@ -74,5 +76,9 @@ earlier attempt to append one corrupted ns-2's continued `CCOPT` line).
   `GITHUB_TOKEN` does not trigger other workflows, so a `push: tags` job would
   never fire — a `workflow_call` job dependency runs in the same release run and
   needs no PAT.
+- The **Docker Hub mirror** is gated on the `DOCKERHUB_USERNAME` secret: when
+  unset (e.g. forks) the Docker Hub login and `docker.io/…` tags drop out and
+  only GHCR is pushed. `docker/build-push-action` builds each image once and
+  pushes it to both registries, so mirroring adds no build cost.
 - ns-2.34 is the oldest supported tree; if its build needs extra fixes on the
   pinned base they go in `docker/Dockerfile.ns2` behind the `NS2_VERSION` arg.

--- a/docs/improvements/14-reproducibility-and-release.md
+++ b/docs/improvements/14-reproducibility-and-release.md
@@ -46,6 +46,19 @@ docker run --rm -v "$PWD/out:/out" anthocnet-bench run-benchmarks.sh
 - `docker build` + `docker run` reproduces a `docs/benchmarks.md`-style CSV on a
   clean machine with no host ns-3.
 
+### Release-pinned images (shipped, #77)
+
+The `Images` workflow publishes the rolling `anthocnet-ns{2,3}:<sim-version>`
+tags on every `main` push, so they track `main` and are **not** reproducible for
+a citation. The `Release` workflow therefore reuses `images.yml` via
+`workflow_call` to additionally publish immutable **release-pinned** tags that
+keep the simulator version and pin the release —
+`anthocnet-ns3:3.42-v0.3.0`, `anthocnet-ns2:2.35-v0.3.0`, and the plain
+`ns{2,3}:<sim-version>-<release>` baselines. Reuse (not a tag `push` event) is
+deliberate: the release job pushes its tag with the default `GITHUB_TOKEN`,
+which does not trigger other workflows, whereas a `workflow_call` job dependency
+runs in the same release and needs no PAT.
+
 ## E2 — Citeability: CITATION.cff, tagged releases, DOI
 
 ### Problem

--- a/docs/improvements/14-reproducibility-and-release.md
+++ b/docs/improvements/14-reproducibility-and-release.md
@@ -46,18 +46,25 @@ docker run --rm -v "$PWD/out:/out" anthocnet-bench run-benchmarks.sh
 - `docker build` + `docker run` reproduces a `docs/benchmarks.md`-style CSV on a
   clean machine with no host ns-3.
 
-### Release-pinned images (shipped, #77)
+### Image tag tiers (shipped, #77)
 
-The `Images` workflow publishes the rolling `anthocnet-ns{2,3}:<sim-version>`
-tags on every `main` push, so they track `main` and are **not** reproducible for
-a citation. The `Release` workflow therefore reuses `images.yml` via
-`workflow_call` to additionally publish immutable **release-pinned** tags that
-keep the simulator version and pin the release —
-`anthocnet-ns3:3.42-v0.3.0`, `anthocnet-ns2:2.35-v0.3.0`, and the plain
-`ns{2,3}:<sim-version>-<release>` baselines. Reuse (not a tag `push` event) is
-deliberate: the release job pushes its tag with the default `GITHUB_TOKEN`,
-which does not trigger other workflows, whereas a `workflow_call` job dependency
-runs in the same release and needs no PAT.
+Each image (e.g. `anthocnet-ns3`) carries three tag tiers:
+
+| tag | example | meaning | mutability |
+|---|---|---|---|
+| `:<sim-version>` | `:3.42` | latest build for that ns version | rolling (per `main` push) |
+| `:<sim-version>-<release>` | `:3.42-v0.3.0` | pinned to a release | **immutable** |
+| `:latest` | `:latest` | newest ns version + latest AntHocNet | rolling (per `main` push) |
+
+The rolling `:<sim-version>` tags track `main`, so they are **not** reproducible
+for a citation — that is what the immutable release-pinned tier is for. The
+`Release` workflow reuses `images.yml` via `workflow_call` to publish the pinned
+tier: it checks out the release tag and writes `<image>:<sim-version>-<release>`.
+Reuse (not a tag `push` event) is deliberate: the release job pushes its tag with
+the default `GITHUB_TOKEN`, which does not trigger other workflows, whereas a
+`workflow_call` job dependency runs in the same release and needs no PAT. The
+`:latest` tier is emitted only by the newest version in each simulator matrix
+(`NS_LATEST` in `images.yml`).
 
 ## E2 — Citeability: CITATION.cff, tagged releases, DOI
 


### PR DESCRIPTION
Closes #77.

## What

1. Three tag tiers per GHCR image (e.g. `anthocnet-ns3`):

| tier | example | meaning | mutability |
|---|---|---|---|
| rolling per-version | `:3.42` | latest build for that ns version | rolling (each `main` push) |
| **release-pinned** | `:3.42-v0.3.0` | pinned to a release | **immutable** |
| **`:latest`** | `:latest` | newest ns version + latest AntHocNet | rolling (each `main` push) |

2. **Mirror every image to Docker Hub** (`docker.io/<user>/…`) alongside GHCR, across all three tiers.

Same tiers apply to `anthocnet-ns2`, and the plain `ns3`/`ns2` baselines get the rolling + release-pinned tiers.

## Why

`images.yml` tagged images on the **simulator** version only and overwrote them on every `main` push, so `anthocnet-ns3:3.42` tracked `main` — not reproducible for a citation — and there was no "newest of everything" tag, and images lived only on GHCR. (Container half of the closed reproducibility epic #30.)

## How

- **`images.yml`**
  - `workflow_call` trigger with a `release` input; when set, checks out that tag and pushes `<image>:<sim-version>-<release>`.
  - job-level `NS_LATEST` drives the `:latest` tag from the newest matrix entry (`3.48` / `2.35`).
  - **Docker Hub**: a second `docker/login-action` and `docker.io/…` tags, gated on `env.DOCKERHUB_USERNAME` (from the `DOCKERHUB_USERNAME` secret) so secret-less runs (forks) push GHCR only. `docker/build-push-action` builds once and pushes to both registries — no extra build.
- **`release.yml`** — expose the computed tag as a job output; add an `images` job (`needs: release`, `uses: ./.github/workflows/images.yml`, `with: release: <tag>`).
- **docs** — `README.md`, `docker/README.md`, `docs/improvements/14-…md` document the tiers and dual-registry publishing.

**Why `workflow_call` not `on: push: tags`:** the release job pushes its tag with the default `GITHUB_TOKEN`, which does not trigger other workflows. A `workflow_call` job dependency runs in the same release run — no PAT.

## Required secrets (already configured)

- `DOCKERHUB_USERNAME` = Docker Hub namespace (lowercase)
- `DOCKERHUB_TOKEN` = Docker Hub Read/Write access token

A **free** Docker Hub account suffices for public images.

## Verification

- Both workflows parse (`yaml.safe_load`); `NS_LATEST` matches each matrix's newest entry; both jobs have the GHCR + Docker Hub login steps.
- Expression guards (`(inputs.release || '') != ''`, `env.DOCKERHUB_USERNAME != ''`, `matrix.version == env.NS_LATEST`) collapse unused tag lines to empty entries that `docker/build-push-action` ignores; `push`/`workflow_dispatch` keep today's behaviour.
- CI-only change; no core/adapter/protocol code. The `Images` workflow doesn't run on PRs, so the full push path is exercised on the next merge / release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wjp43H5YdDZpGsKHTWKgvf