### PR TITLE
feat(core): fill hello advert slots active-first, then by best pheromone (#26 item 6.5)

### DIFF
--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -1,5 +1,6 @@
 #include "anthocnet/core/ant_router_logic.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace anthocnet {
@@ -355,13 +356,28 @@ AntMessage AntRouterLogic::createHelloAnt(std::size_t maxAdverts) {
 
     // Advertise this node's *best real pheromone* per destination so the
     // receiver can bootstrap a goodness-ordered virtual table (D3), skipping
-    // destinations we have no usable path to.
+    // destinations we have no usable path to. Advert slots are filled
+    // deterministically — active sessions first, the remainder by best
+    // pheromone — not by a coin flip (issue #26, item 6.5).
+    std::vector<HelloDest> candidates;
     for (NodeAddress dest : table_.regularDestinations()) {
         const double best = table_.bestRegular(dest);
         if (best <= config_.minPheromone) continue;
-        m.helloDests.push_back({dest, best});
-        if (m.helloDests.size() >= maxAdverts) break;
+        candidates.push_back({dest, best});
     }
+    const std::vector<NodeAddress> active = activeDestinations();
+    auto isActive = [&active](NodeAddress d) {
+        return std::find(active.begin(), active.end(), d) != active.end();
+    };
+    std::stable_sort(candidates.begin(), candidates.end(),
+                     [&isActive](const HelloDest& a, const HelloDest& b) {
+                         const bool activeA = isActive(a.node);
+                         const bool activeB = isActive(b.node);
+                         if (activeA != activeB) return activeA;
+                         return a.pheromone > b.pheromone;
+                     });
+    if (candidates.size() > maxAdverts) candidates.resize(maxAdverts);
+    m.helloDests = std::move(candidates);
     return m;
 }
 

--- a/core/tests/test_diffusion.cpp
+++ b/core/tests/test_diffusion.cpp
@@ -108,5 +108,34 @@ int main() {
         CHECK_EQ(router.selectNextHop(99, /*proactive=*/true), kInvalidAddress);
     }
 
+    // 6. Advert slots over maxAdverts are filled deterministically: active
+    //    sessions first, the remainder by best pheromone — never a coin flip
+    //    (issue #26, item 6.5).
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg;
+        AntRouterLogic router(/*addr*/ 0, cfg, clock, rng);
+        router.table().setPheromoneRegular(/*dest*/ 10, /*neighbor*/ 1, 0.2);
+        router.table().setPheromoneRegular(/*dest*/ 11, /*neighbor*/ 1, 0.9);
+        router.table().setPheromoneRegular(/*dest*/ 12, /*neighbor*/ 1, 0.5);
+
+        // No active session: the two strongest destinations win the slots.
+        AntMessage hello = router.createHelloAnt(/*maxAdverts*/ 2);
+        CHECK_EQ(hello.helloDests.size(), static_cast<std::size_t>(2));
+        CHECK_NEAR(advertFor(hello, 11), 0.9, 1e-12);
+        CHECK_NEAR(advertFor(hello, 12), 0.5, 1e-12);
+        CHECK(advertFor(hello, 10) < 0.0);
+
+        // The weakest destination becomes an active session: it takes a slot
+        // ahead of stronger, inactive ones.
+        router.noteDataSession(10);
+        hello = router.createHelloAnt(/*maxAdverts*/ 2);
+        CHECK_EQ(hello.helloDests.size(), static_cast<std::size_t>(2));
+        CHECK_NEAR(advertFor(hello, 10), 0.2, 1e-12);
+        CHECK_NEAR(advertFor(hello, 11), 0.9, 1e-12);
+        CHECK(advertFor(hello, 12) < 0.0);
+    }
+
     return RUN_TESTS();
 }


### PR DESCRIPTION
Closes out the #26 "S — minor deviations" bucket (item 06). Spec source: `git show ef117b4:docs/improvements/06-evaporation-and-minor.md`.

## What

- **6.5 (implemented):** the spec's `rng_.uniform() > 0.5` coin-flip advert subset was already removed by item 03 (deterministic best-pheromone adverts), but the *slot filling* when candidates exceed `maxAdverts` was still arbitrary map-iteration order — active sessions could be dropped and weak entries could crowd out strong ones. `createHelloAnt` now `stable_sort`s candidates: **active sessions first** (via the existing `activeDestinations()`), the remainder by **descending best pheromone**, then caps at `maxAdverts`.
- **6.4 (verified already complete, no change):** `prevSINR` → `pathTime` rename shipped (ADR-0009 / `docs/wire-format.md`); `kBeta` has zero occurrences (item 01 replaced it with `betaAnts`/`betaData`); the suggested `Exponent{Ant,Data}` enum is superseded by the existing `selectNextHop`/`nextHopForData` split — the surviving `proactive` bool means "blend virtual pheromone", not exponent choice.

Core-only; no wire-format change (`helloDests` layout untouched); no adapter change.

## Tests

New `test_diffusion` case 6: with 3 destinations (pheromones 0.2/0.9/0.5) and `maxAdverts=2`, adverts are the two strongest; after `noteDataSession` on the weak destination, it takes a slot ahead of the weakest inactive one. `make test`: 18/18. `protocol-review`: rules 1/7 PASS.

With this, #26's remaining checklist (6.2 shipped in #95, 6.4 verified, 6.5 here) is done pending the epic's own bookkeeping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_