### PR TITLE
feat(core): enforce the maxPathLength ant hop cap with a drop (#26, item 6.2)

### DIFF
--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -484,6 +484,14 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
     const bool proactive = (ant.type == AntType::Proactive);
 
     if (ant.isForward()) {
+        // 6.2 hop cap ([1] §4.2): an ant that has already traversed
+        // maxPathLength hops is dropped rather than forwarded further. Propagation
+        // is also bounded by broadcastBudget (A3) and (src,seq) dedup, but this is
+        // the explicit per-ant hop ceiling the spec calls for, and — living in the
+        // core — it caps ant reach on every adapter without a per-simulator TTL.
+        if (ant.visited.size() >= config_.maxPathLength) {
+            return {RouteDecision::drop()};
+        }
         stampForward(ant);
 
         if (ant.dst == address_) {

--- a/core/tests/test_router_logic.cpp
+++ b/core/tests/test_router_logic.cpp
@@ -115,5 +115,36 @@ int main() {
         CHECK(router.table().getPheromoneVirtual(9, 2) > 0.0);
     }
 
+    // --- 6.2: a forward ant past the hop cap is dropped -------------------
+    {
+        Config capCfg = cfg;
+        capCfg.maxPathLength = 3;  // small cap for the test
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 4, capCfg, clock, rng);
+
+        // Already traversed maxPathLength hops before reaching us: dropped.
+        AntMessage overCap;
+        overCap.type = AntType::Reactive;
+        overCap.src = 3;
+        overCap.dst = 9;  // not us, so the drop is the hop cap, not delivery
+        overCap.seqNum = 11;
+        overCap.visited = {{3, 0.0}, {5, 0.0}, {6, 0.0}};  // size 3 == cap
+        auto dropped = router.onReceiveAnt(overCap, 6);
+        CHECK_EQ(dropped.size(), static_cast<std::size_t>(1));
+        CHECK(dropped[0].action == RouteAction::Drop);
+
+        // One hop below the cap: forwarded (broadcast, no route), not dropped.
+        AntMessage underCap;
+        underCap.type = AntType::Reactive;
+        underCap.src = 3;
+        underCap.dst = 9;
+        underCap.seqNum = 12;
+        underCap.visited = {{3, 0.0}, {5, 0.0}};  // size 2 < cap
+        auto forwarded = router.onReceiveAnt(underCap, 5);
+        CHECK_EQ(forwarded.size(), static_cast<std::size_t>(1));
+        CHECK(forwarded[0].action == RouteAction::Broadcast);
+    }
+
     return RUN_TESTS();
 }


### PR DESCRIPTION
## Why

Closes the last open item-06 fidelity deviation (#26). The canonical AntHocNet spec ([1] §4.2) bounds a reactive forward ant by a maximum hop count. The core capped the *recorded* visited path at `Config::maxPathLength` (`stampForward` stopped appending) but did **not** stop forwarding an ant that had already reached the cap — it kept propagating, bounded only indirectly by the per-type `broadcastBudget` (A3, #53) and the `(src,seq)` dedup history.

## What

`onReceiveAnt` now drops a forward ant whose visited path has already reached `maxPathLength`, instead of forwarding it further — the explicit hop ceiling the spec's acceptance calls for. Living in the core, this caps ant reach uniformly on **both** adapters without a per-simulator packet TTL (golden rules 1/2), and strengthens the bounded-structure invariant (golden rule 5).

- **Behaviourally inert on normal-diameter scenarios**: paths in the 50–100 node benchmark fields are ~5–15 hops, far below the default cap of 100. It only fires on a pathological loop/flood an ant would otherwise ride to the dedup bound — so benchmark metrics are unchanged, and the NS-3 e2e delivery smoke still passes.
- Covered by a **core test** (`test_router_logic.cpp`): an over-cap forward ant returns `Drop`; a below-cap one is still forwarded. `make test`: 18/18 green.

No wire-format change (`visited` / `maxPathLength` already exist and are unchanged), no adapter change, no NS-2 change. `protocol-review` invariants: PASS (core change carries a core test).

## Item-06 status

This leaves **item 06 done**. 6.4 (`prevSINR`→`pathTime` rename; `kBeta` removed) and 6.5 (hello advertises best-pheromone destinations deterministically, no `uniform()>0.5` coin flip) were already resolved by the item 01/02/03 work — the #26 checkbox just hadn't been ticked.

[1] Di Caro, Ducatelle, Gambardella, "AntHocNet…", PPSN VIII 2004.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYXPvzNU8YaXUW1n6k1Gy1)_