### PR TITLE
feat(ns3): expose T_hop as the HopTime attribute (#88)

### DIFF
--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -53,6 +53,7 @@ RoutingProtocol::RoutingProtocol()
       m_enableMacFailureDetector(true),
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
+      m_hopTime(0.05),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
       m_macServiceAlpha(0.7),
@@ -136,6 +137,16 @@ TypeId RoutingProtocol::GetTypeId() {
                           DoubleValue(1.0),
                           MakeDoubleAccessor(&RoutingProtocol::m_repairTimeout),
                           MakeDoubleChecker<double>())
+            .AddAttribute("HopTime",
+                          "Fixed unloaded-hop reference time T_hop (s): weights "
+                          "hop count against measured delay in the goodness "
+                          "(T_d + h*T_hop)/2, and is the A2 fallback service "
+                          "time. Default is the core's 50 ms; issue #88 "
+                          "suspects the papers meant a few ms — this attribute "
+                          "exists for that sensitivity sweep.",
+                          DoubleValue(0.05),
+                          MakeDoubleAccessor(&RoutingProtocol::m_hopTime),
+                          MakeDoubleChecker<double>(0.0))
             .AddAttribute("LinkfailNotifyInterval",
                           "Minimum spacing (s) between LinkFail notifications "
                           "originated about the same destination (issue #20); "
@@ -270,6 +281,7 @@ void RoutingProtocol::DoInitialize() {
     m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
     m_config.repairWaitFactor = m_repairWaitFactor;
     m_config.repairTimeout = m_repairTimeout;
+    m_config.hopTimeSec = m_hopTime;
     m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
     m_config.enableMacMetric = m_enableMacMetric;
     m_queue.SetTimeout(m_queueTimeout);  // attribute lands after construction (#21)
@@ -323,6 +335,7 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.txFailureThreshold = static_cast<int>(m_txFailureThreshold);
         m_config.repairWaitFactor = m_repairWaitFactor;
         m_config.repairTimeout = m_repairTimeout;
+        m_config.hopTimeSec = m_hopTime;
         m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
         m_config.enableMacMetric = m_enableMacMetric;
         m_logic.reset(new ::anthocnet::core::AntRouterLogic(

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -205,6 +205,7 @@ private:
     bool m_enableMacFailureDetector;
     double m_repairWaitFactor;
     double m_repairTimeout;
+    double m_hopTime;                 ///< T_hop unloaded-hop reference (s), #88
     double m_linkfailNotifyInterval;  ///< issue #20 origin cooldown (s), 0 = off
     Time m_queueTimeout;              ///< issue #21 pending-queue hold before drop
     // Issue #68: measured per-packet MAC service time (EWMA of inter-ack


### PR DESCRIPTION
Exposes the core `Config::hopTimeSec` (T_hop, the unloaded-hop reference constant, 50 ms default) as the ns-3 `HopTime` attribute so it can be swept from the benchmark workflows.

## Why

The #88 sensitivity sweep — does a paper-plausible few-ms T_hop change the delay/jitter picture (#21) and un-inert `betaData` (#56)? — had no adapter-side knob to drive it from the benchmark workflows. This is plain adapter plumbing.

## What

- Adds the `HopTime` ns-3 `Double` attribute, wired to `m_config.hopTimeSec` at both config-population sites.
- Default unchanged (`0.05` s), so behaviour is identical unless the attribute is set.

Golden rules: adapter-only change, no core logic, no wire-format change. The sweep results driven by this knob are recorded on #88 (T_hop is a modest −12% delay/jitter contributor at 0.01, not the #21 lever — the dOff50 ≈ 3 ms diagnostic points the tail at hold-time, not metric weighting).

Closes the sweep-plumbing half of #88.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYXPvzNU8YaXUW1n6k1Gy1)_