### PR TITLE
ci: cap benchmark artifact retention at 7 days

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,6 +62,7 @@ jobs:
           path: |
             scenarios.csv
             docs/benchmarks/*.png
+          retention-days: 7
       - name: Commit refreshed results (if changed)
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           name: paper-benchmark
           path: paper-results.txt
+          retention-days: 7
       - name: Compact result block (cheap to fetch via get_job_logs tail)
         # Re-emit each protocol row as a single greppable line as the LAST log
         # output, so the benchmark-results skill can read just the numbers with a

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -75,6 +75,7 @@ jobs:
           path: |
             scenarios.csv
             docs/benchmarks/*.png
+          retention-days: 7
       - name: Commit charts into docs (optional)
         if: ${{ github.event.inputs.commit == 'true' }}
         run: |


### PR DESCRIPTION
## Why

The `danieljoppi` account hit 100% of its included GitHub Actions storage
(0.5 GB/month). Three benchmark workflows upload artifacts with **no
`retention-days` set, so they default to 90 days**:

- `benchmarks.yml` — uploads `scenarios.csv` + `docs/benchmarks/*.png` on
  **every push to main**, so a new copy is retained for 3 months on each push.
- `scenario-matrix.yml` — uploads `scenarios.csv` + charts (manual dispatch).
- `paper-benchmark.yml` — uploads `paper-results.txt` (manual dispatch).

These are individually small (~80 KB each), so they are not the dominant
consumer, but at 90-day retention on every-push they accumulate needlessly.

## What

Add `retention-days: 7` to all three `actions/upload-artifact@v4` steps. No
other behavior changes — the artifacts are still produced and the benchmark
results are still committed into `docs/` as before.

## Scope note

This is one of a set of changes to reduce Actions storage on the account. The
larger consumer is in a separate repo (bee-book, ~20 MB epub/pdf artifacts);
that is handled in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X5Rmczs9ZpDPqu12VxsN8)_