### PR TITLE
fix(ns3): release held packets on backward-ant traversal and retry-timer route hits (#21)

### DIFF
--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -644,11 +644,23 @@ void RoutingProtocol::RecvAnt(Ptr<Socket> socket) {
     NodeAddress prevHop = ToCore(sender);
     std::vector<RouteDecision> decisions = m_logic->onReceiveAnt(incoming, prevHop);
 
-    // A Deliver means a route to incoming.src was just discovered.
+    // A Deliver means a route to incoming.src was just discovered. And any
+    // backward ant that traverses this node installs/refreshes a route toward
+    // its origin (incoming.src) at EVERY retraced hop, not just at the data
+    // source that gets the Deliver — so flush held packets here too (#21: the
+    // reconv hold released only at the origin left intermediate-node queues
+    // waiting for the 3 s purge). FlushQueue self-guards: it re-queues
+    // anything whose route still doesn't resolve.
+    bool flushed = false;
     for (const RouteDecision& d : decisions) {
         if (d.action == RouteAction::Deliver) {
             FlushQueue(incoming.src);
+            flushed = true;
+            break;
         }
+    }
+    if (!flushed && incoming.isBackward()) {
+        FlushQueue(incoming.src);
     }
     ExecuteDecisions(decisions, incoming.src);
 }
@@ -739,6 +751,12 @@ void RoutingProtocol::ReactiveRetryTimerExpire() {
                 // layer, so the flood already shows there.
                 onAntSent(AntType::Reactive, ::anthocnet::core::AntDirection::Up,
                           /*broadcast=*/true);
+            } else {
+                // #21 dead spot: a route re-formed without a Deliver or a
+                // traversing backward ant (hello-learned neighbour, LinkFail
+                // side effect) routes NEW packets fine while the held ones
+                // rotted to the 3 s purge. Flush them on the retry cadence.
+                FlushQueue(coreDst);
             }
         }
     }


### PR DESCRIPTION
Lever L1 from the [#21 hold-time attribution](https://github.com/danieljoppi/AntHocNet/issues/21#issuecomment-5017846000): the reconvergence hold dominates the delay/jitter tail every seed (60–71 % of held-packet mass, maxes pinned just under the 3 s `QueueTimeout`), and the bottleneck is **release latency**, not discovery cadence (#94 fixed cadence).

## The two defects

1. The only queue flush on route discovery fired on a `Deliver` decision — and the core returns `Deliver` in exactly one place: a backward ant arriving back at its own originator. A retracing backward ant **installs the route at every intermediate node** (reinforce) but returned `Unicast` there, so held packets at intermediates waited for the 3 s purge.
2. **Dead spot:** a route that re-formed with no backward-ant traversal (hello-learned neighbour, LinkFail side effect) routed *new* packets fine while *held* ones rotted — the #94 retry timer only re-flooded when no route existed, and never flushed.

## The fix (adapter-only, 19 lines)

- `RecvAnt`: flush the pending queue for `incoming.src` on **every backward ant**, not just on `Deliver`. `FlushQueue` self-guards (re-queues anything whose route still doesn't resolve), so over-calling is safe.
- `ReactiveRetryTimerExpire`: a pending destination that **has** a route now gets `FlushQueue`, closing the dead spot at ≤ `ReactiveRetryInterval` (0.25 s) latency.

Release policy is the adapter's pending-queue duty (golden rule 2) — no core change, no wire change, zero new control packets.

## Validation plan

5-seed paper-regime run after merge (same criteria posted on #21): reconv hold avg/max down vs the `hold[reconv=353–448/165–216 ms]` baseline, PDR ≥ 92.1, jitter ≤ 150, NRL ≈ 45; plus a tworay cross-check. Results recorded on #21 — if the tail shrinks, L2 (per-reason hold cap) gets re-priced on the new frontier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_