### PR TITLE
feat(core)!: multipath reactive setup (1.5× acceptance filter) with linkfail churn bound, default on (#96)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -181,6 +181,7 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 | Forward / backward / hello / repair ant | path collector / pheromone depositor / neighbour-discovery + gossip / link-failure local search. |
 | Neighbour liveness | a neighbour is "gone" via either missed hellos (core timer, primary) or a failed unicast (MAC signal, fast-path); both call `loseNeighbor`. `INeighborProvider` is advisory, never authoritative for removal (ADR-0008). |
 | Stochastic data routing | data is forwarded by a per-packet pheromone-weighted draw, **excluding the prev hop** (loop safety; only-option fallback). Per-flow stickiness (a bounded `(src,dst)→hop` cache) is config-gated, default off (ADR-0010). |
+| Multipath reactive setup | a later reactive forward ant of an already-seen `(src,seq)` generation is still forwarded when both its hops and travel time are within `antAcceptanceFactor` (1.5) of the generation's best, laying down several good paths ([1] §3.1). Requires its **linkfail churn bound**: losing a best hop that leaves a usable alternate is absorbed, not flooded — without it multipath *regressed* PDR on the ns-3 disk-model harness. Config-gated (`enableMultipath`, default on; #96). |
 | `NodeAddress` | core address type (`int32_t`), = a node's primary interface IP, treated opaquely; `kInvalidAddress` = -1 = "no route / no specific next hop". Broadcast is a `RouteAction`, **never** a `NodeAddress` (ADR-0011). |
 
 ## 10. Open questions for future work

--- a/core/include/anthocnet/core/ant_history.h
+++ b/core/include/anthocnet/core/ant_history.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <map>
 #include <set>
 #include <utility>
 
@@ -39,6 +40,35 @@ private:
 
     std::size_t        maxEntries_;
     std::set<Key>      entries_;
+    std::deque<Key>    insertionOrder_;  // for FIFO eviction
+};
+
+/// Multipath acceptance filter for reactive forward ants ([1] §3.1, issue #96).
+/// Tracks, per (src, seq) generation, the best (fewest-hop / least-time) ant
+/// seen, and admits a later same-generation ant only when both its hops and its
+/// travel time are within `factor` of that best — so several *good* paths get
+/// laid down instead of only the first-arriving one. Bounded FIFO like
+/// AntHistoryTracker (golden rule 5).
+class GenerationTracker {
+public:
+    /// maxEntries == 0 means unbounded.
+    explicit GenerationTracker(std::size_t maxEntries) : maxEntries_(maxEntries) {}
+
+    /// Decide whether to forward a reactive forward ant carrying `hops`/`time`.
+    /// The first ant of a generation is always admitted; a later one only if
+    /// `hops <= factor*bestHops && time <= factor*bestTime`. Admitted ants
+    /// refresh the per-metric minimums. Returns false to drop.
+    bool accept(NodeAddress src, std::uint32_t seqNum, std::uint32_t hops,
+                Time time, double factor);
+
+    void clear();
+
+private:
+    struct Best { std::uint32_t hops; Time time; };
+    using Key = std::pair<NodeAddress, std::uint32_t>;
+
+    std::size_t        maxEntries_;
+    std::map<Key, Best> best_;
     std::deque<Key>    insertionOrder_;  // for FIFO eviction
 };
 

--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -188,6 +188,7 @@ private:
     const ILinkMetric* metric_;            ///< pheromone strategy (item 16)
     const ILinkState* linkState_;          ///< MAC congestion signals (item 10/A2), optional
     AntHistoryTracker history_;
+    GenerationTracker genQuality_;   ///< multipath acceptance filter (#96)
     std::uint32_t   seqNum_ = 0;
     std::map<NodeAddress, double> activeSessions_;  ///< dest -> last data-send time
     std::map<NodeAddress, double> lastSeen_;        ///< neighbor -> last reception time

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -95,13 +95,21 @@ struct Config {
     /// Max times a reactive forward ant may be (re)broadcast in a region with no
     /// pheromone, so route setup doesn't flood ([1] §3.2).
     int reactiveMaxBroadcasts = 2;
-    /// Multipath acceptance factor ([1] §3.1, "empirically set to 1.5"): when a
-    /// node receives a *later* reactive forward ant of a generation it already
-    /// saw, it forwards it only if both its hop count and its travel time are
-    /// within this factor of the best ant of that generation seen so far. This
-    /// is how AntHocNet lays down *multiple* good paths instead of just the
-    /// first-arriving one. >= a very large value collapses setup to single-path
-    /// (pre-#96 behaviour). Confirm the exact value vs the thesis (#96).
+    /// Multipath reactive setup ([1] §3.1, issue #96): when on, a *later*
+    /// reactive forward ant of an already-seen generation is forwarded if it
+    /// passes the antAcceptanceFactor band below, laying down *multiple* good
+    /// paths. When off (default), every ant type uses strict (src,seq) dedup —
+    /// only the first-arriving copy propagates (single-path setup). Default off:
+    /// validation on the ns-3 disk-model harness showed multipath regresses PDR
+    /// there (control-traffic contention + linkfail churn; #96 data).
+    bool enableMultipath = false;
+    /// Multipath acceptance factor ([1] §3.1, "empirically set to 1.5"), used
+    /// only when enableMultipath is on: a later same-generation reactive
+    /// forward ant is forwarded only if both its hop count and its travel time
+    /// are within this factor of the best ant of that generation seen so far.
+    /// *Higher* admits *more* copies (more multipath, up to a flood); 1.0 still
+    /// admits equal-metric copies, so no factor value reproduces strict
+    /// single-path dedup — that is what enableMultipath=false is for.
     double antAcceptanceFactor = 1.5;
     /// Max times a proactive forward ant may be (re)broadcast — covering both the
     /// per-hop exploratory broadcast ([1] §3.3) and a route gap en route. Proactive

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -98,11 +98,14 @@ struct Config {
     /// Multipath reactive setup ([1] §3.1, issue #96): when on, a *later*
     /// reactive forward ant of an already-seen generation is forwarded if it
     /// passes the antAcceptanceFactor band below, laying down *multiple* good
-    /// paths. When off (default), every ant type uses strict (src,seq) dedup —
-    /// only the first-arriving copy propagates (single-path setup). Default off:
-    /// validation on the ns-3 disk-model harness showed multipath regresses PDR
-    /// there (control-traffic contention + linkfail churn; #96 data).
-    bool enableMultipath = false;
+    /// paths — and losing a best hop that leaves a usable alternate is absorbed
+    /// instead of flooding a LinkFail (the churn bound; without it multipath
+    /// regressed PDR on the ns-3 disk-model harness, #96 round 1). When off,
+    /// every ant type uses strict (src,seq) dedup — only the first-arriving
+    /// copy propagates (single-path setup). Default on: with the churn bound,
+    /// multipath beat single-path on every headline metric in the paper regime
+    /// (PDR 92.3 vs 89.4, delay/jitter/NRL all no worse; #96 round 2).
+    bool enableMultipath = true;
     /// Multipath acceptance factor ([1] §3.1, "empirically set to 1.5"), used
     /// only when enableMultipath is on: a later same-generation reactive
     /// forward ant is forwarded only if both its hop count and its travel time

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -95,6 +95,14 @@ struct Config {
     /// Max times a reactive forward ant may be (re)broadcast in a region with no
     /// pheromone, so route setup doesn't flood ([1] §3.2).
     int reactiveMaxBroadcasts = 2;
+    /// Multipath acceptance factor ([1] §3.1, "empirically set to 1.5"): when a
+    /// node receives a *later* reactive forward ant of a generation it already
+    /// saw, it forwards it only if both its hop count and its travel time are
+    /// within this factor of the best ant of that generation seen so far. This
+    /// is how AntHocNet lays down *multiple* good paths instead of just the
+    /// first-arriving one. >= a very large value collapses setup to single-path
+    /// (pre-#96 behaviour). Confirm the exact value vs the thesis (#96).
+    double antAcceptanceFactor = 1.5;
     /// Max times a proactive forward ant may be (re)broadcast — covering both the
     /// per-hop exploratory broadcast ([1] §3.3) and a route gap en route. Proactive
     /// ants monitor known paths; an unbounded budget let them flood any region of

--- a/core/src/ant_history.cpp
+++ b/core/src/ant_history.cpp
@@ -30,5 +30,39 @@ void AntHistoryTracker::clear() {
     insertionOrder_.clear();
 }
 
+bool GenerationTracker::accept(NodeAddress src, std::uint32_t seqNum,
+                               std::uint32_t hops, Time time, double factor) {
+    const Key key{src, seqNum};
+    auto it = best_.find(key);
+    if (it == best_.end()) {
+        // First ant of this generation: always forward and record its metrics.
+        best_.emplace(key, Best{hops, time});
+        insertionOrder_.push_back(key);
+        if (maxEntries_ != 0) {
+            while (insertionOrder_.size() > maxEntries_) {
+                best_.erase(insertionOrder_.front());
+                insertionOrder_.pop_front();
+            }
+        }
+        return true;
+    }
+    // A later ant of a known generation: admit only if both its hop count and
+    // its travel time are within `factor` of the best seen (a bad/looping path
+    // exceeds this and is dropped). Admitted ants refresh the per-metric minima.
+    Best& b = it->second;
+    if (static_cast<double>(hops) <= factor * static_cast<double>(b.hops) &&
+        time <= factor * b.time) {
+        if (hops < b.hops) b.hops = hops;
+        if (time < b.time) b.time = time;
+        return true;
+    }
+    return false;
+}
+
+void GenerationTracker::clear() {
+    best_.clear();
+    insertionOrder_.clear();
+}
+
 } // namespace core
 } // namespace anthocnet

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -457,14 +457,15 @@ void AntRouterLogic::reinforceFromBackAnt(const AntMessage& ant) {
 
 std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incoming,
                                                         NodeAddress prevHop) {
-    // Duplicate / loop detection. A reactive forward ant uses the multipath
-    // acceptance filter (#96, [1] §3.1): a later same-generation ant is
-    // forwarded when both its hops and its travel time are within
-    // antAcceptanceFactor of the best seen, so several good paths get laid down
-    // instead of only the first-arriving one. Every other ant (backward, hello,
-    // linkfail, proactive/repair forward) keeps strict (src,seq) dedup — each of
-    // those must act at most once per generation.
-    if (incoming.isForward() && incoming.type == AntType::Reactive) {
+    // Duplicate / loop detection. With multipath on (#96, [1] §3.1) a reactive
+    // forward ant uses the per-generation acceptance filter: a later
+    // same-generation ant is forwarded when both its hops and its travel time
+    // are within antAcceptanceFactor of the best seen, so several good paths
+    // get laid down instead of only the first-arriving one. Every other ant
+    // (backward, hello, linkfail, proactive/repair forward) — and every ant
+    // when multipath is off — keeps strict (src,seq) dedup.
+    if (config_.enableMultipath && incoming.isForward() &&
+        incoming.type == AntType::Reactive) {
         const auto hops = static_cast<std::uint32_t>(incoming.visited.size());
         Time travel = 0.0;
         for (const AntHop& h : incoming.visited) travel += h.time;

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -149,6 +149,16 @@ std::vector<RouteDecision> AntRouterLogic::reportNeighborLoss(NodeAddress n) {
     for (const auto& pr : affected) {
         const double after = table_.bestRegular(pr.first);
         if (after >= pr.second) continue;  // no ground lost
+        // Multipath churn bound (#96 option 1): with multipath on, losing the
+        // best hop while a usable alternate next-hop survives is the expected
+        // case — data keeps flowing over the alternate, so don't turn every
+        // such break into a LinkFail flood (the #96 runs showed 2-3x linkfail
+        // volume eating the PDR). Only a destination left with NO usable path
+        // is advertised. Single-path (gate off) keeps the pre-#96 behaviour.
+        if (config_.enableMultipath && after > config_.minPheromone) {
+            ++linkfailOriginsSuppressed_;
+            continue;
+        }
         // Origin cooldown (issue #20): under link flapping, re-advertising the
         // same destination every evict/re-learn cycle is what turns breaks into
         // a notification storm; neighbours already applied the first note.
@@ -247,7 +257,14 @@ std::vector<RouteDecision> AntRouterLogic::handleLinkFail(const AntMessage& note
         }
 
         const double after = table_.bestRegular(d);
-        if (viaReporter && after < before) prop.helloDests.push_back({d, after});
+        if (viaReporter && after < before) {
+            // Multipath churn bound (#96 option 1), mirroring the origin side:
+            // if a usable alternate next-hop survives here, absorb the note
+            // instead of re-flooding it — the pheromone update above already
+            // happened, and data still has a path through this node.
+            if (config_.enableMultipath && after > config_.minPheromone) continue;
+            prop.helloDests.push_back({d, after});
+        }
     }
     if (prop.helloDests.empty()) return {};  // absorbed: our best path is intact
 

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -15,7 +15,8 @@ AntRouterLogic::AntRouterLogic(NodeAddress address, const Config& config, IClock
       engine_(config_),
       metric_(metric ? metric : &defaultMetric_),
       linkState_(linkState),
-      history_(config_.maxHistory) {}
+      history_(config_.maxHistory),
+      genQuality_(config_.maxHistory) {}
 
 // --- neighbour learning -----------------------------------------------------
 
@@ -456,8 +457,22 @@ void AntRouterLogic::reinforceFromBackAnt(const AntMessage& ant) {
 
 std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incoming,
                                                         NodeAddress prevHop) {
-    // (src, seq) duplicate / loop detection.
-    if (!history_.record(incoming.src, incoming.seqNum)) {
+    // Duplicate / loop detection. A reactive forward ant uses the multipath
+    // acceptance filter (#96, [1] §3.1): a later same-generation ant is
+    // forwarded when both its hops and its travel time are within
+    // antAcceptanceFactor of the best seen, so several good paths get laid down
+    // instead of only the first-arriving one. Every other ant (backward, hello,
+    // linkfail, proactive/repair forward) keeps strict (src,seq) dedup — each of
+    // those must act at most once per generation.
+    if (incoming.isForward() && incoming.type == AntType::Reactive) {
+        const auto hops = static_cast<std::uint32_t>(incoming.visited.size());
+        Time travel = 0.0;
+        for (const AntHop& h : incoming.visited) travel += h.time;
+        if (!genQuality_.accept(incoming.src, incoming.seqNum, hops, travel,
+                                config_.antAcceptanceFactor)) {
+            return {RouteDecision::drop()};
+        }
+    } else if (!history_.record(incoming.src, incoming.seqNum)) {
         return {RouteDecision::drop()};
     }
 

--- a/core/tests/test_link_failure.cpp
+++ b/core/tests/test_link_failure.cpp
@@ -388,5 +388,67 @@ int main() {
         CHECK_EQ(router0.linkfailOriginsSuppressed(), static_cast<std::uint64_t>(0));
     }
 
+    // 15. #96 multipath churn bound: with multipath on, losing the best hop
+    //     while a usable alternate next-hop survives originates NO LinkFail
+    //     (the alternate carries the data); losing the last path still does.
+    //     A received LinkFail is likewise absorbed, not re-flooded, when an
+    //     alternate survives. Gate off keeps the pre-#96 notifications.
+    {
+        Config mp = cfg;
+        mp.enableMultipath = true;
+        auto hasLinkFail = [](const std::vector<RouteDecision>& decs) {
+            for (const RouteDecision& d : decs) {
+                if (d.action == RouteAction::Broadcast &&
+                    d.message.type == AntType::LinkFail) return true;
+            }
+            return false;
+        };
+
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 0, mp, clock, rng);
+        router.table().setPheromoneRegular(9, 5, 0.8);  // best path via 5
+        router.table().setPheromoneRegular(9, 6, 0.5);  // usable alternate via 6
+        CHECK(!hasLinkFail(router.reportNeighborLoss(5)));  // alternate -> suppressed
+        CHECK_EQ(router.linkfailOriginsSuppressed(), static_cast<std::uint64_t>(1));
+
+        clock.advance(mp.linkfailNotifyInterval + 0.1);  // outside the #20 cooldown
+        CHECK(hasLinkFail(router.reportNeighborLoss(6)));   // last path -> notify
+
+        // Gate off, same topology: losing the best hop notifies (pre-#96).
+        FakeClock clockOff;
+        ScriptedRng rngOff({0.5});
+        AntRouterLogic routerOff(/*addr*/ 0, cfg, clockOff, rngOff);
+        routerOff.table().setPheromoneRegular(9, 5, 0.8);
+        routerOff.table().setPheromoneRegular(9, 6, 0.5);
+        CHECK(hasLinkFail(routerOff.reportNeighborLoss(5)));
+
+        // Propagation side: a LinkFail that degrades our best but leaves a
+        // usable alternate is applied yet absorbed with multipath on.
+        FakeClock clockP;
+        ScriptedRng rngP({0.5});
+        AntRouterLogic routerP(/*addr*/ 0, mp, clockP, rngP);
+        routerP.table().setPheromoneRegular(9, 5, 0.8);  // best via reporter 5
+        routerP.table().setPheromoneRegular(9, 6, 0.5);  // alternate via 6
+
+        AntMessage note;
+        note.type = AntType::LinkFail;
+        note.direction = AntDirection::Up;
+        note.src = 5;
+        note.seqNum = 1;
+        note.broadcastBudget = 2;
+        note.helloDests = {{9, 0.0}};
+        auto decs = routerP.onReceiveAnt(note, /*prevHop*/ 5);
+        CHECK(!hasLinkFail(decs));  // absorbed: 6 still carries the data
+        CHECK_NEAR(routerP.table().getPheromoneRegular(9, 5), 0.0, 1e-12);  // applied
+
+        // Losing the alternate too (a second note, now the last path) re-floods.
+        AntMessage note2 = note;
+        note2.src = 6;
+        note2.seqNum = 2;
+        auto decs2 = routerP.onReceiveAnt(note2, /*prevHop*/ 6);
+        CHECK(hasLinkFail(decs2));
+    }
+
     return RUN_TESTS();
 }

--- a/core/tests/test_link_failure.cpp
+++ b/core/tests/test_link_failure.cpp
@@ -416,9 +416,11 @@ int main() {
         CHECK(hasLinkFail(router.reportNeighborLoss(6)));   // last path -> notify
 
         // Gate off, same topology: losing the best hop notifies (pre-#96).
+        Config sp = cfg;
+        sp.enableMultipath = false;
         FakeClock clockOff;
         ScriptedRng rngOff({0.5});
-        AntRouterLogic routerOff(/*addr*/ 0, cfg, clockOff, rngOff);
+        AntRouterLogic routerOff(/*addr*/ 0, sp, clockOff, rngOff);
         routerOff.table().setPheromoneRegular(9, 5, 0.8);
         routerOff.table().setPheromoneRegular(9, 6, 0.5);
         CHECK(hasLinkFail(routerOff.reportNeighborLoss(5)));

--- a/core/tests/test_router_logic.cpp
+++ b/core/tests/test_router_logic.cpp
@@ -69,10 +69,48 @@ int main() {
         // The previous hop was learned as a neighbour.
         CHECK(router.table().numNeighbors() >= 1u);
 
-        // A duplicate of the same ant is dropped.
-        auto dup = router.onReceiveAnt(fwd, 4);
-        CHECK_EQ(dup.size(), static_cast<std::size_t>(1));
-        CHECK(dup[0].action == RouteAction::Drop);
+        // #96 multipath: a same-generation ant arriving via a much *worse* path
+        // (far outside the 1.5x hop/time band of the best seen) is dropped.
+        AntMessage worse = fwd;
+        worse.visited = {{3, 0.0}, {5, 0.05}, {6, 0.05}, {7, 0.05}};  // 4 hops vs 2
+        auto dropped = router.onReceiveAnt(worse, 7);
+        CHECK_EQ(dropped.size(), static_cast<std::size_t>(1));
+        CHECK(dropped[0].action == RouteAction::Drop);
+    }
+
+    // --- #96 multipath: a comparable second path of a generation is admitted --
+    {
+        Config mp = cfg;
+        mp.antAcceptanceFactor = 1.5;
+        FakeClock clock;
+        clock.set(1.0);
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 9, mp, clock, rng);  // we are the dest
+
+        // First ant of the generation: 2 hops, admitted -> backward ant.
+        AntMessage a;
+        a.type = AntType::Reactive;
+        a.src = 3;
+        a.dst = 9;
+        a.seqNum = 42;
+        a.visited = {{3, 0.0}, {4, 0.01}};
+        auto first = router.onReceiveAnt(a, 4);
+        CHECK_EQ(first.size(), static_cast<std::size_t>(1));
+        CHECK(first[0].action == RouteAction::Unicast);  // back ant for path 1
+
+        // A second copy of the SAME generation via a comparable alternate path
+        // (3 hops, within 1.5x of the 2-hop best) is admitted -> a second back
+        // ant, laying down the alternate path (multipath).
+        AntMessage b;
+        b.type = AntType::Reactive;
+        b.src = 3;
+        b.dst = 9;
+        b.seqNum = 42;                       // same generation
+        // 3 hops (<= 1.5*2) and total time 0.01 (<= 1.5*0.01): within the band.
+        b.visited = {{3, 0.0}, {5, 0.005}, {6, 0.005}};
+        auto second = router.onReceiveAnt(b, 6);
+        CHECK_EQ(second.size(), static_cast<std::size_t>(1));
+        CHECK(second[0].action == RouteAction::Unicast);  // back ant for path 2
     }
 
     // --- forward ant in transit with no route: broadcast ------------------

--- a/core/tests/test_router_logic.cpp
+++ b/core/tests/test_router_logic.cpp
@@ -69,11 +69,12 @@ int main() {
         // The previous hop was learned as a neighbour.
         CHECK(router.table().numNeighbors() >= 1u);
 
-        // #96 multipath: a same-generation ant arriving via a much *worse* path
-        // (far outside the 1.5x hop/time band of the best seen) is dropped.
+        // #96 gate off (default): ANY same-generation copy — even one a
+        // multipath filter would admit — is dropped by strict (src,seq) dedup
+        // (pre-#96 single-path setup).
         AntMessage worse = fwd;
-        worse.visited = {{3, 0.0}, {5, 0.05}, {6, 0.05}, {7, 0.05}};  // 4 hops vs 2
-        auto dropped = router.onReceiveAnt(worse, 7);
+        worse.visited = {{3, 0.0}, {5, 0.005}, {6, 0.005}};  // comparable 3-hop path
+        auto dropped = router.onReceiveAnt(worse, 6);
         CHECK_EQ(dropped.size(), static_cast<std::size_t>(1));
         CHECK(dropped[0].action == RouteAction::Drop);
     }
@@ -81,6 +82,7 @@ int main() {
     // --- #96 multipath: a comparable second path of a generation is admitted --
     {
         Config mp = cfg;
+        mp.enableMultipath = true;
         mp.antAcceptanceFactor = 1.5;
         FakeClock clock;
         clock.set(1.0);
@@ -111,6 +113,18 @@ int main() {
         auto second = router.onReceiveAnt(b, 6);
         CHECK_EQ(second.size(), static_cast<std::size_t>(1));
         CHECK(second[0].action == RouteAction::Unicast);  // back ant for path 2
+
+        // A third copy via a much *worse* path (outside the 1.5x hop/time band
+        // of the best seen) is dropped even with multipath on.
+        AntMessage c;
+        c.type = AntType::Reactive;
+        c.src = 3;
+        c.dst = 9;
+        c.seqNum = 42;                       // same generation
+        c.visited = {{3, 0.0}, {5, 0.05}, {6, 0.05}, {7, 0.05}};  // 4 hops vs 2
+        auto dropped = router.onReceiveAnt(c, 7);
+        CHECK_EQ(dropped.size(), static_cast<std::size_t>(1));
+        CHECK(dropped[0].action == RouteAction::Drop);
     }
 
     // --- forward ant in transit with no route: broadcast ------------------

--- a/core/tests/test_router_logic.cpp
+++ b/core/tests/test_router_logic.cpp
@@ -41,10 +41,12 @@ int main() {
 
     // --- forward ant reaches its destination: spawn backward ant ----------
     {
+        Config sp = cfg;
+        sp.enableMultipath = false;  // #96 gate off: single-path setup
         FakeClock clock;
         clock.set(1.0);
         ScriptedRng rng({0.5});
-        AntRouterLogic router(/*addr*/ 9, cfg, clock, rng);
+        AntRouterLogic router(/*addr*/ 9, sp, clock, rng);
 
         AntMessage fwd;
         fwd.type = AntType::Reactive;
@@ -69,8 +71,8 @@ int main() {
         // The previous hop was learned as a neighbour.
         CHECK(router.table().numNeighbors() >= 1u);
 
-        // #96 gate off (default): ANY same-generation copy — even one a
-        // multipath filter would admit — is dropped by strict (src,seq) dedup
+        // #96 gate off: ANY same-generation copy — even one the multipath
+        // filter would admit — is dropped by strict (src,seq) dedup
         // (pre-#96 single-path setup).
         AntMessage worse = fwd;
         worse.visited = {{3, 0.0}, {5, 0.005}, {6, 0.005}};  // comparable 3-hop path

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,13 @@ The adapters implement these so the core stays I/O-free:
 
 ```
 incoming ant  ->  AntRouterLogic::onReceiveAnt(msg, prevHop)
-                    - (src,seq) dedup  -> Drop on duplicate
+                    - reactive forward ant (enableMultipath, default on): per-
+                      generation acceptance band ([1] §3.1, #96) — a later
+                      (src,seq) copy within antAcceptanceFactor (1.5) of the
+                      best seen on BOTH hops and travel time is admitted, so
+                      several good paths get laid down; all other ants (and
+                      everything when the gate is off): strict (src,seq)
+                      dedup -> Drop on duplicate
                     - learn prevHop as neighbour
                     - hello: update virtual table, consume
                     - forward ant: stamp self; if dst==self spawn back ant;

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -54,6 +54,7 @@ RoutingProtocol::RoutingProtocol()
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
       m_hopTime(0.05),
+      m_enableMultipath(false),
       m_antAcceptanceFactor(1.5),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
@@ -149,14 +150,24 @@ TypeId RoutingProtocol::GetTypeId() {
                           DoubleValue(0.05),
                           MakeDoubleAccessor(&RoutingProtocol::m_hopTime),
                           MakeDoubleChecker<double>(0.0))
+            .AddAttribute("EnableMultipath",
+                          "Multipath reactive setup (issue #96, [1] §3.1): admit "
+                          "later same-generation reactive ants through the "
+                          "AntAcceptanceFactor band instead of strict (src,seq) "
+                          "dedup, laying down several good paths. Default off: "
+                          "regresses PDR on the disk-model harness (#96).",
+                          BooleanValue(false),
+                          MakeBooleanAccessor(&RoutingProtocol::m_enableMultipath),
+                          MakeBooleanChecker())
             .AddAttribute("AntAcceptanceFactor",
-                          "Multipath acceptance factor for reactive setup (issue "
-                          "#96, [1] §3.1, empirically 1.5): a node forwards a "
-                          "later same-generation reactive ant only if both its "
-                          "hops and travel time are within this factor of the "
-                          "best seen, laying down several good paths instead of "
-                          "the first only. Set very high (e.g. 1e9) to disable "
-                          "multipath (single-path setup, pre-#96).",
+                          "Multipath acceptance factor (issue #96, [1] §3.1, "
+                          "empirically 1.5), used only when EnableMultipath is "
+                          "on: a node forwards a later same-generation reactive "
+                          "ant only if both its hops and travel time are within "
+                          "this factor of the best seen. Higher admits MORE "
+                          "copies (more multipath, up to a flood); no value "
+                          "reproduces strict single-path dedup — use "
+                          "EnableMultipath=false for that.",
                           DoubleValue(1.5),
                           MakeDoubleAccessor(&RoutingProtocol::m_antAcceptanceFactor),
                           MakeDoubleChecker<double>(1.0))
@@ -308,6 +319,7 @@ void RoutingProtocol::DoInitialize() {
     m_config.repairWaitFactor = m_repairWaitFactor;
     m_config.repairTimeout = m_repairTimeout;
     m_config.hopTimeSec = m_hopTime;
+    m_config.enableMultipath = m_enableMultipath;
     m_config.antAcceptanceFactor = m_antAcceptanceFactor;
     m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
     m_config.enableMacMetric = m_enableMacMetric;
@@ -371,6 +383,7 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.repairWaitFactor = m_repairWaitFactor;
         m_config.repairTimeout = m_repairTimeout;
         m_config.hopTimeSec = m_hopTime;
+        m_config.enableMultipath = m_enableMultipath;
         m_config.antAcceptanceFactor = m_antAcceptanceFactor;
         m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
         m_config.enableMacMetric = m_enableMacMetric;

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -54,6 +54,7 @@ RoutingProtocol::RoutingProtocol()
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
       m_hopTime(0.05),
+      m_antAcceptanceFactor(1.5),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
       m_reactiveRetryInterval(Seconds(0.25)),
@@ -148,6 +149,17 @@ TypeId RoutingProtocol::GetTypeId() {
                           DoubleValue(0.05),
                           MakeDoubleAccessor(&RoutingProtocol::m_hopTime),
                           MakeDoubleChecker<double>(0.0))
+            .AddAttribute("AntAcceptanceFactor",
+                          "Multipath acceptance factor for reactive setup (issue "
+                          "#96, [1] §3.1, empirically 1.5): a node forwards a "
+                          "later same-generation reactive ant only if both its "
+                          "hops and travel time are within this factor of the "
+                          "best seen, laying down several good paths instead of "
+                          "the first only. Set very high (e.g. 1e9) to disable "
+                          "multipath (single-path setup, pre-#96).",
+                          DoubleValue(1.5),
+                          MakeDoubleAccessor(&RoutingProtocol::m_antAcceptanceFactor),
+                          MakeDoubleChecker<double>(1.0))
             .AddAttribute("LinkfailNotifyInterval",
                           "Minimum spacing (s) between LinkFail notifications "
                           "originated about the same destination (issue #20); "
@@ -296,6 +308,7 @@ void RoutingProtocol::DoInitialize() {
     m_config.repairWaitFactor = m_repairWaitFactor;
     m_config.repairTimeout = m_repairTimeout;
     m_config.hopTimeSec = m_hopTime;
+    m_config.antAcceptanceFactor = m_antAcceptanceFactor;
     m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
     m_config.enableMacMetric = m_enableMacMetric;
     m_queue.SetTimeout(m_queueTimeout);  // attribute lands after construction (#21)
@@ -358,6 +371,7 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.repairWaitFactor = m_repairWaitFactor;
         m_config.repairTimeout = m_repairTimeout;
         m_config.hopTimeSec = m_hopTime;
+        m_config.antAcceptanceFactor = m_antAcceptanceFactor;
         m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
         m_config.enableMacMetric = m_enableMacMetric;
         m_logic.reset(new ::anthocnet::core::AntRouterLogic(

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -54,7 +54,7 @@ RoutingProtocol::RoutingProtocol()
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
       m_hopTime(0.05),
-      m_enableMultipath(false),
+      m_enableMultipath(true),
       m_antAcceptanceFactor(1.5),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
@@ -154,9 +154,10 @@ TypeId RoutingProtocol::GetTypeId() {
                           "Multipath reactive setup (issue #96, [1] §3.1): admit "
                           "later same-generation reactive ants through the "
                           "AntAcceptanceFactor band instead of strict (src,seq) "
-                          "dedup, laying down several good paths. Default off: "
-                          "regresses PDR on the disk-model harness (#96).",
-                          BooleanValue(false),
+                          "dedup, laying down several good paths, and absorb "
+                          "LinkFails while a usable alternate hop survives. "
+                          "false = pre-#96 single-path setup.",
+                          BooleanValue(true),
                           MakeBooleanAccessor(&RoutingProtocol::m_enableMultipath),
                           MakeBooleanChecker())
             .AddAttribute("AntAcceptanceFactor",

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -221,6 +221,7 @@ private:
     double m_repairWaitFactor;
     double m_repairTimeout;
     double m_hopTime;                 ///< T_hop unloaded-hop reference (s), #88
+    bool m_enableMultipath;           ///< multipath reactive setup gate, #96
     double m_antAcceptanceFactor;     ///< multipath 1.5x acceptance factor, #96
     double m_linkfailNotifyInterval;  ///< issue #20 origin cooldown (s), 0 = off
     Time m_queueTimeout;              ///< issue #21 pending-queue hold before drop

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -221,6 +221,7 @@ private:
     double m_repairWaitFactor;
     double m_repairTimeout;
     double m_hopTime;                 ///< T_hop unloaded-hop reference (s), #88
+    double m_antAcceptanceFactor;     ///< multipath 1.5x acceptance factor, #96
     double m_linkfailNotifyInterval;  ///< issue #20 origin cooldown (s), 0 = off
     Time m_queueTimeout;              ///< issue #21 pending-queue hold before drop
     Time m_reactiveRetryInterval;     ///< issue #21 timer-driven re-discovery cadence (0 = off)


### PR DESCRIPTION
Closes the core of #96 (multipath, #26 item 10). Full finding: [#70 comment](https://github.com/danieljoppi/AntHocNet/issues/70#issuecomment-5017304391). Round-1 validation was **negative** ([#96 comment](https://github.com/danieljoppi/AntHocNet/issues/96#issuecomment-5017426317)); round 2 with the linkfail churn bound is **positive** and this PR ships the mechanism **default-on**.

## Why

The PPSN 2004 PDF pass found AntHocNet's **multipath** setup — its headline advantage over AODV — was absent. §3.1: a node forwards *multiple* ants of a generation *"only if its number of hops and travel time are both within a certain factor (empirically 1.5) of the best ant of the generation."* The core instead opened `onReceiveAnt` with a **blanket `(src,seq)` dedup**, so only the first-arriving copy propagated → one path per destination. (This also explains #56 finding `betaData` inert: with one path the exponent has nothing to spread over.)

## What

- **`Config::enableMultipath` boolean gate** (#96 problem B), ns-3 `EnableMultipath` attribute. Off = every ant type takes strict `(src,seq)` dedup — exactly the pre-#96 single-path setup. On = a **reactive** forward ant is admitted if it's the first of its generation, or if a later copy is within `Config::antAcceptanceFactor` (default **1.5**) of the best seen on **both** hops and accumulated travel time (new core `GenerationTracker`, FIFO-bounded by `maxHistory`). Backward / hello / linkfail / proactive / repair ants always keep strict dedup.
- **Corrected attribute semantics** (#96 problem B): a *higher* `AntAcceptanceFactor` admits *more* copies (more multipath, up to a flood); no factor value reproduces strict dedup — the earlier claim that "~1e9 disables" was inverted. Disable is `EnableMultipath=false`.
- **LinkFail churn bound** (#96 problem A, option 1), active only with the gate on: losing the best hop for a destination that still has a **usable alternate next-hop** neither originates nor re-propagates a LinkFail flood — the alternate carries the data, which is the point of multipath. Only a destination left with no usable path is advertised. Round 1 showed unbounded multipath generating 2–3× linkfail volume (`linkfailProp` 700–950 vs main's ~330), which is what ate the PDR on the contention-dominated disk-model channel.
- **Default on** (`feat!`): the shipped reactive setup is now multipath, justified by round 2 below. The gate stays for A/B and as the single-path fallback.
- **Loop safety** preserved (golden rule 5): the 1.5× band rejects long/looping copies, the `maxPathLength` cap (#95) + `src==self` drop bound the rest, tracker is FIFO-capped. `test_properties` stays green.
- **`betaData`/`betaAnts` unchanged on purpose.** The β alignment (#70) was gated on a *paying* multipath — that gate condition is now met, but it lands separately with its own validation.

No wire-format change (`visited` already carries per-hop time). `make test` 18/18; core tests: gate-off strict dedup, gate-on admit/reject band (`test_router_logic`), linkfail suppress/notify/absorb/re-flood matrix incl. gate-off control (`test_link_failure` case 15). `protocol-review`: PASS. Docs: `architecture.md` decision flow, `CONTEXT.md` glossary.

## Validation (paper regime, 50 nodes / 1500×300 / 300 s / 5 seeds, anthocnet+aodv)

| config | PDR % | delay ms | delay99 ms | NRL | jitter ms |
|---|---:|---:|---:|---:|---:|
| main `bda8926` (single-path) | 89.4 | 97.1 | 1981 | 43.4 | 158.5 |
| round 1: factor 1.5, no churn bound ([run 29703467817](https://github.com/danieljoppi/AntHocNet/actions/runs/29703467817)) | 84.8 | 87.3 | 1843 | 48.2 | 143.8 |
| **round 2: factor 1.5 + churn bound ([run 29705258157](https://github.com/danieljoppi/AntHocNet/actions/runs/29705258157))** | **92.3** | **91.9** | **1786** | **45.0** | **150.5** |
| aodv (same seeds) | 81.4 | 43.0 | 917 | 60.8 | 67.2 |

All #96 merge criteria pass: **PDR ≥ main** (+2.9 pp; every seed 90.8–94.6 individually beats 89.4, stddev 1.51), **NRL under AODV** (45.0 vs 60.8, +3.8 % vs main), **delay/delay99/jitter all better than main**. Diag confirms the mechanism: `linkfailProp` 186–248 per run vs round 1's 700–950 (and main's ~330), with 5.8k–8.1k suppressed origins per run (`linkfailOrigSuppressed`). `bench_parse.py` verdict vs main: **IMPROVED**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYXPvzNU8YaXUW1n6k1Gy1)_