### PR TITLE
fix(core): bound the LinkFail origin storm + honest convergence metric (#20, #23)

### DIFF
--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -55,6 +55,12 @@ public:
     std::uint64_t antsReceived(AntType type) const;
     /// Total ant control packets sent across all types (routing overhead).
     std::uint64_t controlPacketsSent() const;
+    /// LinkFail notes this node re-broadcast on another reporter's behalf
+    /// (issue #20: origins = antsSent(LinkFail) − propagations).
+    std::uint64_t linkfailPropagations() const { return linkfailPropagations_; }
+    /// LinkFail propagations suppressed by an exhausted inherited
+    /// broadcastBudget — how often the depth bound actually bites (issue #20).
+    std::uint64_t linkfailBudgetDrops() const { return linkfailBudgetDrops_; }
 
     // --- neighbour learning ----------------------------------------------
     /// Record that `neighbor` is reachable (link-layer detection / hello),
@@ -191,6 +197,8 @@ private:
     IRouterObserver* observer_ = nullptr;           ///< optional, item 15
     std::map<AntType, std::uint64_t> antsSent_;     ///< sent counters by type
     std::map<AntType, std::uint64_t> antsReceived_; ///< received counters by type
+    std::uint64_t linkfailPropagations_ = 0;        ///< re-broadcast LinkFails (issue #20)
+    std::uint64_t linkfailBudgetDrops_  = 0;        ///< budget-suppressed propagations (issue #20)
 };
 
 } // namespace core

--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -61,6 +61,9 @@ public:
     /// LinkFail propagations suppressed by an exhausted inherited
     /// broadcastBudget — how often the depth bound actually bites (issue #20).
     std::uint64_t linkfailBudgetDrops() const { return linkfailBudgetDrops_; }
+    /// Per-destination advertisements dropped by the origin cooldown
+    /// (config.linkfailNotifyInterval, issue #20).
+    std::uint64_t linkfailOriginsSuppressed() const { return linkfailOriginsSuppressed_; }
 
     // --- neighbour learning ----------------------------------------------
     /// Record that `neighbor` is reachable (link-layer detection / hello),
@@ -199,6 +202,8 @@ private:
     std::map<AntType, std::uint64_t> antsReceived_; ///< received counters by type
     std::uint64_t linkfailPropagations_ = 0;        ///< re-broadcast LinkFails (issue #20)
     std::uint64_t linkfailBudgetDrops_  = 0;        ///< budget-suppressed propagations (issue #20)
+    std::uint64_t linkfailOriginsSuppressed_ = 0;   ///< cooldown-suppressed advertisements (issue #20)
+    std::map<NodeAddress, double> lastLinkfailNotify_;  ///< dest -> last originated LinkFail time
 };
 
 } // namespace core

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -76,6 +76,13 @@ struct Config {
     /// Max times a repair / link-failure ant may be (re)broadcast before being
     /// dropped, so local repair and failure notifications can't storm ([1] §3.5).
     int repairMaxBroadcasts = 2;
+
+    /// Minimum spacing (s) between LinkFail notifications this node originates
+    /// about the same destination. Under link flapping (evict -> hello
+    /// re-learn -> evict) every cycle re-broadcast a fresh note about the same
+    /// destinations, making origins ~98% of linkfail volume (issue #20).
+    /// 0 disables the cooldown (the original spec has no rate limit).
+    double linkfailNotifyInterval = 1.0;
     /// Consecutive MAC transmit-failures to the same next hop (with no reception
     /// from it in between) before the adapter's fast-path detector (ADR-0008
     /// detector D) treats the link as broken. Debounces transient congestion

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -81,8 +81,10 @@ struct Config {
     /// about the same destination. Under link flapping (evict -> hello
     /// re-learn -> evict) every cycle re-broadcast a fresh note about the same
     /// destinations, making origins ~98% of linkfail volume (issue #20).
-    /// 0 disables the cooldown (the original spec has no rate limit).
-    double linkfailNotifyInterval = 1.0;
+    /// The #20 sweep picked 5.0: 1 s misses the ~3+ s flap cycle (no effect),
+    /// 10 s starts costing PDR/delay. 0 disables the cooldown (the original
+    /// spec has no rate limit).
+    double linkfailNotifyInterval = 5.0;
     /// Consecutive MAC transmit-failures to the same next hop (with no reception
     /// from it in between) before the adapter's fast-path detector (ADR-0008
     /// detector D) treats the link as broken. Debounces transient congestion

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -230,7 +230,10 @@ std::vector<RouteDecision> AntRouterLogic::handleLinkFail(const AntMessage& note
     prop.dst       = kInvalidAddress;
     prop.seqNum    = nextSeq();
     prop.timeStart = clock_.now();
-    return {broadcastForward(prop)};
+    RouteDecision d = broadcastForward(prop);
+    if (d.action == RouteAction::Broadcast) ++linkfailPropagations_;
+    else ++linkfailBudgetDrops_;
+    return {d};
 }
 
 // --- active sessions (item 04) ----------------------------------------------

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -74,6 +74,18 @@ std::vector<RouteDecision> AntRouterLogic::onMaintenanceTick() {
 
         out.push_back({RouteAction::DiscardPending, dest, false, {}});
 
+        // Same origin cooldown as reportNeighborLoss (issue #20): the break
+        // that armed this repair usually already advertised dest's loss.
+        if (config_.linkfailNotifyInterval > 0.0) {
+            auto itN = lastLinkfailNotify_.find(dest);
+            if (itN != lastLinkfailNotify_.end() &&
+                now - itN->second < config_.linkfailNotifyInterval) {
+                ++linkfailOriginsSuppressed_;
+                continue;
+            }
+            lastLinkfailNotify_[dest] = now;
+        }
+
         AntMessage note;
         note.type            = AntType::LinkFail;
         note.direction       = AntDirection::Up;
@@ -132,9 +144,23 @@ std::vector<RouteDecision> AntRouterLogic::reportNeighborLoss(NodeAddress n) {
     loseNeighbor(n);  // prune n from the table + last-seen
 
     AntMessage note;
+    const double now = clock_.now();
     for (const auto& pr : affected) {
         const double after = table_.bestRegular(pr.first);
-        if (after < pr.second) note.helloDests.push_back({pr.first, after});  // we lost ground
+        if (after >= pr.second) continue;  // no ground lost
+        // Origin cooldown (issue #20): under link flapping, re-advertising the
+        // same destination every evict/re-learn cycle is what turns breaks into
+        // a notification storm; neighbours already applied the first note.
+        if (config_.linkfailNotifyInterval > 0.0) {
+            auto it = lastLinkfailNotify_.find(pr.first);
+            if (it != lastLinkfailNotify_.end() &&
+                now - it->second < config_.linkfailNotifyInterval) {
+                ++linkfailOriginsSuppressed_;
+                continue;
+            }
+            lastLinkfailNotify_[pr.first] = now;
+        }
+        note.helloDests.push_back({pr.first, after});
     }
     if (note.helloDests.empty()) return {};
 

--- a/core/tests/test_link_failure.cpp
+++ b/core/tests/test_link_failure.cpp
@@ -102,6 +102,24 @@ int main() {
         CHECK(decs[0].action == RouteAction::Broadcast);
         CHECK(decs[0].message.type == AntType::LinkFail);
         CHECK_NEAR(router.table().getPheromoneRegular(9, 5), 0.0, 1e-12);
+        // Issue #20: the re-broadcast is counted as a propagation, not an origin.
+        CHECK_EQ(router.linkfailPropagations(), static_cast<std::uint64_t>(1));
+        CHECK_EQ(router.linkfailBudgetDrops(), static_cast<std::uint64_t>(0));
+
+        // Same situation but the inherited budget is exhausted: the propagation
+        // is suppressed and counted as a budget drop.
+        router.table().setPheromoneRegular(9, 5, 0.8);
+        AntMessage spent = note;
+        spent.seqNum = 2;
+        spent.broadcastBudget = 0;
+        auto decs2 = router.onReceiveAnt(spent, /*prevHop*/ 5);
+        bool rebroadcast = false;
+        for (const auto& d : decs2) {
+            if (d.action == RouteAction::Broadcast) rebroadcast = true;
+        }
+        CHECK(!rebroadcast);
+        CHECK_EQ(router.linkfailPropagations(), static_cast<std::uint64_t>(1));
+        CHECK_EQ(router.linkfailBudgetDrops(), static_cast<std::uint64_t>(1));
     }
     {
         FakeClock clock;

--- a/core/tests/test_link_failure.cpp
+++ b/core/tests/test_link_failure.cpp
@@ -348,5 +348,45 @@ int main() {
         CHECK(router.onMaintenanceTick().empty());
     }
 
+    // 14. Issue #20: per-destination origin cooldown — a flapping link does not
+    //     re-originate a LinkFail for the same destination within
+    //     linkfailNotifyInterval; it resumes once the window elapses.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 0, cfg, clock, rng);  // interval = 1.0 default
+        auto hasLinkFail = [](const std::vector<RouteDecision>& decs) {
+            for (const RouteDecision& d : decs) {
+                if (d.action == RouteAction::Broadcast &&
+                    d.message.type == AntType::LinkFail) return true;
+            }
+            return false;
+        };
+
+        router.table().setPheromoneRegular(9, 5, 0.8);
+        CHECK(hasLinkFail(router.reportNeighborLoss(5)));  // first loss notifies
+
+        router.table().setPheromoneRegular(9, 5, 0.8);     // flap: route re-forms
+        clock.advance(0.4);                                // inside the window
+        CHECK(!hasLinkFail(router.reportNeighborLoss(5)));
+        CHECK_EQ(router.linkfailOriginsSuppressed(), static_cast<std::uint64_t>(1));
+
+        router.table().setPheromoneRegular(9, 5, 0.8);     // flap again
+        clock.advance(cfg.linkfailNotifyInterval + 0.1);   // window elapsed
+        CHECK(hasLinkFail(router.reportNeighborLoss(5)));
+
+        // interval = 0 disables the cooldown entirely.
+        Config cfg0 = cfg;
+        cfg0.linkfailNotifyInterval = 0.0;
+        FakeClock clock0;
+        ScriptedRng rng0({0.5});
+        AntRouterLogic router0(/*addr*/ 0, cfg0, clock0, rng0);
+        router0.table().setPheromoneRegular(9, 5, 0.8);
+        CHECK(hasLinkFail(router0.reportNeighborLoss(5)));
+        router0.table().setPheromoneRegular(9, 5, 0.8);
+        CHECK(hasLinkFail(router0.reportNeighborLoss(5)));  // immediate repeat allowed
+        CHECK_EQ(router0.linkfailOriginsSuppressed(), static_cast<std::uint64_t>(0));
+    }
+
     return RUN_TESTS();
 }

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -76,6 +76,13 @@ bool g_diag = false;
 std::map<uint8_t, uint64_t> g_antTx;   // by AntType byte
 std::map<uint8_t, uint64_t> g_antRx;
 double g_firstDeliveryS = -1.0;
+// #23: per-flow route-setup latency. g_firstDeliveryS alone is the sim time of
+// the FIRST packet any sink receives — a min over all flows' random starts —
+// so it measures the luckiest flow, not convergence. Track per-flow app start
+// and first sink Rx instead (index-aligned with `sinks`; default pairing only,
+// converge/--sink mode shares one sink and is skipped).
+std::vector<double> g_flowStart;
+std::vector<double> g_flowFirstRx;  // -1 = flow never delivered
 
 void DiagAntTx(uint8_t type, uint8_t /*dir*/, bool /*broadcast*/) {
     if (g_diag) g_antTx[type] += 1;
@@ -85,6 +92,12 @@ void DiagAntRx(uint8_t type, uint8_t /*dir*/) {
 }
 void DiagSinkRx(Ptr<const Packet>, const Address&) {
     if (g_firstDeliveryS < 0.0) g_firstDeliveryS = Simulator::Now().GetSeconds();
+}
+void DiagSinkRxFlow(uint32_t idx, Ptr<const Packet> p, const Address& a) {
+    DiagSinkRx(p, a);
+    if (idx < g_flowFirstRx.size() && g_flowFirstRx[idx] < 0.0) {
+        g_flowFirstRx[idx] = Simulator::Now().GetSeconds();
+    }
 }
 
 // --- queue diagnostics (--qdiag): does the A2 congestion signal exist? --------
@@ -163,6 +176,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_antTx.clear();
     g_antRx.clear();
     g_firstDeliveryS = -1.0;
+    g_flowStart.clear();
+    g_flowFirstRx.clear();
     g_qCount = g_qNonzero = g_qMax = 0;
     g_qSum = 0.0;
 
@@ -288,13 +303,15 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                           InetSocketAddress(ifs.GetAddress(dst), port));
         onoff.SetAttribute("DataRate", StringValue(rate.str()));
         onoff.SetAttribute("PacketSize", UintegerValue(64));
-        onoff.SetAttribute("StartTime", TimeValue(Seconds(startVar->GetValue())));
+        const double startS = startVar->GetValue();
+        onoff.SetAttribute("StartTime", TimeValue(Seconds(startS)));
         onoff.SetAttribute("StopTime", TimeValue(Seconds(P.simTime - 1.0)));
         apps.Add(onoff.Install(nodes.Get(src)));
 
         // In converge mode every flow shares one sink node/port, so install its
         // PacketSink exactly once (a second bind on the same port would fail).
         if (!converge) {
+            g_flowStart.push_back(startS);  // #23: index-aligned with `sinks`
             PacketSinkHelper sink("ns3::UdpSocketFactory",
                                   InetSocketAddress(Ipv4Address::GetAny(), port));
             sinks.Add(sink.Install(nodes.Get(dst)));
@@ -308,9 +325,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     sinks.Start(Seconds(0.0));
 
     if (g_diag) {
-        // First-delivery timestamp from every data sink (all protocols).
+        // First-delivery timestamp from every data sink (all protocols), plus
+        // per-flow first-Rx for the #23 setup-latency metric (default pairing
+        // only; converge mode has one shared sink and no per-flow mapping).
+        g_flowFirstRx.assign(g_flowStart.size(), -1.0);
         for (uint32_t i = 0; i < sinks.GetN(); ++i) {
-            sinks.Get(i)->TraceConnectWithoutContext("Rx", MakeCallback(&DiagSinkRx));
+            if (!converge && sinks.GetN() == g_flowStart.size()) {
+                sinks.Get(i)->TraceConnectWithoutContext(
+                    "Rx", MakeBoundCallback(&DiagSinkRxFlow, i));
+            } else {
+                sinks.Get(i)->TraceConnectWithoutContext("Rx", MakeCallback(&DiagSinkRx));
+            }
         }
         // Per-type ant tallies from AntHocNet's own trace sources (item 15).
         // Guarded to anthocnet: other protocols have no "Tx"/"Rx" ant traces.
@@ -394,6 +419,22 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                   << " pdr=" << r.pdr
                   << " firstDeliveryS=" << g_firstDeliveryS
                   << " ctrlTx=" << g_controlPkts;
+        // #23: route-setup latency per flow (first delivery − flow start).
+        {
+            std::vector<double> setup;
+            uint32_t never = 0;
+            for (std::size_t i = 0; i < g_flowFirstRx.size(); ++i) {
+                if (g_flowFirstRx[i] < 0.0) { ++never; continue; }
+                setup.push_back(g_flowFirstRx[i] - g_flowStart[i]);
+            }
+            if (!setup.empty() || never > 0) {
+                std::sort(setup.begin(), setup.end());
+                std::cout << " setupMedS="
+                          << (setup.empty() ? -1.0 : setup[setup.size() / 2])
+                          << " setupMaxS=" << (setup.empty() ? -1.0 : setup.back())
+                          << " flowsNoDelivery=" << never;
+            }
+        }
         if (proto == "anthocnet") {
             auto n = [](std::map<uint8_t, uint64_t>& m, uint8_t k) {
                 auto it = m.find(k);

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -412,7 +412,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             // Issue #20: origin vs propagation split of the linkfail volume
             // (origins = antTx[linkfail] - linkfailProp; budgetDrop counts
             // propagations suppressed by the inherited broadcastBudget).
-            uint64_t lfProp = 0, lfBudget = 0;
+            uint64_t lfProp = 0, lfBudget = 0, lfSuppressed = 0;
             for (uint32_t i = 0; i < nodes.GetN(); ++i) {
                 Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
                 if (!ip) continue;
@@ -421,9 +421,11 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                 if (!ahn) continue;
                 lfProp += ahn->LinkfailPropagations();
                 lfBudget += ahn->LinkfailBudgetDrops();
+                lfSuppressed += ahn->LinkfailOriginsSuppressed();
             }
             std::cout << " linkfailProp=" << lfProp
-                      << " linkfailBudgetDrop=" << lfBudget;
+                      << " linkfailBudgetDrop=" << lfBudget
+                      << " linkfailOrigSuppressed=" << lfSuppressed;
         }
         std::cout << "\n";
     }

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -37,6 +37,7 @@
 #include "ns3/olsr-module.h"
 #include "ns3/dsdv-module.h"
 #include "ns3/anthocnet-helper.h"
+#include "ns3/anthocnet-routing-protocol.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -408,6 +409,21 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                       << ",proactive=" << n(g_antRx, 0x04)
                       << ",repair=" << n(g_antRx, 0x08)
                       << ",linkfail=" << n(g_antRx, 0x10) << "]";
+            // Issue #20: origin vs propagation split of the linkfail volume
+            // (origins = antTx[linkfail] - linkfailProp; budgetDrop counts
+            // propagations suppressed by the inherited broadcastBudget).
+            uint64_t lfProp = 0, lfBudget = 0;
+            for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+                Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
+                if (!ip) continue;
+                Ptr<anthocnet::RoutingProtocol> ahn =
+                    DynamicCast<anthocnet::RoutingProtocol>(ip->GetRoutingProtocol());
+                if (!ahn) continue;
+                lfProp += ahn->LinkfailPropagations();
+                lfBudget += ahn->LinkfailBudgetDrops();
+            }
+            std::cout << " linkfailProp=" << lfProp
+                      << " linkfailBudgetDrop=" << lfBudget;
         }
         std::cout << "\n";
     }

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -416,8 +416,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             for (uint32_t i = 0; i < nodes.GetN(); ++i) {
                 Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
                 if (!ip) continue;
-                Ptr<anthocnet::RoutingProtocol> ahn =
-                    DynamicCast<anthocnet::RoutingProtocol>(ip->GetRoutingProtocol());
+                Ptr<ns3::anthocnet::RoutingProtocol> ahn =
+                    DynamicCast<ns3::anthocnet::RoutingProtocol>(ip->GetRoutingProtocol());
                 if (!ahn) continue;
                 lfProp += ahn->LinkfailPropagations();
                 lfBudget += ahn->LinkfailBudgetDrops();

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -53,6 +53,7 @@ RoutingProtocol::RoutingProtocol()
       m_enableMacFailureDetector(true),
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
+      m_linkfailNotifyInterval(1.0),
       m_enableMacMetric(false) {}
 
 RoutingProtocol::~RoutingProtocol() = default;
@@ -132,6 +133,13 @@ TypeId RoutingProtocol::GetTypeId() {
                           DoubleValue(1.0),
                           MakeDoubleAccessor(&RoutingProtocol::m_repairTimeout),
                           MakeDoubleChecker<double>())
+            .AddAttribute("LinkfailNotifyInterval",
+                          "Minimum spacing (s) between LinkFail notifications "
+                          "originated about the same destination (issue #20); "
+                          "0 disables the cooldown.",
+                          DoubleValue(1.0),
+                          MakeDoubleAccessor(&RoutingProtocol::m_linkfailNotifyInterval),
+                          MakeDoubleChecker<double>(0.0))
             .AddAttribute("EnableMacMetric",
                           "Congestion-aware per-hop cost (item 10/A2): forward ants "
                           "record (MAC-queue+1)*hop-time instead of wall-clock "
@@ -223,6 +231,7 @@ void RoutingProtocol::DoInitialize() {
     m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
     m_config.repairWaitFactor = m_repairWaitFactor;
     m_config.repairTimeout = m_repairTimeout;
+    m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
     m_config.enableMacMetric = m_enableMacMetric;
     Ipv4RoutingProtocol::DoInitialize();
 }
@@ -274,6 +283,7 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
         m_config.repairWaitFactor = m_repairWaitFactor;
         m_config.repairTimeout = m_repairTimeout;
+        m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
         m_config.enableMacMetric = m_enableMacMetric;
         m_logic.reset(new ::anthocnet::core::AntRouterLogic(
             ToCore(iface.GetLocal()), m_config, m_clock, m_rng,

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -53,7 +53,7 @@ RoutingProtocol::RoutingProtocol()
       m_enableMacFailureDetector(true),
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
-      m_linkfailNotifyInterval(1.0),
+      m_linkfailNotifyInterval(5.0),
       m_enableMacMetric(false) {}
 
 RoutingProtocol::~RoutingProtocol() = default;
@@ -137,7 +137,7 @@ TypeId RoutingProtocol::GetTypeId() {
                           "Minimum spacing (s) between LinkFail notifications "
                           "originated about the same destination (issue #20); "
                           "0 disables the cooldown.",
-                          DoubleValue(1.0),
+                          DoubleValue(5.0),
                           MakeDoubleAccessor(&RoutingProtocol::m_linkfailNotifyInterval),
                           MakeDoubleChecker<double>(0.0))
             .AddAttribute("EnableMacMetric",

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -202,6 +202,7 @@ private:
     bool m_enableMacFailureDetector;
     double m_repairWaitFactor;
     double m_repairTimeout;
+    double m_linkfailNotifyInterval;  ///< issue #20 origin cooldown (s), 0 = off
     bool m_enableMacMetric;  ///< item 10/A2 congestion-aware per-hop metric
 
     // WifiMac handle for the item-10/A2 queue-occupancy signal (null on non-wifi

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -110,6 +110,9 @@ public:
     uint64_t LinkfailBudgetDrops() const {
         return m_logic ? m_logic->linkfailBudgetDrops() : 0;
     }
+    uint64_t LinkfailOriginsSuppressed() const {
+        return m_logic ? m_logic->linkfailOriginsSuppressed() : 0;
+    }
 
 protected:
     void DoInitialize() override;

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -102,6 +102,15 @@ public:
     /// Seed the protocol's RNG; returns the number of streams used.
     int64_t AssignStreams(int64_t stream);
 
+    /// Issue #20 diagnostics: LinkFail origin/propagation split from the core
+    /// (origins = antTx[linkfail] − propagations; budget drops = suppressed).
+    uint64_t LinkfailPropagations() const {
+        return m_logic ? m_logic->linkfailPropagations() : 0;
+    }
+    uint64_t LinkfailBudgetDrops() const {
+        return m_logic ? m_logic->linkfailBudgetDrops() : 0;
+    }
+
 protected:
     void DoInitialize() override;
     void DoDispose() override;


### PR DESCRIPTION
Resolves the two P1s investigated after #51: the LinkFail broadcast storm (#20, fixed) and the slow-convergence report (#23, shown to be a measurement artifact). Full evidence threads live on the issues.

## #20 — LinkFail origin storm

**Measured mechanism** (drop-split counters, [evidence](https://github.com/danieljoppi/AntHocNet/issues/20#issuecomment-5011162051)): ~98% of linkfail volume is *origins*, not propagation — link flapping (evict → hello re-learn → re-evict) re-broadcast a fresh notification about the same destinations every ~3+ s cycle. Propagation was already properly damped (2%; lost-ground absorption + `broadcastBudget`), falsifying the issue body's cascade hypothesis.

**Fix**: per-destination origin cooldown — `Config::linkfailNotifyInterval` / ns-3 attribute `LinkfailNotifyInterval` (0 restores original-spec behaviour), applied in `reportNeighborLoss` and the D6 repair-timeout path. Window chosen by sweep on identical seeds: 1 s misses the flap cycle (no effect), 10 s costs PDR/delay, **5 s default** → linkfail −25%, total ctrlTx −9%, NRL −8.7%, PDR within seed noise. Covered by `test_link_failure` case 14 (notify → in-window flap suppressed → post-window resumes → 0 disables).

**Validation** ([final tables](https://github.com/danieljoppi/AntHocNet/issues/20#issuecomment-5012095379)): paper regime anthocnet 86.4 PDR / **36.92 NRL** (still leads the field); high-mobility (speed 30, pause 0) **NRL 39.35 vs AODV 65.60**, PDR 85.8 vs 78.1 — the issue's acceptance criterion holds with margin.

**Instrumentation retained**: `linkfailProp` / `linkfailBudgetDrop` / `linkfailOrigSuppressed` in `--diag`.

## #23 — convergence was a metric artifact

`firstDeliveryS` records the sim time of the first packet received by *any* sink — the minimum over 20 flows with uniform(0,150 s) starts — so the issue's "22–45 s" measured the luckiest flow against sim start, not route setup. This PR adds the honest per-flow metric (`setupMedS`/`setupMaxS`/`flowsNoDelivery` = first delivery − flow start) to `--diag` for every protocol. [Measured](https://github.com/danieljoppi/AntHocNet/issues/23#issuecomment-5012365659): AntHocNet median setup is **~2.0 s = the OnOff first-packet floor, better than AODV's 2.1–3.0 s**; `flowsNoDelivery=0` everywhere. Residual worst-flow tail folds into #21.

## Verification

- `make test`: 18/18 core tests (new case in `test_link_failure.cpp`).
- `check_invariants.sh`: no NS headers in core, core change carries a core test, wire format untouched.
- CI matrix validates the ns-3 module/example builds across 3.36–3.48 on this PR.
- Behaviour A/B'd on CI as linked above; benchmark docs re-baseline automatically on merge.

Closes #20. Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s

---
_Generated by [Claude Code](https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s)_