### PR TITLE
fix(ns3): drive re-discovery for held data with a reactive-retry timer (#21)

### DIFF
--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -56,6 +56,7 @@ RoutingProtocol::RoutingProtocol()
       m_hopTime(0.05),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
+      m_reactiveRetryInterval(Seconds(0.25)),
       m_macServiceAlpha(0.7),
       m_lastAckTime(Seconds(0)),
       m_enableMacMetric(false) {}
@@ -162,6 +163,19 @@ TypeId RoutingProtocol::GetTypeId() {
                           "-2.4 pp PDR, still above AODV).",
                           TimeValue(Seconds(3)),
                           MakeTimeAccessor(&RoutingProtocol::m_queueTimeout),
+                          MakeTimeChecker())
+            .AddAttribute("ReactiveRetryInterval",
+                          "How often to re-flood a reactive forward ant for "
+                          "destinations that still have data waiting in the "
+                          "pending queue but no route (issue #21). The core's "
+                          "data-driven retry only fires when a data packet "
+                          "arrives (~1 pkt/s at paper CBR), so a lost first "
+                          "re-discovery attempt otherwise waits a full second — "
+                          "the reconvergence hold that dominates the delay/jitter "
+                          "tail. This timer retries independently; 0 disables it "
+                          "(pre-#21 behaviour).",
+                          TimeValue(Seconds(0.25)),
+                          MakeTimeAccessor(&RoutingProtocol::m_reactiveRetryInterval),
                           MakeTimeChecker())
             .AddAttribute("MacServiceAlpha",
                           "EWMA weight of the previous estimate when smoothing "
@@ -310,6 +324,14 @@ void RoutingProtocol::Start() {
     m_proactiveTimer.SetFunction(&RoutingProtocol::ProactiveTimerExpire, this);
     m_helloTimer.Schedule(m_helloInterval);
     m_proactiveTimer.Schedule(m_proactiveInterval);
+
+    // Issue #21: drive re-discovery for held data at a sub-second cadence
+    // (0 disables). Off the data-packet path, so a broken route re-forms
+    // without waiting for the next CBR packet to trigger the retry.
+    if (m_reactiveRetryInterval.IsStrictlyPositive()) {
+        m_reactiveRetryTimer.SetFunction(&RoutingProtocol::ReactiveRetryTimerExpire, this);
+        m_reactiveRetryTimer.Schedule(m_reactiveRetryInterval);
+    }
 }
 
 // --- interface notifications ------------------------------------------------
@@ -665,6 +687,34 @@ void RoutingProtocol::ProactiveTimerExpire() {
         }
     }
     m_proactiveTimer.Schedule(m_proactiveInterval);
+}
+
+void RoutingProtocol::ReactiveRetryTimerExpire() {
+    // Issue #21: the reconvergence hold — data waiting for a broken route to
+    // re-form — dominates the delay/jitter tail. The core only re-emits a
+    // reactive ant when a data packet arrives (~1 pkt/s at paper CBR), so a
+    // lost first attempt waits a full second. Re-flood discovery here, off the
+    // data path, for every destination still holding data with no route. Bounded
+    // by the pending queue: once a route forms the packets flush and the
+    // destination stops being retried; unreachable destinations age out at
+    // QueueTimeout. Mirrors the core's own reactive emission (createForwardAnt +
+    // Broadcast), so the ant is the same bounded expanding-ring flood.
+    if (m_logic) {
+        for (Ipv4Address dst : m_queue.PendingDestinations()) {
+            const NodeAddress coreDst = ToCore(dst);
+            if (m_logic->nextHopForData(coreDst) == kInvalidAddress) {
+                AntMessage refa = m_logic->createForwardAnt(AntType::Reactive, coreDst);
+                SendAnt(refa, Ipv4Address("255.255.255.255"));
+                // This emission bypasses the core's sendAnt (which fires the
+                // observer), so surface it on the Tx trace ourselves to keep the
+                // --diag antTx[reactive] tally honest. NRL is counted at the IP
+                // layer, so the flood already shows there.
+                onAntSent(AntType::Reactive, ::anthocnet::core::AntDirection::Up,
+                          /*broadcast=*/true);
+            }
+        }
+    }
+    m_reactiveRetryTimer.Schedule(m_reactiveRetryInterval);
 }
 
 // --- MAC transmit-failure hook (ADR-0008 detector D) ------------------------

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -164,6 +164,13 @@ private:
     // timers
     void HelloTimerExpire();
     void ProactiveTimerExpire();
+    /// Issue #21: re-flood a reactive forward ant for every destination with
+    /// data still waiting in the pending queue but no route. onDataPacket only
+    /// retries when a data packet arrives (~1 pkt/s at paper CBR), so a lost
+    /// first re-discovery attempt otherwise waits a full second; this timer
+    /// retries at a sub-second cadence, shortening the reconvergence hold that
+    /// dominates the delay/jitter tail.
+    void ReactiveRetryTimerExpire();
 
     // ADR-0008 detector D: MAC transmit-failure hook. The WifiMac "DroppedMpdu"
     // trace fires when a unicast frame is dropped after exhausting retries; we
@@ -196,6 +203,7 @@ private:
 
     Timer m_helloTimer;
     Timer m_proactiveTimer;
+    Timer m_reactiveRetryTimer;  ///< issue #21: re-flood discovery for held data
 
     // attribute-backed parameters
     Time m_helloInterval;
@@ -215,6 +223,7 @@ private:
     double m_hopTime;                 ///< T_hop unloaded-hop reference (s), #88
     double m_linkfailNotifyInterval;  ///< issue #20 origin cooldown (s), 0 = off
     Time m_queueTimeout;              ///< issue #21 pending-queue hold before drop
+    Time m_reactiveRetryInterval;     ///< issue #21 timer-driven re-discovery cadence (0 = off)
     // Issue #68: measured per-packet MAC service time (EWMA of inter-ack
     // spacing while the MAC queue stays backlogged — pure service time, no
     // queue wait, so (Q+1)*T̂_mac does not double-count congestion).

--- a/ns3/model/anthocnet-rqueue.cc
+++ b/ns3/model/anthocnet-rqueue.cc
@@ -58,6 +58,18 @@ void RequestQueue::Purge() {
     m_queue.swap(kept);
 }
 
+std::vector<Ipv4Address> RequestQueue::PendingDestinations() {
+    Purge();
+    std::vector<Ipv4Address> dests;
+    for (const QueueEntry& e : m_queue) {
+        const Ipv4Address d = Dst(e);
+        if (std::find(dests.begin(), dests.end(), d) == dests.end()) {
+            dests.push_back(d);
+        }
+    }
+    return dests;
+}
+
 void RequestQueue::NoteDelivered(const QueueEntry& e) {
     const uint8_t r = e.holdReason < kHoldReasons ? e.holdReason : HOLD_SETUP;
     const double hold = (Simulator::Now() - e.enqueueFirst).GetSeconds();

--- a/ns3/model/anthocnet-rqueue.h
+++ b/ns3/model/anthocnet-rqueue.h
@@ -77,6 +77,11 @@ public:
 
     uint32_t Size();
 
+    /// Distinct destinations with at least one packet still waiting (issue #21:
+    /// the reactive-retry timer re-floods discovery only for these). Purges
+    /// expired entries first, so an aged-out destination is not retried.
+    std::vector<Ipv4Address> PendingDestinations();
+
     /// Record a packet leaving the queue by *delivery* (the adapter forwarded
     /// it once a route appeared): attributes its total hold time to its reason
     /// (issue #21). Call once per packet, just before invoking its ucb.


### PR DESCRIPTION
## Why

The #21 hold-time attribution ([#93](https://github.com/danieljoppi/AntHocNet/pull/93), merged) located the delay/jitter tail in the **reconvergence wait after an in-use route breaks**: ~75–80% of the delivered pending-queue hold mass is packets re-discovering a lost route (mean ~380 ms, max ~2.8 s across 5 seeds), vs a fast repair path (~70 ms) and rare setup. See [#21 (issuecomment-5015453473)](https://github.com/danieljoppi/AntHocNet/issues/21#issuecomment-5015453473).

**Root cause, confirmed by sweep:** the core re-emits a reactive forward ant only when a *data packet* arrives with no route (`onDataPacket`), rate-limited by `Config::reactiveRetryInterval` (1 s). At paper CBR (1 pkt/s/flow), consecutive packets to a destination are already ~1 s apart, so that gate never engages and the retry cadence is pinned to the *traffic rate*. A lost first re-discovery attempt therefore waits a full second for the next packet to re-trigger discovery. Sweeping `reactiveRetryInterval` to 0.5 and 0.25 s produced **byte-identical** results ([runs 29684371747 / 29684372944](https://github.com/danieljoppi/AntHocNet/actions/runs/29684371747)) — inert in the sub-second direction.

## Fix

Adapter-side (golden rule 2: adapters own timers + the pending queue): a periodic `ReactiveRetryTimer` re-floods a reactive forward ant, **off the data path**, for every destination that still has data waiting in the pending queue but no route. A broken route now re-forms at the timer cadence (default 0.25 s) instead of waiting for the next CBR packet.

- **Bounded** by the pending queue: once a route forms the packets flush and the destination stops being retried; unreachable destinations age out at `QueueTimeout` (3 s, #86). AntHocNet's NRL headroom (35.7 vs AODV 60.8, −41%) absorbs the extra floods.
- The emission mirrors the core's own reactive ant (`createForwardAnt` + Broadcast) and is surfaced on the Tx trace so the `--diag antTx` tally stays honest; NRL is counted at the IP layer and already captures the floods.
- New ns-3 attribute `ReactiveRetryInterval` (default 0.25 s; **0 = pre-#21 behaviour**) makes the cadence tunable.

**No core logic, wire format, or NS-2 change.** `protocol-review` invariants: PASS.

## Validation

Paper regime, 5 seeds, dispersion, anthocnet vs aodv on identical realisations. A/B: default 0.25 s vs the `0` (timer-off = old baseline) control, plus a 0.5 s frontier point. Results posted to #21 before merge; **merges only if mean delay + jitter drop at ≥ PDR with NRL still under AODV.**