### PR TITLE
fix(bench): pin the paper's 2 Mbit/s radio — ns-3 default rate control halves single-hop PDR (#51)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -84,16 +84,21 @@ stock-baseline control (`manet-baselines`, which links no AntHocNet code) confir
 this is the *scenario/harness config*, not our module (stock-only ≈ harness
 baselines).
 
-**Root cause (found, tracked in [#51](https://github.com/danieljoppi/AntHocNet/issues/51)).**
-The single-hop sanity anchor does **not** read ~100%: a **2-node, 1-flow, in-range,
-static** link delivers only ~50% (`tx=121 rx=61`), confirmed real by independent
-app/sink counters (`appTx==fmTx`, `appRx==fmRx`). So the depression is a **stock
-single-hop 802.11 unicast loss of ~50% per frame**, which every protocol inherits
-before any multi-hop effect — not (primarily) a propagation/range issue. Notably,
-making the field denser does **not** fix it: static `range=600 m` still gives stock
-AODV only ~36%, and TwoRayGround is *worse* (~24%), not better. The earlier
-"300 m partitions the field / adopt ~600 m" reading is superseded — see the
-[#24 correction](https://github.com/danieljoppi/AntHocNet/issues/24#issuecomment-4828992577).
+**Root cause (resolved — [#51](https://github.com/danieljoppi/AntHocNet/issues/51)).**
+The single-hop sanity anchor did **not** read ~100%: a **2-node, 1-flow, in-range,
+static** link delivered only ~50% (`tx=121 rx=61`), confirmed real by independent
+app/sink counters (`appTx==fmTx`, `appRx==fmRx`) — a **stock single-hop 802.11
+unicast loss of ~50% per frame**, inherited by every protocol before any multi-hop
+effect. Drop-point tracing localized it: with no `RemoteStationManager` set,
+`WifiHelper` installs ns-3's default `IdealWifiManager`, whose SNR feedback under
+the 0-loss disk model alternates unicasts between 1 Mbit/s (delivers) and DSSS
+11 Mbit/s (**never** delivers in this stack — a pinned `constant11` radio scores
+0% PDR and even loses ARP replies) — exactly one packet in two. All harnesses now
+pin the paper's fixed 2 Mbit/s radio (`ConstantRateWifiManager`,
+`DsssRate2Mbps` data / `DsssRate1Mbps` control), restoring the 2-node anchor to
+**100.0%**; `--rateManager` still reaches `ideal`/`arf`/other fixed rates for A/B.
+The earlier "300 m partitions the field / adopt ~600 m" reading is superseded —
+see the [#24 correction](https://github.com/danieljoppi/AntHocNet/issues/24#issuecomment-4828992577).
 
 **Acceptance / do-not-do-yet.** The single-hop anchor must deliver ≈100% (and stock
 **AODV ≈ 90%** on the low-mobility Broch field — `paper-benchmark` with

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -138,6 +138,7 @@ struct Params {
     double   cbrBps;
     double   startWindow;
     std::string propagation;  // "range" (disk, default) | "tworay" (two-ray ground, #24)
+    std::string rateManager;  // "constant2" (paper's 2 Mbit/s radio, default) | ... (#51)
     int32_t  sink;            // >=0: all flows converge on this node (gateway
                               // hotspot, #71); <0: default i->(n-1-i) pairing.
 };
@@ -169,6 +170,21 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
 
     WifiHelper wifi;
     wifi.SetStandard(WIFI_STANDARD_80211b);
+    // #51: the ns-3 default (IdealWifiManager) oscillates 1<->11 Mbps and loses
+    // every second unicast to retry exhaustion (DSSS 11 Mbps never delivers in
+    // this setup), halving PDR for every protocol. Default is the paper's fixed
+    // 2 Mbit/s radio; --rateManager reaches the alternatives for A/B.
+    if (P.rateManager == "arf") {
+        wifi.SetRemoteStationManager("ns3::ArfWifiManager");
+    } else if (P.rateManager.rfind("constant", 0) == 0) {
+        std::string rate = P.rateManager == "constant1"  ? "DsssRate1Mbps"
+                         : P.rateManager == "constant2"  ? "DsssRate2Mbps"
+                         : P.rateManager == "constant5"  ? "DsssRate5_5Mbps"
+                                                         : "DsssRate11Mbps";
+        wifi.SetRemoteStationManager("ns3::ConstantRateWifiManager",
+                                     "DataMode", StringValue(rate),
+                                     "ControlMode", StringValue("DsssRate1Mbps"));
+    }  // "ideal": keep the WifiHelper default
     YansWifiPhyHelper phy;
     YansWifiChannelHelper channel;
     if (P.propagation == "tworay") {
@@ -449,6 +465,11 @@ int main(int argc, char* argv[]) {
                           "signal? (#73)", g_qdiag);
     std::string propagation = "range";
     cmd.AddValue("propagation", "Propagation loss model: 'range' (disk) or 'tworay'", propagation);
+    std::string rateManager = "constant2";
+    cmd.AddValue("rateManager",
+                 "Rate control: constant1|constant2|constant5|constant11 (fixed "
+                 "DSSS rate; default constant2, the paper's radio) | arf | ideal "
+                 "(ns-3 default; loses ~50% single-hop, #51)", rateManager);
     cmd.Parse(argc, argv);
     if (runs < 1) runs = 1;
 
@@ -465,6 +486,7 @@ int main(int argc, char* argv[]) {
     P.cbrBps  = cbrBps >= 0 ? cbrBps : (paper ? 512.0 : 8000.0);
     P.startWindow = paper ? 180.0 : 5.0;
     P.propagation = propagation;
+    P.rateManager = rateManager;
     P.sink = sink;
 
     // 1 ms delay bins for the 99th-percentile computation.

--- a/ns3/examples/anthocnet-example.cc
+++ b/ns3/examples/anthocnet-example.cc
@@ -40,6 +40,12 @@ int main(int argc, char* argv[]) {
     // Wifi ad-hoc PHY/MAC.
     WifiHelper wifi;
     wifi.SetStandard(WIFI_STANDARD_80211b);
+    // Pin the paper's 2 Mbit/s radio: the ns-3 default (IdealWifiManager)
+    // oscillates into DSSS 11 Mbps, which never delivers here, and halves
+    // single-hop PDR (#51).
+    wifi.SetRemoteStationManager("ns3::ConstantRateWifiManager",
+                                 "DataMode", StringValue("DsssRate2Mbps"),
+                                 "ControlMode", StringValue("DsssRate1Mbps"));
     YansWifiPhyHelper phy;
     YansWifiChannelHelper channel = YansWifiChannelHelper::Default();
     phy.SetChannel(channel.Create());

--- a/ns3/examples/manet-baselines.cc
+++ b/ns3/examples/manet-baselines.cc
@@ -49,6 +49,80 @@ uint64_t g_appTx = 0, g_appRx = 0;
 void AppTx(Ptr<const Packet>) { ++g_appTx; }
 void AppRx(Ptr<const Packet>, const Address&) { ++g_appRx; }
 
+// #51 drop localization (gated by --dropdiag): per-node counters for every
+// drop point between the sender's L3 and the receiver's L3 — PHY rx (with
+// reason), PHY tx, MAC tx/rx, retry exhaustion, ARP pending-queue, IP L3 —
+// plus PhyTxBegin/MacRx activity counts, to find where the #51 ~50% dies.
+bool g_dropDiag = false;
+std::map<std::string, uint64_t> g_drops;
+uint32_t g_dropLines = 0;
+constexpr uint32_t kMaxDropLines = 40;
+
+void NoteDrop(const std::string& what, uint32_t size) {
+    ++g_drops[what];
+    if (g_dropLines < kMaxDropLines) {
+        std::cout << "  [dropdiag] t=" << Simulator::Now().GetSeconds()
+                  << " " << what << " size=" << size << "\n";
+        ++g_dropLines;
+    }
+}
+void PacketDropCb(std::string ctx, Ptr<const Packet> p) { NoteDrop(ctx, p->GetSize()); }
+void PacketCountCb(std::string ctx, Ptr<const Packet>) { ++g_drops[ctx]; }
+void PhyTxBeginCb(std::string ctx, Ptr<const Packet>, double) { ++g_drops[ctx]; }
+void PhyRxDropCb(std::string ctx, Ptr<const Packet> p, WifiPhyRxfailureReason reason) {
+    std::ostringstream what;
+    what << ctx << ":" << reason;
+    NoteDrop(what.str(), p->GetSize());
+}
+void StaFailCb(std::string ctx, Mac48Address) { NoteDrop(ctx, 0); }
+void Ipv4DropCb(std::string ctx, const Ipv4Header&, Ptr<const Packet> p,
+                Ipv4L3Protocol::DropReason reason, Ptr<Ipv4>, uint32_t) {
+    const char* name = nullptr;
+    switch (reason) {
+        case Ipv4L3Protocol::DROP_TTL_EXPIRED:      name = "TTL_EXPIRED"; break;
+        case Ipv4L3Protocol::DROP_NO_ROUTE:         name = "NO_ROUTE"; break;
+        case Ipv4L3Protocol::DROP_BAD_CHECKSUM:     name = "BAD_CHECKSUM"; break;
+        case Ipv4L3Protocol::DROP_INTERFACE_DOWN:   name = "INTERFACE_DOWN"; break;
+        case Ipv4L3Protocol::DROP_ROUTE_ERROR:      name = "ROUTE_ERROR"; break;
+        case Ipv4L3Protocol::DROP_FRAGMENT_TIMEOUT: name = "FRAGMENT_TIMEOUT"; break;
+        default: break;
+    }
+    std::ostringstream what;
+    what << ctx << ":";
+    if (name) what << name; else what << static_cast<int>(reason);
+    NoteDrop(what.str(), p->GetSize());
+}
+
+void ConnectDropDiag(const NodeContainer& nodes, const NetDeviceContainer& devices) {
+    for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+        std::string n = "n" + std::to_string(i);
+        Ptr<WifiNetDevice> wd = DynamicCast<WifiNetDevice>(devices.Get(i));
+        if (wd) {
+            wd->GetPhy()->TraceConnect("PhyRxDrop", n + "/phyRxDrop",
+                                       MakeCallback(&PhyRxDropCb));
+            wd->GetPhy()->TraceConnect("PhyTxDrop", n + "/phyTxDrop",
+                                       MakeCallback(&PacketDropCb));
+            wd->GetPhy()->TraceConnect("PhyTxBegin", n + "/phyTxBegin",
+                                       MakeCallback(&PhyTxBeginCb));
+            wd->GetMac()->TraceConnect("MacTxDrop", n + "/macTxDrop",
+                                       MakeCallback(&PacketDropCb));
+            wd->GetMac()->TraceConnect("MacRxDrop", n + "/macRxDrop",
+                                       MakeCallback(&PacketDropCb));
+            wd->GetMac()->TraceConnect("MacRx", n + "/macRx",
+                                       MakeCallback(&PacketCountCb));
+            wd->GetRemoteStationManager()->TraceConnect(
+                "MacTxDataFailed", n + "/staTxDataFailed", MakeCallback(&StaFailCb));
+            wd->GetRemoteStationManager()->TraceConnect(
+                "MacTxFinalDataFailed", n + "/staTxFinalDataFailed",
+                MakeCallback(&StaFailCb));
+        }
+        Ptr<Ipv4L3Protocol> l3 = nodes.Get(i)->GetObject<Ipv4L3Protocol>();
+        if (l3) l3->TraceConnect("Drop", n + "/ipDrop", MakeCallback(&Ipv4DropCb));
+        Ptr<ArpL3Protocol> arp = nodes.Get(i)->GetObject<ArpL3Protocol>();
+        if (arp) arp->TraceConnect("Drop", n + "/arpDrop", MakeCallback(&PacketDropCb));
+    }
+}
+
 struct Params {
     uint32_t nNodes;
     double   simTime;
@@ -70,6 +144,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_controlPkts = 0;
     g_appTx = 0;
     g_appRx = 0;
+    g_drops.clear();
+    g_dropLines = 0;
 
     NodeContainer nodes;
     nodes.Create(P.nNodes);
@@ -138,6 +214,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     address.SetBase("10.1.0.0", "255.255.0.0");
     Ipv4InterfaceContainer ifs = address.Assign(devices);
 
+    if (g_dropDiag) ConnectDropDiag(nodes, devices);
+
     Ptr<UniformRandomVariable> startVar = CreateObject<UniformRandomVariable>();
     startVar->SetAttribute("Min", DoubleValue(0.0));
     startVar->SetAttribute("Max", DoubleValue(std::min(P.startWindow, P.simTime * 0.5)));
@@ -203,6 +281,11 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     std::cout << "  [diag " << proto << " seed=" << seed << "] TOTALS"
               << " fmTx=" << tx << " fmRx=" << rx
               << " appTx=" << g_appTx << " appRx=" << g_appRx << "\n";
+    if (g_dropDiag) {
+        std::cout << "  [dropdiag " << proto << " seed=" << seed << "] TOTALS";
+        for (const auto& kv : g_drops) std::cout << " " << kv.first << "=" << kv.second;
+        std::cout << "\n";
+    }
     r.pdr = tx ? 100.0 * rx / tx : 0.0;
     r.meanDelayMs = rx ? 1000.0 * totalDelay / rx : 0.0;
     r.nrl = rx ? static_cast<double>(g_controlPkts) / rx : 0.0;
@@ -242,6 +325,7 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("runs", "Number of RNG runs to average (seeds 1..runs)", runs);
     cmd.AddValue("protocols", "Comma-separated list (aodv,olsr,dsdv)", protocols);
     cmd.AddValue("propagation", "Propagation loss model: 'range' (disk) or 'tworay'", propagation);
+    cmd.AddValue("dropdiag", "Trace PHY/MAC/ARP/IP drop points per node (#51)", g_dropDiag);
     cmd.Parse(argc, argv);
     if (runs < 1) runs = 1;
 

--- a/ns3/examples/manet-baselines.cc
+++ b/ns3/examples/manet-baselines.cc
@@ -159,6 +159,7 @@ struct Params {
     uint32_t nFlows;
     double   cbrBps, startWindow;
     std::string propagation;
+    std::string rateManager;
 };
 
 struct Result {
@@ -180,6 +181,19 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
 
     WifiHelper wifi;
     wifi.SetStandard(WIFI_STANDARD_80211b);
+    // #51 A/B: the ns-3 default (IdealWifiManager) oscillates 1<->11 Mbps on
+    // this link and loses every second data frame to retry exhaustion.
+    if (P.rateManager == "arf") {
+        wifi.SetRemoteStationManager("ns3::ArfWifiManager");
+    } else if (P.rateManager.rfind("constant", 0) == 0) {
+        std::string rate = P.rateManager == "constant1"  ? "DsssRate1Mbps"
+                         : P.rateManager == "constant2"  ? "DsssRate2Mbps"
+                         : P.rateManager == "constant5"  ? "DsssRate5_5Mbps"
+                                                         : "DsssRate11Mbps";
+        wifi.SetRemoteStationManager("ns3::ConstantRateWifiManager",
+                                     "DataMode", StringValue(rate),
+                                     "ControlMode", StringValue("DsssRate1Mbps"));
+    }  // "ideal": keep the WifiHelper default
     YansWifiPhyHelper phy;
     YansWifiChannelHelper channel;
     if (P.propagation == "tworay") {
@@ -336,6 +350,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
 
 int main(int argc, char* argv[]) {
     std::string scenario, protocols = "aodv,olsr,dsdv", propagation = "range";
+    std::string rateManager = "ideal";
     int32_t nNodes = 0;
     double simTime = -1, area = -1, areaX = -1, areaY = -1;
     double speed = -1, pause = -1, range = -1, cbrBps = -1;
@@ -358,6 +373,9 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("protocols", "Comma-separated list (aodv,olsr,dsdv)", protocols);
     cmd.AddValue("propagation", "Propagation loss model: 'range' (disk) or 'tworay'", propagation);
     cmd.AddValue("dropdiag", "Trace PHY/MAC/ARP/IP drop points per node (#51)", g_dropDiag);
+    cmd.AddValue("rateManager",
+                 "Rate control: ideal (ns-3 default) | arf | constant1|constant2|"
+                 "constant5|constant11 (fixed DSSS rate; #51 A/B)", rateManager);
     cmd.Parse(argc, argv);
     if (runs < 1) runs = 1;
 
@@ -374,6 +392,7 @@ int main(int argc, char* argv[]) {
     P.cbrBps  = cbrBps >= 0 ? cbrBps : (paper ? 512.0 : 8000.0);
     P.startWindow = paper ? 180.0 : 5.0;
     P.propagation = propagation;
+    P.rateManager = rateManager;
 
     std::vector<std::string> list;
     std::stringstream ss(protocols);
@@ -384,7 +403,8 @@ int main(int argc, char* argv[]) {
               << " run(s)\n  nodes=" << P.nNodes << " time=" << P.simTime
               << "s area=" << P.areaX << "x" << P.areaY << "m speed=" << P.speed
               << "m/s pause=" << P.pause << "s range=" << P.range
-              << "m flows=" << P.nFlows << " propagation=" << P.propagation << "\n\n"
+              << "m flows=" << P.nFlows << " propagation=" << P.propagation
+              << " rateManager=" << P.rateManager << "\n\n"
               << "protocol        PDR%  delay(ms)  delay99(ms)     NRL\n"
               << "--------------------------------------------------------\n";
     for (const std::string& proto : list) {

--- a/ns3/examples/manet-baselines.cc
+++ b/ns3/examples/manet-baselines.cc
@@ -46,7 +46,7 @@ void CountTx(Ptr<const Packet>, Ptr<Ipv4>, uint32_t) { ++g_controlPkts; }
 // #24 ground truth, independent of FlowMonitor: count what the OnOff apps
 // actually send and what the PacketSinks actually receive.
 uint64_t g_appTx = 0, g_appRx = 0;
-void AppTx(Ptr<const Packet>) { ++g_appTx; }
+void AppTx(Ptr<const Packet>);
 void AppRx(Ptr<const Packet>, const Address&) { ++g_appRx; }
 
 // #51 drop localization (gated by --dropdiag): per-node counters for every
@@ -56,13 +56,26 @@ void AppRx(Ptr<const Packet>, const Address&) { ++g_appRx; }
 bool g_dropDiag = false;
 std::map<std::string, uint64_t> g_drops;
 uint32_t g_dropLines = 0;
-constexpr uint32_t kMaxDropLines = 40;
+constexpr uint32_t kMaxDropLines = 60;
+// First two nodes' mobility, so drop events can report the live distance
+// (discriminates "receiver out of range per the loss model" from everything
+// else — YansWifiChannel silently skips receivers below sensitivity).
+Ptr<MobilityModel> g_mobA, g_mobB;
 
-void NoteDrop(const std::string& what, uint32_t size) {
+std::string PosStr() {
+    if (!g_mobA || !g_mobB) return "";
+    Vector a = g_mobA->GetPosition(), b = g_mobB->GetPosition();
+    std::ostringstream os;
+    os << " d=" << g_mobA->GetDistanceFrom(g_mobB)
+       << " a=(" << a.x << "," << a.y << ") b=(" << b.x << "," << b.y << ")";
+    return os.str();
+}
+
+void NoteDrop(const std::string& what, uint32_t size, const std::string& extra = "") {
     ++g_drops[what];
     if (g_dropLines < kMaxDropLines) {
         std::cout << "  [dropdiag] t=" << Simulator::Now().GetSeconds()
-                  << " " << what << " size=" << size << "\n";
+                  << " " << what << " size=" << size << extra << "\n";
         ++g_dropLines;
     }
 }
@@ -74,7 +87,11 @@ void PhyRxDropCb(std::string ctx, Ptr<const Packet> p, WifiPhyRxfailureReason re
     what << ctx << ":" << reason;
     NoteDrop(what.str(), p->GetSize());
 }
-void StaFailCb(std::string ctx, Mac48Address) { NoteDrop(ctx, 0); }
+void StaFailCb(std::string ctx, Mac48Address) { NoteDrop(ctx, 0, PosStr()); }
+void DistanceProbe() {
+    std::cout << "  [dropdiag] t=" << Simulator::Now().GetSeconds()
+              << " probe" << PosStr() << "\n";
+}
 void Ipv4DropCb(std::string ctx, const Ipv4Header&, Ptr<const Packet> p,
                 Ipv4L3Protocol::DropReason reason, Ptr<Ipv4>, uint32_t) {
     const char* name = nullptr;
@@ -93,7 +110,18 @@ void Ipv4DropCb(std::string ctx, const Ipv4Header&, Ptr<const Packet> p,
     NoteDrop(what.str(), p->GetSize());
 }
 
+// Defined after the dropdiag helpers so it can report the send-time distance.
+void AppTx(Ptr<const Packet>) {
+    ++g_appTx;
+    if (g_dropDiag && g_appTx <= 16) {
+        std::cout << "  [dropdiag] t=" << Simulator::Now().GetSeconds()
+                  << " appTx#" << g_appTx << PosStr() << "\n";
+    }
+}
+
 void ConnectDropDiag(const NodeContainer& nodes, const NetDeviceContainer& devices) {
+    g_mobA = nodes.GetN() > 0 ? nodes.Get(0)->GetObject<MobilityModel>() : nullptr;
+    g_mobB = nodes.GetN() > 1 ? nodes.Get(1)->GetObject<MobilityModel>() : nullptr;
     for (uint32_t i = 0; i < nodes.GetN(); ++i) {
         std::string n = "n" + std::to_string(i);
         Ptr<WifiNetDevice> wd = DynamicCast<WifiNetDevice>(devices.Get(i));
@@ -214,7 +242,11 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     address.SetBase("10.1.0.0", "255.255.0.0");
     Ipv4InterfaceContainer ifs = address.Assign(devices);
 
-    if (g_dropDiag) ConnectDropDiag(nodes, devices);
+    if (g_dropDiag) {
+        ConnectDropDiag(nodes, devices);
+        for (double t = 0.0; t < P.simTime; t += 20.0)
+            Simulator::Schedule(Seconds(t), &DistanceProbe);
+    }
 
     Ptr<UniformRandomVariable> startVar = CreateObject<UniformRandomVariable>();
     startVar->SetAttribute("Min", DoubleValue(0.0));

--- a/ns3/examples/manet-baselines.cc
+++ b/ns3/examples/manet-baselines.cc
@@ -181,8 +181,10 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
 
     WifiHelper wifi;
     wifi.SetStandard(WIFI_STANDARD_80211b);
-    // #51 A/B: the ns-3 default (IdealWifiManager) oscillates 1<->11 Mbps on
-    // this link and loses every second data frame to retry exhaustion.
+    // #51: the ns-3 default (IdealWifiManager) oscillates 1<->11 Mbps and loses
+    // every second unicast to retry exhaustion (DSSS 11 Mbps never delivers in
+    // this setup). Default is the paper's fixed 2 Mbit/s radio; --rateManager
+    // reaches the alternatives (including the old behaviour, 'ideal') for A/B.
     if (P.rateManager == "arf") {
         wifi.SetRemoteStationManager("ns3::ArfWifiManager");
     } else if (P.rateManager.rfind("constant", 0) == 0) {
@@ -350,7 +352,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
 
 int main(int argc, char* argv[]) {
     std::string scenario, protocols = "aodv,olsr,dsdv", propagation = "range";
-    std::string rateManager = "ideal";
+    std::string rateManager = "constant2";
     int32_t nNodes = 0;
     double simTime = -1, area = -1, areaX = -1, areaY = -1;
     double speed = -1, pause = -1, range = -1, cbrBps = -1;
@@ -374,8 +376,9 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("propagation", "Propagation loss model: 'range' (disk) or 'tworay'", propagation);
     cmd.AddValue("dropdiag", "Trace PHY/MAC/ARP/IP drop points per node (#51)", g_dropDiag);
     cmd.AddValue("rateManager",
-                 "Rate control: ideal (ns-3 default) | arf | constant1|constant2|"
-                 "constant5|constant11 (fixed DSSS rate; #51 A/B)", rateManager);
+                 "Rate control: constant1|constant2|constant5|constant11 (fixed "
+                 "DSSS rate; default constant2, the paper's radio) | arf | ideal "
+                 "(ns-3 default; loses ~50% single-hop, #51)", rateManager);
     cmd.Parse(argc, argv);
     if (runs < 1) runs = 1;
 


### PR DESCRIPTION
Root-causes and fixes #51 — the stock single-hop ~50% UDP loss that depressed every absolute PDR number in the benchmark taxonomy (the #24 whole-field depression).

## Root cause (full evidence thread on #51)

No harness in this repo set a `RemoteStationManager`, so every binary inherited ns-3's default **`IdealWifiManager`**. Under the 0-loss disk model each delivered frame reports a huge SNR, so Ideal promotes the next unicast to **DSSS 11 Mbps — which never delivers in this stack configuration** (a pinned `constant11` radio scores 0.0% PDR and even loses unicast ARP replies). The frame burns all 7 MAC retries (receiver PHY completely silent), the failure resets the feedback, the next frame goes out at 1 Mbps and delivers — one packet in two lost, strictly alternating, protocol-independent. Proven by per-drop-point tracing (`--dropdiag`) plus a rate-manager A/B on the 2-node in-range static reproducer:

| rateManager | aodv | olsr | dsdv |
|---|---:|---:|---:|
| ideal (old default) | 50.5 | 50.5 | 50.4 |
| **constant2** | **100.0** | **100.0** | **100.0** |
| constant11 | 0.0 | 0.0 | 0.0 |
| arf | 100.0 | 100.0 | 100.0 |

## Changes

- `anthocnet-compare`, `manet-baselines`, `anthocnet-example`: default to the paper's fixed 2 Mbit/s radio (`ConstantRateWifiManager`, `DsssRate2Mbps` data / `DsssRate1Mbps` control); `--rateManager={constant1|constant2|constant5|constant11|arf|ideal}` keeps every variant reachable for A/B (compare + baselines).
- `manet-baselines`: `--dropdiag` drop-point instrumentation (PHY/MAC/remote-station/ARP/IP drop traces, position probes), default off — the tooling that localized the bug, kept for future diagnosis.
- `docs/benchmarks.md`: #51 root-cause section updated to resolved; re-baselining of the published tables happens automatically on merge (`benchmarks.yml`).

## Validation (3-run means, commit 975730a)

- 2-node in-range anchor: 50.4% → **100.0%**.
- Acceptance gate (`docs/benchmarks.md`): stock AODV **92.5%** on the low-mobility Broch field (criterion ≈90%) — olsr 100.0, dsdv 99.7 ([run 29631443698](https://github.com/danieljoppi/AntHocNet/actions/runs/29631443698)).
- Paper regime ([run 29631444272](https://github.com/danieljoppi/AntHocNet/actions/runs/29631444272)): **anthocnet 21.1 → 87.7**, aodv 25.1 → 80.9, olsr 35.2 → 78.7, dsdv 28.8 → 72.0 — the field moves into the paper's 84–98% band and AntHocNet leads AODV in its design regime. AntHocNet's delay tail (7.4 s delay99) remains and is tracked in #21/#23.

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s

---
_Generated by [Claude Code](https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s)_