### PR TITLE
feat(ns3): attribute pending-queue hold time by reason (#21)

### DIFF
--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -500,6 +500,45 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             std::cout << " linkfailProp=" << lfProp
                       << " linkfailBudgetDrop=" << lfBudget
                       << " linkfailOrigSuppressed=" << lfSuppressed;
+
+            // Issue #21: pending-queue hold-time attribution. dOff50 is ~3 ms
+            // (#88) so the delay/jitter gap vs AODV is carried by queue-held
+            // packets; this splits the delivered hold time (and the aged-out
+            // drops) across the setup / reconvergence / repair hold paths so
+            // the dominant one can be attacked. Summed across nodes.
+            ns3::anthocnet::HoldStats hs;
+            for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+                Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
+                if (!ip) continue;
+                Ptr<ns3::anthocnet::RoutingProtocol> ahn =
+                    DynamicCast<ns3::anthocnet::RoutingProtocol>(ip->GetRoutingProtocol());
+                if (!ahn) continue;
+                const ns3::anthocnet::HoldStats& s = ahn->HoldTimeStats();
+                for (uint8_t r = 0; r < ns3::anthocnet::kHoldReasons; ++r) {
+                    hs.deliveredCount[r] += s.deliveredCount[r];
+                    hs.deliveredSumS[r] += s.deliveredSumS[r];
+                    if (s.deliveredMaxS[r] > hs.deliveredMaxS[r])
+                        hs.deliveredMaxS[r] = s.deliveredMaxS[r];
+                    hs.droppedCount[r] += s.droppedCount[r];
+                    hs.droppedSumS[r] += s.droppedSumS[r];
+                }
+            }
+            static const char* kReasonName[3] = {"setup", "reconv", "repair"};
+            std::cout << " hold[";
+            for (uint8_t r = 0; r < ns3::anthocnet::kHoldReasons; ++r) {
+                const double meanMs = hs.deliveredCount[r]
+                    ? 1000.0 * hs.deliveredSumS[r] / hs.deliveredCount[r] : 0.0;
+                std::cout << (r ? " " : "") << kReasonName[r] << "="
+                          << hs.deliveredCount[r] << "/" << std::setprecision(1)
+                          << meanMs << "ms/max" << std::setprecision(1)
+                          << 1000.0 * hs.deliveredMaxS[r] << "ms";
+            }
+            std::cout << "] holdDrop[";
+            for (uint8_t r = 0; r < ns3::anthocnet::kHoldReasons; ++r) {
+                std::cout << (r ? " " : "") << kReasonName[r] << "="
+                          << hs.droppedCount[r];
+            }
+            std::cout << "]";
         }
         std::cout << "\n";
     }

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -448,6 +448,7 @@ Ptr<Ipv4Route> RoutingProtocol::RouteOutput(Ptr<Packet> p, const Ipv4Header& hea
     m_logic->noteDataSession(ToCore(dst));
     NodeAddress next = m_logic->nextHopForData(ToCore(dst));
     if (next != kInvalidAddress) {
+        m_everRouted.insert(ToCore(dst));  // #21: this dest has been routed
         Ptr<Ipv4Route> route = Create<Ipv4Route>();
         route->SetDestination(dst);
         route->SetGateway(ToIpv4(next));
@@ -498,6 +499,7 @@ bool RoutingProtocol::RouteInput(Ptr<const Packet> p, const Ipv4Header& header,
     // prev hop), so exclusion is NS-2-only for now; NS-3 still relies on TTL.
     NodeAddress next = m_logic->nextHopForData(ToCore(dst));
     if (next != kInvalidAddress) {
+        m_everRouted.insert(ToCore(dst));  // #21: this dest has been routed
         Ptr<Ipv4Route> route = Create<Ipv4Route>();
         route->SetDestination(dst);
         route->SetGateway(ToIpv4(next));
@@ -520,6 +522,11 @@ void RoutingProtocol::DeferredRouteOutput(Ptr<const Packet> p, const Ipv4Header&
     entry.header = header;
     entry.ucb = ucb;
     entry.ecb = ecb;
+    // #21 attribution: a deferred packet is either a first-time reactive setup
+    // (this dest was never routed) or a reconvergence wait (route was known and
+    // lost). NotifyTxError's re-injection path tags its own entries HOLD_REPAIR.
+    entry.holdReason = m_everRouted.count(ToCore(header.GetDestination()))
+                           ? HOLD_RECONV : HOLD_SETUP;
     m_queue.Enqueue(entry);
 
     // Ask the core what to do; it returns Queue + a reactive forward ant.
@@ -614,7 +621,11 @@ void RoutingProtocol::FlushQueue(NodeAddress coreDest) {
         route->SetSource(e.header.GetSource());
         route->SetOutputDevice(m_ipv4->GetNetDevice(
             m_ipv4->GetInterfaceForAddress(m_socketAddresses.begin()->second.GetLocal())));
-        if (!e.ucb.IsNull()) e.ucb(route, e.packet, e.header);
+        if (!e.ucb.IsNull()) {
+            m_everRouted.insert(coreDest);      // #21: this dest has been routed
+            m_queue.NoteDelivered(e);           // #21: attribute this packet's hold
+            e.ucb(route, e.packet, e.header);
+        }
     }
 }
 
@@ -723,6 +734,7 @@ void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI
         entry.header = ipHeader;
         entry.ucb = m_cachedUcb;
         entry.ecb = m_cachedEcb;
+        entry.holdReason = HOLD_REPAIR;  // #21: held during local repair (#46)
         m_queue.Enqueue(entry);
         FlushQueue(dataDest);
     }

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 
 #include "anthocnet/core/ant_router_logic.h"
 #include "anthocnet/core/config.h"
@@ -113,6 +114,12 @@ public:
     uint64_t LinkfailOriginsSuppressed() const {
         return m_logic ? m_logic->linkfailOriginsSuppressed() : 0;
     }
+
+    /// Issue #21 hold-time attribution: per-reason (setup / reconvergence /
+    /// repair) pending-queue hold-time stats accumulated over the run, read by
+    /// the comparison harness under --diag to locate the delay tail's dominant
+    /// hold path.
+    const HoldStats& HoldTimeStats() const { return m_queue.Stats(); }
 
 protected:
     void DoInitialize() override;
@@ -226,6 +233,12 @@ private:
     // a MAC-dropped data packet it only sees as a raw MPDU (issue #46).
     UnicastForwardCallback m_cachedUcb;
     ErrorCallback m_cachedEcb;
+
+    // Destinations this node has ever had a usable next hop for (issue #21):
+    // separates a first-time reactive setup (never routed) from a
+    // reconvergence wait (route was known and lost) when a data packet is
+    // deferred, so the hold-time attribution can tell the two apart.
+    std::set<::anthocnet::core::NodeAddress> m_everRouted;
 
     // trace sources (item 15): ant sent/received and route add/remove.
     TracedCallback<uint8_t, uint8_t, bool> m_txAntTrace;

--- a/ns3/model/anthocnet-rqueue.cc
+++ b/ns3/model/anthocnet-rqueue.cc
@@ -10,6 +10,10 @@ namespace anthocnet {
 
 bool RequestQueue::Enqueue(QueueEntry& entry) {
     Purge();
+    // Preserve the first-enqueue timestamp across re-queues (FlushQueue puts an
+    // entry back when its route vanishes again) so the #21 hold time measures
+    // the whole wait, not just the last leg.
+    if (entry.enqueueFirst.IsZero()) entry.enqueueFirst = Simulator::Now();
     entry.expire = Simulator::Now() + m_timeout;
     if (m_queue.size() >= m_maxLen) {
         // Drop the oldest to make room.
@@ -40,11 +44,26 @@ void RequestQueue::Purge() {
     for (QueueEntry& e : m_queue) {
         if (e.expire > now) {
             kept.push_back(e);
-        } else if (!e.ecb.IsNull()) {
-            e.ecb(e.packet, e.header, Socket::ERROR_NOROUTETOHOST);
+        } else {
+            // Aged out at QueueTimeout (#21): attribute the lost hold to its
+            // reason before firing the error callback.
+            const uint8_t r = e.holdReason < kHoldReasons ? e.holdReason : HOLD_SETUP;
+            m_stats.droppedCount[r] += 1;
+            m_stats.droppedSumS[r] += (now - e.enqueueFirst).GetSeconds();
+            if (!e.ecb.IsNull()) {
+                e.ecb(e.packet, e.header, Socket::ERROR_NOROUTETOHOST);
+            }
         }
     }
     m_queue.swap(kept);
+}
+
+void RequestQueue::NoteDelivered(const QueueEntry& e) {
+    const uint8_t r = e.holdReason < kHoldReasons ? e.holdReason : HOLD_SETUP;
+    const double hold = (Simulator::Now() - e.enqueueFirst).GetSeconds();
+    m_stats.deliveredCount[r] += 1;
+    m_stats.deliveredSumS[r] += hold;
+    if (hold > m_stats.deliveredMaxS[r]) m_stats.deliveredMaxS[r] = hold;
 }
 
 uint32_t RequestQueue::Size() {

--- a/ns3/model/anthocnet-rqueue.h
+++ b/ns3/model/anthocnet-rqueue.h
@@ -11,10 +11,34 @@
 #include "ns3/packet.h"
 #include "ns3/nstime.h"
 
+#include <cstdint>
 #include <vector>
 
 namespace ns3 {
 namespace anthocnet {
+
+/// Why a data packet is sitting in the pending queue — used to attribute the
+/// delay tail (issue #21) to the dominant hold path. SETUP = first reactive
+/// discovery for a destination this node has never yet routed to; RECONV =
+/// re-discovery after a previously-known route was lost; REPAIR = re-injected
+/// after a MAC transmit failure while a local repair runs (#46).
+enum HoldReason : uint8_t { HOLD_SETUP = 0, HOLD_RECONV = 1, HOLD_REPAIR = 2 };
+constexpr uint8_t kHoldReasons = 3;
+
+/// Per-reason hold-time accounting over a run (issue #21 tail attribution).
+/// The #88 sweep showed the median offered packet delivers in ~3 ms (dOff50):
+/// the mean/jitter gap vs AODV is carried entirely by queue-held packets, so
+/// which reason accumulates the most *delivered* hold time is the dominant
+/// cause of the tail. `dropped*` counts packets that aged out at QueueTimeout
+/// (a PDR loss rather than a delay, but the same hold mechanic).
+struct HoldStats
+{
+    uint64_t deliveredCount[kHoldReasons] = {0, 0, 0};
+    double   deliveredSumS[kHoldReasons]  = {0.0, 0.0, 0.0};
+    double   deliveredMaxS[kHoldReasons]  = {0.0, 0.0, 0.0};
+    uint64_t droppedCount[kHoldReasons]   = {0, 0, 0};
+    double   droppedSumS[kHoldReasons]    = {0.0, 0.0, 0.0};
+};
 
 /// One queued packet plus the callbacks needed to resume it once a route
 /// appears (or to error it when it expires).
@@ -25,6 +49,11 @@ struct QueueEntry
     Ipv4RoutingProtocol::UnicastForwardCallback ucb;
     Ipv4RoutingProtocol::ErrorCallback ecb;
     Time expire;
+    // #21 hold-time attribution: time this packet first entered the queue
+    // (preserved across re-queues so the total wait is measured, not the last
+    // leg) and why it is waiting.
+    Time enqueueFirst;
+    uint8_t holdReason = HOLD_SETUP;
 };
 
 class RequestQueue
@@ -48,12 +77,21 @@ public:
 
     uint32_t Size();
 
+    /// Record a packet leaving the queue by *delivery* (the adapter forwarded
+    /// it once a route appeared): attributes its total hold time to its reason
+    /// (issue #21). Call once per packet, just before invoking its ucb.
+    void NoteDelivered(const QueueEntry& e);
+
+    /// Read-only hold-time attribution accumulated over the run (issue #21).
+    const HoldStats& Stats() const { return m_stats; }
+
 private:
     static Ipv4Address Dst(const QueueEntry& e) { return e.header.GetDestination(); }
 
     std::vector<QueueEntry> m_queue;
     uint32_t m_maxLen;
     Time m_timeout;
+    HoldStats m_stats;
 };
 
 } // namespace anthocnet


### PR DESCRIPTION
## Why

The #88 T_hop sweep pinned the #21 delay/jitter gap vs AODV to **hold time, not metric weighting**: `dOff50 ≈ 3 ms` (the median offered packet delivers in milliseconds) while mean delay is 113–128 ms and jitter 200–230 ms. The whole gap is carried by the minority of packets that wait in the pending queue during link breaks, repair, or slow flow setup. To attack the dominant hold path we first have to *see* which one it is (per the #91 plan, step 2).

## What

Per-packet hold-time attribution in the ns-3 pending queue, split across the three hold paths:

- **setup** — first reactive discovery for a destination never yet routed;
- **reconv** — re-discovery after a previously-known route was lost;
- **repair** — re-injected after a MAC transmit failure during local repair (the #46 path).

Mechanics:
- `QueueEntry` records its first-enqueue time (preserved across the `FlushQueue` re-queue, so total wait is measured, not the last leg) and a hold reason.
- `RequestQueue` accumulates, per reason, delivered count / mean / max hold and aged-out (`QueueTimeout`) drop counts.
- `RoutingProtocol` tracks which destinations have ever had a usable next hop, to separate setup from reconvergence.
- `anthocnet-compare` emits a `hold[...] holdDrop[...]` block on the existing `# diag` line (anthocnet-only, `--diag`), summed across nodes.

## Scope / invariants

Observability only — **no core logic, wire format, or default behaviour changes**. The accumulation mirrors the existing linkfail `# diag` counters and is read by the `paper-benchmark` workflow to locate the tail's owner. `protocol-review` invariant check: PASS (core has no NS headers; no wire change; no core-logic change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYXPvzNU8YaXUW1n6k1Gy1)_