### PR TITLE
feat: paper-parity QoS metrics, across-run dispersion, and the provisional thesis preset

### DIFF
--- a/.claude/skills/benchmark-results/bench_parse.py
+++ b/.claude/skills/benchmark-results/bench_parse.py
@@ -25,9 +25,11 @@ import re
 import sys
 
 # A results row: "anthocnet   50.2   1108.3   10656.8   2.57   83.30"
+# (trailing columns — #57 jitter / offered-load percentiles, possibly "inf" —
+# are tolerated and ignored; the first six fields are position-stable).
 ROW = re.compile(
     r"^\s*([A-Za-z][\w-]*)\s+"
-    r"([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s*$"
+    r"([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)(?:\s+\S+)*\s*$"
 )
 METRICS = ["pdr", "delay", "delay99", "thrput", "nrl"]
 # Compact single-line form the workflow can emit: "##BENCH## anthocnet 50.2 ..."

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -130,7 +130,7 @@ jobs:
         # (e.g. an instant ns-3 exit) — fail hard instead of passing silently.
         run: |
           awk '$1 ~ /^(anthocnet|aodv|olsr|dsdv)$/ && $2 ~ /^[0-9.]+$/ \
-               {print "##BENCH##", $1, $2, $3, $4, $5, $6}' \
+               {print "##BENCH##", $1, $2, $3, $4, $5, $6, $7, $8}' \
             "$GITHUB_WORKSPACE/paper-results.txt" > "$GITHUB_WORKSPACE/bench-rows.txt"
           if ! [ -s "$GITHUB_WORKSPACE/bench-rows.txt" ]; then
             echo "FAIL: no protocol result rows in paper-results.txt — empty results table (#28)."

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -130,7 +130,7 @@ jobs:
         # (e.g. an instant ns-3 exit) — fail hard instead of passing silently.
         run: |
           awk '$1 ~ /^(anthocnet|aodv|olsr|dsdv)$/ && $2 ~ /^[0-9.]+$/ \
-               {print "##BENCH##", $1, $2, $3, $4, $5, $6, $7, $8}' \
+               {print "##BENCH##", $1, $2, $3, $4, $5, $6, $7, $8, $9}' \
             "$GITHUB_WORKSPACE/paper-results.txt" > "$GITHUB_WORKSPACE/bench-rows.txt"
           if ! [ -s "$GITHUB_WORKSPACE/bench-rows.txt" ]; then
             echo "FAIL: no protocol result rows in paper-results.txt — empty results table (#28)."

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -7,11 +7,24 @@ same realisations. Metrics come from an NS-3 `FlowMonitor`:
 
 - **PDR** — packet-delivery ratio (received / sent), %, over the CBR data flows.
 - **mean delay** — average end-to-end delay of delivered packets, ms.
-- **99th-percentile delay** — the paper's QoS/jitter metric; a small tail of
-  very-high-delay packets is how AODV loses out in the original results.
+- **99th-percentile delay** — tail of the delivered-packet delay distribution.
+  Caveat (#57/#54): across protocols with very different PDR this is
+  survivorship-confounded — the extra packets a protocol delivers are precisely
+  the hard/late ones — so prefer the offered-load percentiles for cross-protocol
+  tail claims.
+- **jitter** — mean delay jitter over delivered packets (FlowMonitor
+  `jitterSum`), ms. The original paper's QoS metric (avg delay + jitter).
+- **dOff90** (`delay_off50_ms`/`delay_off90_ms` in the CSV) — delay at the
+  50th/90th percentile of *offered* (sent) packets, counting an undelivered
+  packet as infinite delay (`inf` / `-1` in the CSV when less than that fraction
+  arrived). Monotone-honest: dropping hard packets cannot improve it.
 - **throughput** — application bytes delivered per second, kbps.
 - **NRL** — normalized routing load: routing-control packets transmitted (each
   hop) per data packet delivered, counted uniformly at the IP layer.
+
+Aggregates are means over the RNG runs; the CSV also carries per-metric sample
+stddev across runs (`pdr_sd`, `delay_sd`, `delay99_sd`, `nrl_sd`), which the
+charts render as error bars, and the human table prints as `# stddev` lines.
 
 The table below is a small, fast scenario used for a quick regression signal.
 To reproduce the **paper's base scenario** (50 nodes, 1500×300 m, random-waypoint

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -695,8 +695,9 @@ int main(int argc, char* argv[]) {
               << std::right << std::setw(8) << "PDR%" << std::setw(11) << "delay(ms)"
               << std::setw(13) << "delay99(ms)" << std::setw(13) << "thrput(kbps)"
               << std::setw(8) << "NRL"
-              << std::setw(12) << "jitter(ms)" << std::setw(12) << "dOff90(ms)" << "\n";
-    std::cout << std::string(89, '-') << "\n";
+              << std::setw(12) << "jitter(ms)" << std::setw(12) << "dOff50(ms)"
+              << std::setw(12) << "dOff90(ms)" << "\n";
+    std::cout << std::string(101, '-') << "\n";
     for (std::size_t i = 0; i < list.size(); ++i) {
         std::cout << std::left << std::setw(12) << list[i] << std::right << std::fixed
                   << std::setw(8) << std::setprecision(1) << agg[i].pdr
@@ -705,8 +706,10 @@ int main(int argc, char* argv[]) {
                   << std::setw(13) << std::setprecision(2) << agg[i].thrput
                   << std::setw(8) << std::setprecision(2) << agg[i].nrl
                   << std::setw(12) << std::setprecision(2) << agg[i].jitter;
-        if (agg[i].dOff90 < 0) std::cout << std::setw(12) << "inf";
-        else std::cout << std::setw(12) << std::setprecision(1) << agg[i].dOff90;
+        for (double v : {agg[i].dOff50, agg[i].dOff90}) {
+            if (v < 0) std::cout << std::setw(12) << "inf";
+            else std::cout << std::setw(12) << std::setprecision(1) << v;
+        }
         std::cout << "\n";
     }
     // #28 dispersion: '# ' prefix keeps these out of the CSV/##BENCH## paths.

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -40,6 +40,7 @@
 #include "ns3/anthocnet-routing-protocol.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <iomanip>
 #include <map>
@@ -163,9 +164,13 @@ struct Result {
     uint64_t rxPackets = 0;
     double pdr = 0.0;            // %
     double meanDelayMs = 0.0;
-    double delay99Ms = 0.0;      // 99th percentile (the paper's QoS/jitter metric)
+    double delay99Ms = 0.0;      // 99th pct over *delivered* packets
     double throughputKbps = 0.0;
     double nrl = 0.0;            // control pkts / delivered data pkts
+    // #57 paper-parity / survivorship-safe QoS metrics:
+    double jitterMs = 0.0;       // mean delay jitter (the paper's QoS metric)
+    double dOff50Ms = -1.0;      // delay at the 50th pct of *offered* (sent)
+    double dOff90Ms = -1.0;      // packets, undelivered = inf; -1 encodes inf
 };
 
 Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
@@ -370,6 +375,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     double totalDelay = 0.0;
     uint64_t rxForDelay = 0;
     double totalRxBytes = 0.0;
+    double totalJitter = 0.0;    // #57: FlowMonitor jitterSum over data flows
+    uint64_t jitterSamples = 0;  // each flow contributes rx-1 jitter samples
     std::map<uint32_t, uint64_t> delayBins;  // aggregated delay histogram
     double binWidth = 0.0;
     // Restrict the delivery/delay/throughput metrics to the CBR *data* flows
@@ -385,6 +392,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         totalDelay += kv.second.delaySum.GetSeconds();
         rxForDelay += kv.second.rxPackets;
         totalRxBytes += kv.second.rxBytes;
+        totalJitter += kv.second.jitterSum.GetSeconds();
+        if (kv.second.rxPackets > 0) jitterSamples += kv.second.rxPackets - 1;
         // Copy: Histogram's accessors are non-const in older ns-3 (<=3.36).
         Histogram h = kv.second.delayHistogram;
         for (uint32_t b = 0; b < h.GetNBins(); ++b) {
@@ -397,6 +406,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     r.throughputKbps = (totalRxBytes * 8.0 / 1000.0) / P.simTime;
     r.nrl = r.rxPackets ? static_cast<double>(g_controlPkts) / r.rxPackets : 0.0;
 
+    r.jitterMs = jitterSamples ? 1000.0 * totalJitter / jitterSamples : 0.0;
+
     // 99th-percentile delay from the aggregated histogram.
     if (rxForDelay && binWidth > 0.0) {
         uint64_t target = static_cast<uint64_t>(0.99 * rxForDelay);
@@ -408,6 +419,28 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                 break;
             }
         }
+    }
+
+    // #57 offered-load delay percentiles: the q-th percentile over *sent*
+    // packets, treating undelivered as infinite delay. Monotone-honest — a
+    // protocol cannot improve this by dropping the hard packets (the
+    // survivorship confound in cross-protocol delay99, see #21/#54). The
+    // histogram holds only delivered packets, but undelivered sort above every
+    // delivered delay, so the q·tx-th smallest overall is reachable iff
+    // q·tx <= delivered; otherwise the percentile is infinite (-1).
+    if (r.txPackets && binWidth > 0.0) {
+        auto offered = [&](double q) {
+            uint64_t target = static_cast<uint64_t>(q * r.txPackets);
+            if (target < 1) target = 1;
+            uint64_t cum = 0;
+            for (auto& kv : delayBins) {
+                cum += kv.second;
+                if (cum >= target) return 1000.0 * (kv.first + 0.5) * binWidth;
+            }
+            return -1.0;  // fewer than q of the sent packets ever arrived
+        };
+        r.dOff50Ms = offered(0.50);
+        r.dOff90Ms = offered(0.90);
     }
 
     // Diagnostics line (prefixed "# " so CSV consumers ignore it). Shows whether
@@ -559,7 +592,17 @@ int main(int argc, char* argv[]) {
     }
 
     // Each protocol: mean over runs (every protocol sees the same seed set).
-    struct Agg { double pdr = 0, delay = 0, delay99 = 0, thrput = 0, nrl = 0; };
+    // #28: also sample stddev across runs (0 when runs==1) so published numbers
+    // carry dispersion. Offered-load percentiles use -1 as "infinite": any
+    // infinite run makes the aggregate infinite (monotone-honest, like the
+    // metric itself).
+    struct Agg {
+        double pdr = 0, delay = 0, delay99 = 0, thrput = 0, nrl = 0;
+        double jitter = 0, dOff50 = 0, dOff90 = 0;
+        double pdrSq = 0, delaySq = 0, delay99Sq = 0, nrlSq = 0;
+        bool off50Inf = false, off90Inf = false;
+        double pdrSd = 0, delaySd = 0, delay99Sd = 0, nrlSd = 0;
+    };
     std::vector<Agg> agg(list.size());
     for (std::size_t i = 0; i < list.size(); ++i) {
         for (uint32_t s = 1; s <= runs; ++s) {
@@ -569,19 +612,43 @@ int main(int argc, char* argv[]) {
             agg[i].delay99 += r.delay99Ms;
             agg[i].thrput += r.throughputKbps;
             agg[i].nrl += r.nrl;
+            agg[i].jitter += r.jitterMs;
+            agg[i].pdrSq += r.pdr * r.pdr;
+            agg[i].delaySq += r.meanDelayMs * r.meanDelayMs;
+            agg[i].delay99Sq += r.delay99Ms * r.delay99Ms;
+            agg[i].nrlSq += r.nrl * r.nrl;
+            if (r.dOff50Ms < 0) agg[i].off50Inf = true; else agg[i].dOff50 += r.dOff50Ms;
+            if (r.dOff90Ms < 0) agg[i].off90Inf = true; else agg[i].dOff90 += r.dOff90Ms;
         }
         agg[i].pdr /= runs;
         agg[i].delay /= runs;
         agg[i].delay99 /= runs;
         agg[i].thrput /= runs;
         agg[i].nrl /= runs;
+        agg[i].jitter /= runs;
+        agg[i].dOff50 = agg[i].off50Inf ? -1.0 : agg[i].dOff50 / runs;
+        agg[i].dOff90 = agg[i].off90Inf ? -1.0 : agg[i].dOff90 / runs;
+        if (runs > 1) {
+            auto sd = [runs](double sum, double sumSq) {
+                const double mean = sum / runs;
+                const double var = (sumSq - runs * mean * mean) / (runs - 1);
+                return var > 0.0 ? std::sqrt(var) : 0.0;
+            };
+            agg[i].pdrSd = sd(agg[i].pdr * runs, agg[i].pdrSq);
+            agg[i].delaySd = sd(agg[i].delay * runs, agg[i].delaySq);
+            agg[i].delay99Sd = sd(agg[i].delay99 * runs, agg[i].delay99Sq);
+            agg[i].nrlSd = sd(agg[i].nrl * runs, agg[i].nrlSq);
+        }
     }
 
     if (csv) {
         // Field order through throughput_kbps is stable (downstream parsers rely
-        // on it); delay99_ms and nrl are appended.
+        // on it); later columns are append-only (consumers read by header name):
+        // delay99_ms/nrl, then #57 jitter + offered-load percentiles (-1 = inf),
+        // then #28 per-metric sample stddev across runs (0 when runs==1).
         std::cout << "protocol,runs,nNodes,area,speed,flows,pdr_pct,delay_ms,"
-                     "throughput_kbps,delay99_ms,nrl\n";
+                     "throughput_kbps,delay99_ms,nrl,jitter_ms,delay_off50_ms,"
+                     "delay_off90_ms,pdr_sd,delay_sd,delay99_sd,nrl_sd\n";
         std::cout << std::fixed;
         for (std::size_t i = 0; i < list.size(); ++i) {
             std::cout << list[i] << ',' << runs << ',' << P.nNodes << ','
@@ -591,7 +658,14 @@ int main(int argc, char* argv[]) {
                       << std::setprecision(1) << agg[i].delay << ','
                       << std::setprecision(2) << agg[i].thrput << ','
                       << std::setprecision(1) << agg[i].delay99 << ','
-                      << std::setprecision(3) << agg[i].nrl << '\n';
+                      << std::setprecision(3) << agg[i].nrl << ','
+                      << std::setprecision(2) << agg[i].jitter << ','
+                      << std::setprecision(1) << agg[i].dOff50 << ','
+                      << std::setprecision(1) << agg[i].dOff90 << ','
+                      << std::setprecision(2) << agg[i].pdrSd << ','
+                      << std::setprecision(1) << agg[i].delaySd << ','
+                      << std::setprecision(1) << agg[i].delay99Sd << ','
+                      << std::setprecision(3) << agg[i].nrlSd << '\n';
         }
         return 0;
     }
@@ -601,18 +675,36 @@ int main(int argc, char* argv[]) {
               << P.areaX << "x" << P.areaY << "m maxSpeed=" << P.speed
               << "m/s pause=" << P.pause << "s flows=" << P.nFlows
               << (P.sink >= 0 ? " sink=" + std::to_string(P.sink) : "") << "\n\n";
+    // First six fields (proto..NRL) are position-stable: the workflows' compact
+    // ##BENCH## re-emit and bench_parse.py read them by position. The #57 QoS
+    // columns (jitter, offered-load 90th pct) are appended to the right.
     std::cout << std::left << std::setw(12) << "protocol"
               << std::right << std::setw(8) << "PDR%" << std::setw(11) << "delay(ms)"
               << std::setw(13) << "delay99(ms)" << std::setw(13) << "thrput(kbps)"
-              << std::setw(8) << "NRL" << "\n";
-    std::cout << std::string(65, '-') << "\n";
+              << std::setw(8) << "NRL"
+              << std::setw(12) << "jitter(ms)" << std::setw(12) << "dOff90(ms)" << "\n";
+    std::cout << std::string(89, '-') << "\n";
     for (std::size_t i = 0; i < list.size(); ++i) {
         std::cout << std::left << std::setw(12) << list[i] << std::right << std::fixed
                   << std::setw(8) << std::setprecision(1) << agg[i].pdr
                   << std::setw(11) << std::setprecision(1) << agg[i].delay
                   << std::setw(13) << std::setprecision(1) << agg[i].delay99
                   << std::setw(13) << std::setprecision(2) << agg[i].thrput
-                  << std::setw(8) << std::setprecision(2) << agg[i].nrl << "\n";
+                  << std::setw(8) << std::setprecision(2) << agg[i].nrl
+                  << std::setw(12) << std::setprecision(2) << agg[i].jitter;
+        if (agg[i].dOff90 < 0) std::cout << std::setw(12) << "inf";
+        else std::cout << std::setw(12) << std::setprecision(1) << agg[i].dOff90;
+        std::cout << "\n";
+    }
+    // #28 dispersion: '# ' prefix keeps these out of the CSV/##BENCH## paths.
+    if (runs > 1) {
+        for (std::size_t i = 0; i < list.size(); ++i) {
+            std::cout << std::fixed << "# stddev " << list[i]
+                      << " pdr=" << std::setprecision(2) << agg[i].pdrSd
+                      << " delay=" << std::setprecision(1) << agg[i].delaySd
+                      << " delay99=" << std::setprecision(1) << agg[i].delay99Sd
+                      << " nrl=" << std::setprecision(3) << agg[i].nrlSd << "\n";
+        }
     }
     return 0;
 }

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -535,7 +535,9 @@ int main(int argc, char* argv[]) {
     std::string protocols = "anthocnet,aodv,olsr,dsdv";
 
     CommandLine cmd(__FILE__);
-    cmd.AddValue("scenario", "Preset: 'paper' for the AntHocNet base scenario", scenario);
+    cmd.AddValue("scenario", "Preset: 'paper' (Broch/CMU calibration field) or "
+                             "'thesis' (the AntHocNet papers' own evaluation "
+                             "field, provisional values — #58)", scenario);
     cmd.AddValue("nNodes", "Number of nodes", nNodes);
     cmd.AddValue("time", "Simulation time (s)", simTime);
     cmd.AddValue("area", "Square area side (m); shorthand for areaX=areaY", area);
@@ -565,12 +567,23 @@ int main(int argc, char* argv[]) {
     cmd.Parse(argc, argv);
     if (runs < 1) runs = 1;
 
-    const bool paper = (scenario == "paper");
+    // 'paper' = the Broch/CMU MobiCom'98 field (the literature *calibration*
+    // anchor, #24). 'thesis' = the AntHocNet papers' own evaluation field
+    // (ETT 2005 / Ducatelle PhD 2007): 100 nodes on 3000x1000 m, otherwise the
+    // same radio/traffic/mobility regime. Fidelity claims run on 'thesis',
+    // calibration on 'paper'. VALUES ARE PROVISIONAL (#58): reconstructed from
+    // secondary knowledge because the primary PDFs are network-blocked here —
+    // verify against the thesis parameter table before publishing.
+    const bool thesis = (scenario == "thesis");
+    const bool paper = (scenario == "paper") || thesis;
     Params P;
-    P.nNodes  = nNodes > 0 ? static_cast<uint32_t>(nNodes) : (paper ? 50 : 20);
+    P.nNodes  = nNodes > 0 ? static_cast<uint32_t>(nNodes)
+                           : (thesis ? 100 : paper ? 50 : 20);
     P.simTime = simTime >= 0 ? simTime : (paper ? 900.0 : 40.0);
-    P.areaX   = areaX >= 0 ? areaX : (area >= 0 ? area : (paper ? 1500.0 : 300.0));
-    P.areaY   = areaY >= 0 ? areaY : (area >= 0 ? area : (paper ? 300.0 : 300.0));
+    P.areaX   = areaX >= 0 ? areaX
+                           : (area >= 0 ? area : (thesis ? 3000.0 : paper ? 1500.0 : 300.0));
+    P.areaY   = areaY >= 0 ? areaY
+                           : (area >= 0 ? area : (thesis ? 1000.0 : paper ? 300.0 : 300.0));
     P.speed   = speed >= 0 ? speed : (paper ? 20.0 : 5.0);
     P.pause   = pause >= 0 ? pause : (paper ? 30.0 : 1.0);
     P.range   = range >= 0 ? range : (paper ? 300.0 : 0.0);

--- a/ns3/tools/make-charts.py
+++ b/ns3/tools/make-charts.py
@@ -51,7 +51,10 @@ def plot_sweep(name, rows, outdir):
     """One paper-style line figure for a single sweep group."""
     protos = protos_in(rows)
     xlabel = rows[0].get("class", name) if rows else name
-    # series[proto][metric] -> list of (x, value) sorted by x
+    # series[proto][metric] -> list of (x, value, stddev) sorted by x; stddev
+    # comes from the matching *_sd column (#28 dispersion) when present.
+    sd_col = {"pdr_pct": "pdr_sd", "delay_ms": "delay_sd",
+              "delay99_ms": "delay99_sd", "nrl": "nrl_sd"}
     series = defaultdict(lambda: defaultdict(list))
     for r in rows:
         x = fnum(r["x"])
@@ -60,10 +63,20 @@ def plot_sweep(name, rows, outdir):
         for m in ("pdr_pct", "delay_ms", "delay99_ms", "nrl"):
             v = fnum(r.get(m))
             if v is not None:
-                series[r["protocol"]][m].append((x, v))
+                series[r["protocol"]][m].append((x, v, fnum(r.get(sd_col[m]))))
     for p in series:
         for m in series[p]:
             series[p][m].sort()
+
+    def draw(ax, pts, color, label, marker="o", linestyle="-"):
+        xs = [x for x, _, _ in pts]
+        ys = [y for _, y, _ in pts]
+        errs = [e for _, _, e in pts]
+        yerr = errs if any(e is not None and e > 0 for e in errs) else None
+        if yerr is not None:
+            yerr = [e if e is not None else 0.0 for e in errs]
+        ax.errorbar(xs, ys, yerr=yerr, marker=marker, linestyle=linestyle,
+                    color=color, label=label, capsize=3, elinewidth=0.8)
 
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(15, 4.2))
     fig.suptitle(f"Sweep: {name}", fontsize=13, fontweight="bold")
@@ -72,20 +85,16 @@ def plot_sweep(name, rows, outdir):
         c = PROTO_COLOR.get(p, None)
         pdr = series[p]["pdr_pct"]
         if pdr:
-            ax1.plot([x for x, _ in pdr], [y for _, y in pdr],
-                     marker="o", color=c, label=p)
+            draw(ax1, pdr, c, p)
         d = series[p]["delay_ms"]
         if d:
-            ax2.plot([x for x, _ in d], [y for _, y in d],
-                     marker="o", color=c, label=p)
+            draw(ax2, d, c, p)
         d99 = series[p]["delay99_ms"]
         if d99:
-            ax2.plot([x for x, _ in d99], [y for _, y in d99],
-                     marker="^", linestyle="--", color=c, label=f"{p} 99%")
+            draw(ax2, d99, c, f"{p} 99%", marker="^", linestyle="--")
         nrl = series[p]["nrl"]
         if nrl:
-            ax3.plot([x for x, _ in nrl], [y for _, y in nrl],
-                     marker="o", color=c, label=p)
+            draw(ax3, nrl, c, p)
 
     ax1.set_title("Packet delivery ratio")
     ax1.set_ylabel("PDR (%)")
@@ -112,13 +121,18 @@ def plot_discrete(rows, outdir):
         if r["scenario"] not in scenarios:
             scenarios.append(r["scenario"])
     protos = protos_in(rows)
-    # value[(scenario, proto)][metric]
+    # value[(scenario, proto)][metric]; *_sd columns feed bar error bars (#28).
+    sd_col = {"pdr_pct": "pdr_sd", "delay_ms": "delay_sd", "nrl": "nrl_sd"}
     val = defaultdict(dict)
+    err = defaultdict(dict)
     for r in rows:
         for m in ("pdr_pct", "delay_ms", "nrl"):
             v = fnum(r.get(m))
             if v is not None:
                 val[(r["scenario"], r["protocol"])][m] = v
+            e = fnum(r.get(sd_col[m]))
+            if e is not None:
+                err[(r["scenario"], r["protocol"])][m] = e
 
     metrics = [("pdr_pct", "PDR (%)"), ("delay_ms", "mean delay (ms)"),
                ("nrl", "NRL")]
@@ -131,8 +145,10 @@ def plot_discrete(rows, outdir):
     for ax, (m, label) in zip(axes, metrics):
         for i, p in enumerate(protos):
             ys = [val.get((s, p), {}).get(m, 0.0) for s in scenarios]
+            es = [err.get((s, p), {}).get(m, 0.0) for s in scenarios]
             offs = [x + (i - (n - 1) / 2) * width for x in xs]
-            ax.bar(offs, ys, width=width, color=PROTO_COLOR.get(p), label=p)
+            ax.bar(offs, ys, width=width, color=PROTO_COLOR.get(p), label=p,
+                   yerr=es if any(e > 0 for e in es) else None, capsize=2)
         ax.set_ylabel(label)
         ax.set_xticks(xs)
         ax.set_xticklabels(scenarios, rotation=20, ha="right", fontsize=8)

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -76,7 +76,11 @@ SWEEPS = {
 }
 
 # Columns of the per-run anthocnet-compare CSV we carry through (by header name).
-METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl"]
+# jitter/offered-load percentiles are the #57 paper-parity QoS metrics
+# (delay_off*_ms: -1 encodes infinity); *_sd are the #28 across-run stddevs.
+METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
+           "jitter_ms", "delay_off50_ms", "delay_off90_ms",
+           "pdr_sd", "delay_sd", "delay99_sd", "nrl_sd"]
 PARAMS = ["runs", "nNodes", "area", "speed", "flows"]
 OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + ["runs", "nNodes", "areaX", "speed", "pause", "flows"] + METRICS)

--- a/ns3/tools/update-benchmarks.py
+++ b/ns3/tools/update-benchmarks.py
@@ -21,16 +21,26 @@ END = "<!-- BENCHMARK-TABLE-END -->"
 
 
 _TABLE_HEAD = [
-    "| protocol | PDR % | mean delay (ms) | 99th delay (ms) | throughput (kbps) | NRL |",
-    "|----------|------:|----------------:|----------------:|------------------:|----:|",
+    "| protocol | PDR % | mean delay (ms) | 99th delay (ms) | throughput (kbps) | NRL "
+    "| jitter (ms) | dOff90 (ms) |",
+    "|----------|------:|----------------:|----------------:|------------------:|----:"
+    "|------------:|------------:|",
 ]
 
 
+def _off(v):
+    # #57 offered-load percentile: -1 encodes infinity (less than the offered
+    # fraction ever delivered).
+    return "inf" if v not in (None, "", "-") and float(v) < 0 else (v or "-")
+
+
 def _row(r):
-    # delay99_ms / nrl are newer columns; tolerate older CSVs without them.
+    # Columns after delay_ms are newer; tolerate older CSVs without them.
+    # jitter_ms / delay_off90_ms are the #57 paper-parity QoS metrics.
     return (f"| {r['protocol']} | {r['pdr_pct']} | {r['delay_ms']} | "
             f"{r.get('delay99_ms', '-')} | {r['throughput_kbps']} | "
-            f"{r.get('nrl', '-')} |")
+            f"{r.get('nrl', '-')} | {r.get('jitter_ms', '-')} | "
+            f"{_off(r.get('delay_off90_ms'))} |")
 
 
 def build_single(rows):


### PR DESCRIPTION
Four commits: the #57 survivorship-safe QoS metrics, the #28 dispersion columns, and the #58 provisional thesis-field preset, per the maintainer's proceed-on-the-thesis decision.

## #57 — paper-parity / survivorship-safe QoS metrics (`74307dc`, `e82c82a`)

`anthocnet-compare` now reports, alongside the existing columns:
- **jitter (ms)** — mean delay jitter from FlowMonitor `jitterSum` (the original papers' QoS metric; estimator-definition check tracked as #89);
- **dOff50 / dOff90** — delay at the 50th/90th percentile of *offered* (sent) packets, counting undelivered as infinite (`inf` in the table, `-1` in the CSV). Monotone-honest: dropping hard packets cannot improve it — the fix for the cross-protocol survivorship confound in delay99 (#54/#21). dOff90 is structurally `inf` below 90% PDR, so the table carries both percentiles (`e82c82a`).

New CSV columns (`jitter_ms`, `delay_off50_ms`, `delay_off90_ms`) are append-only; all downstream consumers read by header name and were updated: `run-scenarios.py` carries them into the taxonomy, `update-benchmarks.py` renders them (incl. `inf`), `bench_parse.py` tolerates the extra table fields.

**First live run** (29665853612, paper regime, 5 seeds, anthocnet vs aodv) already earned its keep — posted to #21: the QoS gap is **real, not a survivorship artifact** (anthocnet jitter 229 vs aodv 67 ms at +4.0pp PDR, −41% NRL); #21's acceptance restated on the new metrics.

## #28-S — across-run dispersion (`74307dc`)

Per-metric sample stddev across RNG runs: CSV columns `pdr_sd/delay_sd/delay99_sd/nrl_sd`, `# stddev` lines under the human table, and error bars in both chart types (`make-charts.py` sweep lines + taxonomy bars, verified on synthetic data). Published numbers now carry uncertainty — the same run-to-run noise that produced the #47 and #68-hotspot false signals is now visible at a glance.

## #58 — provisional `--scenario=thesis` preset (`2c7f110`)

Per the maintainer decision recorded on #58/#70 (2026-07-19): proceed on the **Ducatelle 2007 PhD thesis** as the source of record without blocking on PDF access. `--scenario=thesis` models the papers' own evaluation field — 100 nodes on 3000×1000 m, same radio/traffic/mobility regime — distinct from the `paper` preset's Broch/CMU *calibration* role (#24). Values are marked **PROVISIONAL** in-code; the reconstruction table with confidence levels is on #58, and the two findings it surfaced are tracked as #88 (T_hop magnitude) and #89 (jitter estimator).

## CI plumbing (`bdd1421`, part of `e82c82a`)

The `paper-benchmark.yml` compact `##BENCH##` block now re-emits the new columns (`$7..$9`) so the QoS numbers are readable from a cheap `get_job_logs` tail; `bench_parse.py` already tolerates the extra fields.

## Verification

- Python consumers: `py_compile` clean; chart/docs-table generators exercised end-to-end on a synthetic CSV (error bars and `inf` rendering verified visually).
- Harness C++: compiled and ran green on ns-3.42 in run 29665853612 (the 22-minute live run above); the full 3.36–3.48 matrix runs on this PR's CI.
- No core/ changes — adapters/harness only; wire format untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s

---
_Generated by [Claude Code](https://claude.ai/code/session_015bERuB9anZJkEXDjAMst3s)_