### PR TITLE
feat: measured A2 MAC metric (ns-3 + ns-2) + blocking benchmark anchors

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,6 +47,17 @@ jobs:
           ./ns3 build
       - name: Install matplotlib
         run: apt-get update && apt-get install -y python3-matplotlib
+      - name: Validation-anchor gate (blocks publish; #59)
+        # Run the known-expected anchors on the *stock* baselines harness
+        # before producing or publishing any numbers: if an anchor regresses
+        # (cf. the #51 ~50% single-hop loss that silently depressed every
+        # published PDR ~2x) this step fails and the table/charts below are
+        # never refreshed from a mis-calibrated channel. Thresholds live in
+        # ns3/tools/anchors.yml; rationale in docs/benchmarks.md "Validation
+        # anchors".
+        run: |
+          bash ns3/tools/check-anchors.sh /opt/ns-3 single-hop
+          bash ns3/tools/check-anchors.sh /opt/ns-3 broch-low-mobility
       - name: Run scenario taxonomy (quick)
         run: |
           python3 ns3/tools/run-scenarios.py /opt/ns-3 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,13 @@ jobs:
           echo "AntHocNet PDR% = ${pdr:-<none>}"
           awk -v p="${pdr:-0}" 'BEGIN { exit (p+0 > 0) ? 0 : 1 }' \
             || { echo "FAIL: AntHocNet delivered no packets (PDR=${pdr:-<none>})"; exit 1; }
+      - name: Validation-anchor gate (single-hop PDR floor, #59)
+        # Blocking anchor from docs/benchmarks.md "Validation anchors": on a
+        # static, in-range 2-node link the *stock* stack (manet-baselines, no
+        # AntHocNet code) must deliver ~100% — a #51-style channel/rate-manager
+        # regression reads ~50% and used to go completely undetected. Runs on
+        # one matrix version to keep CI cheap (this reuses the job's build);
+        # the heavier Broch-field anchor runs per-merge in benchmarks.yml.
+        # Thresholds: ns3/tools/anchors.yml.
+        if: matrix.version == '3.42'
+        run: bash ns3/tools/check-anchors.sh /opt/ns-3 single-hop

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -97,7 +97,21 @@ jobs:
             cmd="anthocnet-compare $common --diag --protocols=${{ github.event.inputs.protocols }}"
           fi
           echo "$cmd"
-          ./ns3 run "$cmd" 2>/dev/null | tee "$GITHUB_WORKSPACE/paper-results.txt"
+          # #28 hardening: stderr used to be discarded wholesale and the
+          # pipeline's exit status was tee's, so a bad extraArgs attribute made
+          # ns-3 exit instantly and the job still passed with an EMPTY results
+          # table (run 29656957470). pipefail propagates the ns-3 exit status;
+          # stderr goes to a file (kept out of the results) and its tail is
+          # printed so the fatal-error text is visible in the log.
+          set -o pipefail
+          ./ns3 run "$cmd" 2>"$GITHUB_WORKSPACE/ns3-stderr.log" \
+            | tee "$GITHUB_WORKSPACE/paper-results.txt" \
+            || { echo "--- ns-3 run FAILED; stderr tail ---"; \
+                 tail -n 60 "$GITHUB_WORKSPACE/ns3-stderr.log"; exit 1; }
+          if [ -s "$GITHUB_WORKSPACE/ns3-stderr.log" ]; then
+            echo "--- ns-3 stderr tail (non-fatal) ---"
+            tail -n 20 "$GITHUB_WORKSPACE/ns3-stderr.log"
+          fi
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
@@ -108,7 +122,14 @@ jobs:
         # Re-emit each protocol row as a single greppable line as the LAST log
         # output, so the benchmark-results skill can read just the numbers with a
         # small tail_lines instead of scraping the whole table+cleanup noise.
+        # Empty-table gate (#28): zero rows means the run produced no results
+        # (e.g. an instant ns-3 exit) — fail hard instead of passing silently.
         run: |
           awk '$1 ~ /^(anthocnet|aodv|olsr|dsdv)$/ && $2 ~ /^[0-9.]+$/ \
                {print "##BENCH##", $1, $2, $3, $4, $5, $6}' \
-            "$GITHUB_WORKSPACE/paper-results.txt" || true
+            "$GITHUB_WORKSPACE/paper-results.txt" > "$GITHUB_WORKSPACE/bench-rows.txt"
+          if ! [ -s "$GITHUB_WORKSPACE/bench-rows.txt" ]; then
+            echo "FAIL: no protocol result rows in paper-results.txt — empty results table (#28)."
+            exit 1
+          fi
+          cat "$GITHUB_WORKSPACE/bench-rows.txt"

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -72,6 +72,10 @@ jobs:
       - name: Build
         run: cd /opt/ns-3 && ./ns3 build
       - name: Run paper scenario
+        # Container jobs default to plain `sh`, where `set -o pipefail` is an
+        # illegal option (run 29664072922 died instantly on it). The image is
+        # Ubuntu, so bash is present — declare it explicitly.
+        shell: bash
         run: |
           cd /opt/ns-3
           common="--scenario=paper \

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -108,6 +108,19 @@ change are blocked on the [#51](https://github.com/danieljoppi/AntHocNet/issues/
 fix** — doing it sooner would bake the single-hop penalty into the baseline. The
 *relative* comparison (identical per-protocol realisations) is valid throughout.
 
+**Enforcement ([#59](https://github.com/danieljoppi/AntHocNet/issues/59)).** With
+#51 fixed, the first two anchors are **blocking CI gates**, run on the stock
+`manet-baselines` harness by
+[`ns3/tools/check-anchors.sh`](../ns3/tools/check-anchors.sh) with floors kept in
+one file, [`ns3/tools/anchors.yml`](../ns3/tools/anchors.yml): the single-hop
+anchor (AODV + DSDV, PDR ≥ 99, measured 100.0) runs on every push/PR in `ci.yml`
+(inside the ns-3.42 `ns3-build` job), and both it and the Broch low-mobility AODV
+floor (PDR ≥ 85, vs. ≈ 92.5 measured, ~90 literature) run in `benchmarks.yml`
+*before* the results table/charts are regenerated — a regressed anchor fails the
+workflow and blocks the publish step, so a #51-style channel/config regression can
+no longer silently corrupt the published numbers. Recalibration is a one-line
+edit to `anchors.yml`.
+
 ## Results
 
 The per-scenario tables and the taxonomy chart below are regenerated and

--- a/ns2/patch/fragments/ns-default.tcl.fragment
+++ b/ns2/patch/fragments/ns-default.tcl.fragment
@@ -9,3 +9,4 @@ Agent/AntHocNet set enable_proactive_ 1
 Agent/AntHocNet set enable_diffusion_ 1
 Agent/AntHocNet set proactive_bcast_prob_ 0.1
 Agent/AntHocNet set session_ttl_ 5.0
+Agent/AntHocNet set enable_mac_metric_ 0

--- a/ns2/patch/fragments/ns-lib.tcl.proc.fragment
+++ b/ns2/patch/fragments/ns-lib.tcl.proc.fragment
@@ -1,5 +1,9 @@
 Simulator instproc create-ahn-agent { node } {
 	set ragent [new Agent/AntHocNet [$node node-addr]]
+	# Hand the agent its interface queue for the A2 MAC metric (issue #69).
+	# The ifq does not exist yet here (add-interface runs later in
+	# create-wireless-node), so defer the lookup to simulation start.
+	$self at 0.0 "$ragent if-queue \[$node set ifq_(0)\]"
 	$self at 0.0 "$ragent start"
 	$node set ragent_ $ragent
 	return $ragent

--- a/ns2/src/ahn_router.cc
+++ b/ns2/src/ahn_router.cc
@@ -49,6 +49,7 @@ AntHocNetAgent::AntHocNetAgent(nsaddr_t id)
       logic_(nullptr),
       dmux_(nullptr),
       logtarget_(nullptr),
+      ifqueue_(nullptr),
       hello_timer_(this),
       proactive_timer_(this),
       num_nodes_(0),
@@ -66,6 +67,7 @@ AntHocNetAgent::AntHocNetAgent(nsaddr_t id)
       enable_mac_failure_detector_(1),
       repair_wait_factor_(5.0),
       repair_timeout_(1.0),
+      enable_mac_metric_(0),
       queueCount_(0) {
     bind("num_nodes_", &num_nodes_);
     bind("num_nodes_x_", &num_nodes_x_);
@@ -82,6 +84,7 @@ AntHocNetAgent::AntHocNetAgent(nsaddr_t id)
     bind_bool("enable_mac_failure_detector_", &enable_mac_failure_detector_);
     bind("repair_wait_factor_", &repair_wait_factor_);
     bind("repair_timeout_", &repair_timeout_);
+    bind_bool("enable_mac_metric_", &enable_mac_metric_);
 }
 
 AntHocNetAgent::~AntHocNetAgent() {
@@ -104,9 +107,12 @@ void AntHocNetAgent::startProtocol() {
     config_.txFailureThreshold = tx_failure_threshold_;
     config_.repairWaitFactor  = repair_wait_factor_;
     config_.repairTimeout     = repair_timeout_;
+    config_.enableMacMetric   = enable_mac_metric_ != 0;
 
     delete logic_;
-    logic_ = new anthocnet::core::AntRouterLogic(id_, config_, clock_, rng_);
+    logic_ = new anthocnet::core::AntRouterLogic(id_, config_, clock_, rng_,
+                                                 /*metric=*/nullptr,
+                                                 /*linkState=*/this);
 
     hello_timer_.handle((Event*) 0);
     proactive_timer_.handle((Event*) 0);
@@ -132,8 +138,33 @@ int AntHocNetAgent::command(int argc, const char* const* argv) {
             logtarget_ = (Trace*) TclObject::lookup(argv[2]);
             return logtarget_ ? TCL_OK : TCL_ERROR;
         }
+        if (strcmp(argv[1], "if-queue") == 0) {
+            // Interface queue between LL and MAC (the AODV wiring pattern),
+            // handed over by create-ahn-agent for the A2 MAC metric.
+            ifqueue_ = (Queue*) TclObject::lookup(argv[2]);
+            return ifqueue_ ? TCL_OK : TCL_ERROR;
+        }
     }
     return Agent::command(argc, argv);
+}
+
+// --- item 10/A2: MAC congestion signals (core::ILinkState) ------------------
+
+int AntHocNetAgent::macQueueLength() const {
+    // Packets backlogged in the interface queue between LL and MAC — those a
+    // newly-forwarded packet would wait behind. Without the "if-queue" handle
+    // the backlog reads 0, so the metric degrades to the unloaded hop time.
+    return ifqueue_ ? ifqueue_->length() : 0;
+}
+
+anthocnet::core::Time AntHocNetAgent::macServiceTime() const {
+    // Nominal per-packet MAC service time, matching the NS-3 adapter's current
+    // pass: the congestion signal is the *measured queue occupancy*
+    // (macQueueLength), so per-hop cost = (Q+1)*hopTime. A measured tx-time
+    // EWMA (issue #68) has no clean hook in NS-2 — the MAC reports transmit
+    // *failures* to the agent (xmit_failure_) but no per-packet success/timing
+    // callback — so the nominal reference stays until one is plumbed (#69).
+    return config_.hopTimeSec;
 }
 
 // --- receive ----------------------------------------------------------------

--- a/ns2/src/ahn_router.h
+++ b/ns2/src/ahn_router.h
@@ -16,6 +16,7 @@
 #include <trace.h>
 #include <timer-handler.h>
 #include <classifier-port.h>
+#include <queue.h>
 
 #include <list>
 #include <map>
@@ -60,7 +61,10 @@ private:
     Event intr_;
 };
 
-class AntHocNetAgent : public Agent {
+// The agent is also a core ILinkState (item 10/A2): it supplies MAC congestion
+// signals for the congestion-aware per-hop metric. Only meaningful when
+// enable_mac_metric_ is set; the core queries these while stamping a forward ant.
+class AntHocNetAgent : public Agent, public anthocnet::core::ILinkState {
     friend class AhnHelloTimer;
     friend class AhnProactiveTimer;
 
@@ -72,6 +76,10 @@ public:
     void recv(Packet* p, Handler* h) override;
 
     void linkFailed(Packet* p);
+
+    // core::ILinkState (item 10/A2)
+    int macQueueLength() const override;
+    anthocnet::core::Time macServiceTime() const override;
 
 protected:
     // packet paths
@@ -104,6 +112,7 @@ private:
 
     PortClassifier* dmux_;
     Trace* logtarget_;
+    Queue* ifqueue_;  // interface queue between LL and MAC ("if-queue" TCL command)
 
     AhnHelloTimer hello_timer_;
     AhnProactiveTimer proactive_timer_;
@@ -124,6 +133,7 @@ private:
     int    enable_mac_failure_detector_;  // detector D gate (issue #46)
     double repair_wait_factor_;
     double repair_timeout_;
+    int    enable_mac_metric_;  // item 10/A2 congestion-aware metric gate (issue #69)
 
     std::map<nsaddr_t, std::list<AhnQueued> > queue_;
     int queueCount_;  // total pending packets across all destinations

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -55,6 +55,8 @@ RoutingProtocol::RoutingProtocol()
       m_repairTimeout(1.0),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
+      m_macServiceAlpha(0.7),
+      m_lastAckTime(Seconds(0)),
       m_enableMacMetric(false) {}
 
 RoutingProtocol::~RoutingProtocol() = default;
@@ -150,6 +152,13 @@ TypeId RoutingProtocol::GetTypeId() {
                           TimeValue(Seconds(3)),
                           MakeTimeAccessor(&RoutingProtocol::m_queueTimeout),
                           MakeTimeChecker())
+            .AddAttribute("MacServiceAlpha",
+                          "EWMA weight of the previous estimate when smoothing "
+                          "the measured per-packet MAC service time (issue #68; "
+                          "the paper-family smoothing coefficient, cf. #70).",
+                          DoubleValue(0.7),
+                          MakeDoubleAccessor(&RoutingProtocol::m_macServiceAlpha),
+                          MakeDoubleChecker<double>(0.0, 1.0))
             .AddAttribute("EnableMacMetric",
                           "Congestion-aware per-hop cost (item 10/A2): forward ants "
                           "record (MAC-queue+1)*hop-time instead of wall-clock "
@@ -213,11 +222,31 @@ int RoutingProtocol::macQueueLength() const {
 }
 
 ::anthocnet::core::Time RoutingProtocol::macServiceTime() const {
-    // Nominal per-packet MAC service time. The congestion signal in this pass is
-    // the *measured queue occupancy* (macQueueLength); the service-time unit is
-    // the unloaded reference hop time, so per-hop cost = (Q+1)*hopTime. Upgrading
-    // this to a measured tx-time EWMA is a follow-up (see #55 / item 10/A2).
-    return m_config.hopTimeSec;
+    // Measured per-packet MAC service time (issue #68): EWMA of inter-ack
+    // spacing sampled while the MAC queue stayed backlogged, so contention and
+    // retransmissions are included but queue wait is not — (Q+1)*T̂_mac must
+    // not double-count the queue. 0 until the first sample; the core then
+    // falls back to the unloaded reference hop time (ILinkState contract).
+    return m_macServiceEwmaSec;
+}
+
+void RoutingProtocol::NotifyAckedMpdu(Ptr<const AHN_WIFI_MPDU>) {
+    // A valid pure-service sample is the spacing between two consecutive
+    // successful transmissions during which the MAC never idled — i.e. the
+    // queue was still non-empty at the previous ack.
+    const Time now = Simulator::Now();
+    if (m_backlogAtLastAck && m_lastAckTime.IsStrictlyPositive()) {
+        const double sample = (now - m_lastAckTime).GetSeconds();
+        if (sample > 0.0) {
+            m_macServiceEwmaSec =
+                m_macServiceEwmaSec > 0.0
+                    ? m_macServiceAlpha * m_macServiceEwmaSec +
+                          (1.0 - m_macServiceAlpha) * sample
+                    : sample;
+        }
+    }
+    m_lastAckTime = now;
+    m_backlogAtLastAck = macQueueLength() > 0;
 }
 
 // --- lifecycle --------------------------------------------------------------
@@ -338,6 +367,9 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         if (wmac) {
             wmac->TraceConnectWithoutContext(
                 "DroppedMpdu", MakeCallback(&RoutingProtocol::NotifyTxError, this));
+            // Issue #68: sample measured MAC service time on each success.
+            wmac->TraceConnectWithoutContext(
+                "AckedMpdu", MakeCallback(&RoutingProtocol::NotifyAckedMpdu, this));
             // Keep the first wifi MAC for the item-10/A2 queue-occupancy signal.
             if (!m_wifiMac) m_wifiMac = wmac;
         }

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -163,6 +163,9 @@ private:
     // treat a retry-limit drop as a broken link to that next hop and drive the
     // shared core reportTxFailure path (prune + bounded repair ant).
     void NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI_MPDU> mpdu);
+    /// Issue #68: successful-transmission hook — samples the measured
+    /// per-packet MAC service time for the A2 congestion metric.
+    void NotifyAckedMpdu(Ptr<const AHN_WIFI_MPDU> mpdu);
     // Resolve a failed next-hop MAC to a core address via the ARP caches.
     bool MapMacToCore(const Mac48Address& mac,
                       ::anthocnet::core::NodeAddress& out) const;
@@ -204,6 +207,13 @@ private:
     double m_repairTimeout;
     double m_linkfailNotifyInterval;  ///< issue #20 origin cooldown (s), 0 = off
     Time m_queueTimeout;              ///< issue #21 pending-queue hold before drop
+    // Issue #68: measured per-packet MAC service time (EWMA of inter-ack
+    // spacing while the MAC queue stays backlogged — pure service time, no
+    // queue wait, so (Q+1)*T̂_mac does not double-count congestion).
+    double m_macServiceAlpha;         ///< EWMA smoothing (old-value weight)
+    double m_macServiceEwmaSec = 0.0; ///< 0 = no sample yet (core falls back)
+    Time m_lastAckTime;               ///< previous AckedMpdu timestamp
+    bool m_backlogAtLastAck = false;  ///< queue was non-empty at previous ack
     bool m_enableMacMetric;  ///< item 10/A2 congestion-aware per-hop metric
 
     // WifiMac handle for the item-10/A2 queue-occupancy signal (null on non-wifi

--- a/ns3/tools/anchors.yml
+++ b/ns3/tools/anchors.yml
@@ -1,0 +1,16 @@
+# Validation-anchor thresholds (#59) — the single place to recalibrate.
+# Consumed by ns3/tools/check-anchors.sh, which parses "key: number" lines
+# (a trailing "# comment" is fine as long as it contains no colon). Scenario
+# definitions live in the script; expected values and their rationale in
+# docs/benchmarks.md "Validation anchors".
+
+# 2-node, in-range, static, fixed 2 Mbit/s radio: measured 100.0% post-#51.
+# A #51-style rate-manager regression reads ~50%, so 99.0 has wide margin
+# while still catching partial regressions.
+single_hop_pdr_min: 99.0
+
+# Broch/Perkins field at low mobility (pause=900 speed=1), stock AODV.
+# Literature floor ~90% (Broch et al. 1998); measured 92.5% on current main
+# (time=300, runs=3). 85.0 leaves margin for the gate's 2-run average and
+# random node placement — tighten once more gate runs accumulate.
+broch_low_mobility_aodv_pdr_min: 85.0

--- a/ns3/tools/check-anchors.sh
+++ b/ns3/tools/check-anchors.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Validation-anchor gate (#59): run a known-expected scenario on the *stock*
+# baselines harness (manet-baselines — no AntHocNet code in the binary) and
+# fail if PDR falls below the floor in anchors.yml. This is the enforcement
+# half of docs/benchmarks.md "Validation anchors": a channel/PHY/harness
+# regression (like the #51 IdealWifiManager ~50% single-hop loss) fails CI
+# loudly instead of silently corrupting every published number.
+#
+# Usage: check-anchors.sh <ns3-dir> <single-hop|broch-low-mobility>
+#
+# The ns-3 tree must already be configured + built with the anthocnet module's
+# examples enabled (manet-baselines builds as part of the module's examples).
+set -euo pipefail
+
+NS3DIR=${1:-}
+ANCHOR=${2:-}
+if [ -z "$NS3DIR" ] || [ -z "$ANCHOR" ]; then
+    echo "usage: $0 <ns3-dir> <single-hop|broch-low-mobility>" >&2
+    exit 2
+fi
+
+ANCHORS_FILE="$(cd "$(dirname "$0")" && pwd)/anchors.yml"
+
+floor_for() {
+    # "key: 99.0  # comment" -> 99 (the "+0" strips any trailing comment).
+    awk -F': *' -v k="$1" \
+        '$1 == k { print $2 + 0; found = 1 } END { if (!found) exit 1 }' \
+        "$ANCHORS_FILE"
+}
+
+case "$ANCHOR" in
+    single-hop)
+        # 2 nodes, 50x50 m, 300 m disk range, static (pause=900 speed=1):
+        # every packet is one in-range hop, so the stack itself must deliver
+        # ~everything. AODV (reactive, buffers during route discovery) and
+        # DSDV (proactive, buffers until the first periodic update) both read
+        # 100.0% post-#51; OLSR is excluded because its multi-second neighbor
+        # sensing loses early packets on a short run (startup artefact, not a
+        # channel property).
+        args="--nNodes=2 --areaX=50 --areaY=50 --range=300 --pause=900 --speed=1 --time=60 --runs=1"
+        protocols="aodv,dsdv"
+        floor=$(floor_for single_hop_pdr_min)
+        ;;
+    broch-low-mobility)
+        # Broch/Perkins 1500x300 m 50-node field (--scenario=paper) at
+        # near-static mobility: the literature calibration target — stock
+        # AODV delivers ~90-100% here (Broch et al., MobiCom 1998).
+        args="--scenario=paper --pause=900 --speed=1 --time=300 --runs=2"
+        protocols="aodv"
+        floor=$(floor_for broch_low_mobility_aodv_pdr_min)
+        ;;
+    *)
+        echo "unknown anchor '$ANCHOR' (want: single-hop | broch-low-mobility)" >&2
+        exit 2
+        ;;
+esac
+
+cmd="manet-baselines $args --protocols=$protocols"
+echo "[$ANCHOR] ./ns3 run \"$cmd\"  (gate: PDR >= $floor)"
+cd "$NS3DIR"
+if ! out=$(./ns3 run "$cmd" 2>&1); then
+    printf '%s\n' "$out" | tail -n 40
+    echo "FAIL [$ANCHOR]: manet-baselines did not run (output tail above)"
+    exit 1
+fi
+printf '%s\n' "$out"
+
+status=0
+for proto in ${protocols//,/ }; do
+    # Summary-table row: "<proto>  <PDR%>  <delay> ...". Diag lines never
+    # start with a bare protocol name, so this only matches the table.
+    pdr=$(printf '%s\n' "$out" |
+          awk -v p="$proto" '$1 == p && $2 ~ /^[0-9.]+$/ { v = $2 } END { print v }')
+    if [ -z "$pdr" ]; then
+        echo "FAIL [$ANCHOR]: no result row for '$proto' — empty table (#28-style silent failure)"
+        status=1
+    elif awk -v v="$pdr" -v f="$floor" 'BEGIN { exit (v + 0 >= f + 0) ? 0 : 1 }'; then
+        echo "PASS [$ANCHOR] $proto PDR=$pdr >= $floor"
+    else
+        echo "FAIL [$ANCHOR] $proto PDR=$pdr < floor $floor — validation anchor regressed."
+        echo "  A drop here means the harness/channel/PHY config broke (cf. #51), not a"
+        echo "  protocol property. See docs/benchmarks.md 'Validation anchors' and #59;"
+        echo "  thresholds live in ns3/tools/anchors.yml."
+        status=1
+    fi
+done
+exit $status


### PR DESCRIPTION
Four commits closing out the A2 congestion-metric arc (#68, #69) and the validation-anchor enforcement (#59), plus a CI regression fix found along the way.

## #68 — measured per-packet MAC service-time EWMA (`b2ce59e`)

Replaces the nominal `T̂_mac` with a measured EWMA sampled from the WifiMac `AckedMpdu` trace: inter-ack spacing counted only while the MAC queue stays backlogged, so the sample is pure service time (contention + retries) with no queue-wait double-count against the `(Q+1)` factor. New `MacServiceAlpha` attribute (0.7, old-value weight); works across the ns-3.36–3.48 matrix via the existing `AHN_WIFI_MPDU` version gate; core falls back to `hopTimeSec` when no sample. Still gated by `EnableMacMetric`, **default off**.

**Validation (full record on #68):**
- Paper regime A/B (runs=3, identical seeds): dead neutral — 84.0 PDR both legs; queues too shallow, `(Q+1)≈1`.
- Gateway hotspot (`--sink=25`, two independent pairs at runs=3 and runs=5): PDR delta is run-to-run noise (sign flips −0.1pp/+2.6pp), while both pairs consistently show mean delay +9–19% and delay99 +6–10% for NRL −2–4% — the metric detours around congestion and pays path length. **Default-on rejected on current evidence**; implementation retained behind the gate. #68 can close when this merges; #21 cross-noted that A2 is not the residual-delay lever.

## #69 — NS-2 sources an `ILinkState` from the interface queue (`f2f8f5d`)

`AntHocNetAgent` now derives `core::ILinkState` (mirroring the NS-3 adapter): `macQueueLength()` from the LL↔MAC interface queue via a new `if-queue` TCL command (handle wired in `create-ahn-agent`, deferred to t=0 because the ifq doesn't exist at agent-creation time), `macServiceTime()` returns the nominal `hopTimeSec` (>0 is load-bearing — it selects the `(Q+1)·T̂` form in the core; NS-2's MAC has no per-packet success/timing callback for a measured EWMA, documented in-code). Gated by a new `enable_mac_metric_` TCL bool, **default 0** — byte-identical behaviour when off. Patch selftest passes (no new upstream anchors). Developed by a parallel worktree subagent, reviewed and cherry-picked.

## #59 — validation anchors become blocking CI gates (`67a4941`)

The #51 lesson enforced: `ns3/tools/check-anchors.sh` + `anchors.yml` assert the 2-node single-hop floor (aodv/dsdv ≥ 99% PDR) and the Broch low-mobility AODV floor (≥ 85%) — in `ci.yml` (ns3-3.42 leg) and ahead of the `benchmarks.yml` publish step, so a channel/config regression can never silently corrupt published numbers again. Also hardens `paper-benchmark.yml`: pipefail, stderr captured to a file with tails printed, and a hard failure when the results table is empty (the exact silent-pass mode of run 29656957470). Developed by a parallel worktree subagent, reviewed and cherry-picked.

## CI fix — `shell: bash` for the paper-benchmark run step (`26d4ff6`)

Container jobs default run steps to plain `sh`, where `set -o pipefail` is an illegal option — every dispatch after the #59 hardening died instantly (runs 29664072922/29664071973). The ns-3 image is Ubuntu-based, so declaring `shell: bash` restores the pipeline; the anchors-gate invocations elsewhere already call `bash` explicitly. Regression + fix recorded on #59.

## Verification

- `make test`: 18/18 core test binaries pass (incl. the new EWMA/backlog cases).
- `ns2/patch/selftest.sh`: clean apply / idempotent / revert round-trip.
- `check_invariants.sh`: no NS headers in core/, wire format untouched (no `kWireVersion` bump needed — no wire change).
- 4 green `paper-benchmark` runs on this branch prove the #68 code compiles and runs on ns-3.42; the full 3.36–3.48 matrix + NS-2 build + the new anchor gates run on this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s

---
_Generated by [Claude Code](https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s)_