### PR TITLE
feat(ns3)!: per-reason pending-queue hold cap, default ReconvHoldCap=1.0s (#21, #103)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,6 +161,15 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 - The NS-2 patch depends on **stable text anchors** in upstream files; a future
   NS-2 release that moves an anchor makes the installer fail loudly (by design)
   and the fragment must be updated.
+- **Delay-tail (#21) is partly a channel-model artefact.** On the contention-
+  dominated ns-3 disk model AntHocNet's delay/jitter tail runs above AODV; on
+  two-ray (the paper's PHY) the gap roughly halves, and with the ns-3
+  `ReconvHoldCap` (issue #21 lever L2, default **1 s**: deep-tail
+  reconvergence holds drop at the cap instead of the 3 s `QueueTimeout`)
+  mean delay reaches parity with AODV on two-ray for near-noise PDR cost
+  (#103). The residual disk-model gap is the CONTEXT-§8 channel penalty plus
+  the still-unverified `T_hop` (#88), not an algorithmic deviation. NS-3 only;
+  the NS-2 adapter has no equivalent cap yet.
 
 ## 9. Glossary
 

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -58,6 +58,8 @@ RoutingProtocol::RoutingProtocol()
       m_antAcceptanceFactor(1.5),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
+      m_reconvHoldCap(Seconds(0)),
+      m_repairHoldCap(Seconds(0)),
       m_reactiveRetryInterval(Seconds(0.25)),
       m_macServiceAlpha(0.7),
       m_lastAckTime(Seconds(0)),
@@ -187,6 +189,27 @@ TypeId RoutingProtocol::GetTypeId() {
                           "-2.4 pp PDR, still above AODV).",
                           TimeValue(Seconds(3)),
                           MakeTimeAccessor(&RoutingProtocol::m_queueTimeout),
+                          MakeTimeChecker())
+            .AddAttribute("ReconvHoldCap",
+                          "Issue #21 lever L2 (multipath drop-vs-late trade): "
+                          "cap the total time a RECONV-held data packet (waiting "
+                          "for a lost route to re-form) may wait since it first "
+                          "entered the queue, bounded by QueueTimeout. RECONV "
+                          "holds carry 60-71% of the delay-tail mass (#21 "
+                          "attribution); capping them below the 3 s timeout "
+                          "truncates delay99/jitter at a PDR cost (aged-out "
+                          "packets become drops). 0 = disabled (use QueueTimeout).",
+                          TimeValue(Seconds(0)),
+                          MakeTimeAccessor(&RoutingProtocol::m_reconvHoldCap),
+                          MakeTimeChecker())
+            .AddAttribute("RepairHoldCap",
+                          "Issue #21 lever L2: same cap for REPAIR-held packets "
+                          "(re-injected after a MAC transmit failure while local "
+                          "repair runs). REPAIR holds are mostly near-zero already "
+                          "(immediate flush when an alternate survives), so this "
+                          "is secondary to ReconvHoldCap. 0 = disabled.",
+                          TimeValue(Seconds(0)),
+                          MakeTimeAccessor(&RoutingProtocol::m_repairHoldCap),
                           MakeTimeChecker())
             .AddAttribute("ReactiveRetryInterval",
                           "How often to re-flood a reactive forward ant for "
@@ -325,6 +348,10 @@ void RoutingProtocol::DoInitialize() {
     m_config.linkfailNotifyInterval = m_linkfailNotifyInterval;
     m_config.enableMacMetric = m_enableMacMetric;
     m_queue.SetTimeout(m_queueTimeout);  // attribute lands after construction (#21)
+    // Issue #21 L2: per-reason hold caps (default 0 == disabled). SETUP stays
+    // uncapped on QueueTimeout; only the tail-dominant RECONV/REPAIR holds cap.
+    m_queue.SetHoldCap(HOLD_RECONV, m_reconvHoldCap);
+    m_queue.SetHoldCap(HOLD_REPAIR, m_repairHoldCap);
     Ipv4RoutingProtocol::DoInitialize();
 }
 

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -58,7 +58,7 @@ RoutingProtocol::RoutingProtocol()
       m_antAcceptanceFactor(1.5),
       m_linkfailNotifyInterval(5.0),
       m_queueTimeout(Seconds(3)),
-      m_reconvHoldCap(Seconds(0)),
+      m_reconvHoldCap(Seconds(1.0)),
       m_repairHoldCap(Seconds(0)),
       m_reactiveRetryInterval(Seconds(0.25)),
       m_macServiceAlpha(0.7),
@@ -198,8 +198,12 @@ TypeId RoutingProtocol::GetTypeId() {
                           "holds carry 60-71% of the delay-tail mass (#21 "
                           "attribution); capping them below the 3 s timeout "
                           "truncates delay99/jitter at a PDR cost (aged-out "
-                          "packets become drops). 0 = disabled (use QueueTimeout).",
-                          TimeValue(Seconds(0)),
+                          "packets become drops). Default 1 s from the #103 A/B: "
+                          "delay99 -37% / jitter -26% on the disk model and "
+                          "delay/jitter near-parity with AODV on two-ray (the "
+                          "paper PHY), for PDR cost within run-to-run noise. "
+                          "0 = disabled (revert to QueueTimeout, pre-#103).",
+                          TimeValue(Seconds(1.0)),
                           MakeTimeAccessor(&RoutingProtocol::m_reconvHoldCap),
                           MakeTimeChecker())
             .AddAttribute("RepairHoldCap",

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -225,6 +225,8 @@ private:
     double m_antAcceptanceFactor;     ///< multipath 1.5x acceptance factor, #96
     double m_linkfailNotifyInterval;  ///< issue #20 origin cooldown (s), 0 = off
     Time m_queueTimeout;              ///< issue #21 pending-queue hold before drop
+    Time m_reconvHoldCap;             ///< issue #21 L2: cap on reconv holds (0 = off)
+    Time m_repairHoldCap;             ///< issue #21 L2: cap on repair holds (0 = off)
     Time m_reactiveRetryInterval;     ///< issue #21 timer-driven re-discovery cadence (0 = off)
     // Issue #68: measured per-packet MAC service time (EWMA of inter-ack
     // spacing while the MAC queue stays backlogged — pure service time, no

--- a/ns3/model/anthocnet-rqueue.cc
+++ b/ns3/model/anthocnet-rqueue.cc
@@ -14,7 +14,18 @@ bool RequestQueue::Enqueue(QueueEntry& entry) {
     // entry back when its route vanishes again) so the #21 hold time measures
     // the whole wait, not just the last leg.
     if (entry.enqueueFirst.IsZero()) entry.enqueueFirst = Simulator::Now();
-    entry.expire = Simulator::Now() + m_timeout;
+    // Global QueueTimeout, measured from this (re-)enqueue. Issue #21 lever L2:
+    // if a per-reason hold cap is set, also bound the expiry to `cap` since the
+    // packet FIRST entered the queue (so re-queues can't extend the tail), and
+    // take whichever fires sooner. Zero cap == disabled, so behaviour is
+    // unchanged by default.
+    Time expire = Simulator::Now() + m_timeout;
+    const Time cap = (entry.holdReason < kHoldReasons) ? m_holdCap[entry.holdReason] : Time();
+    if (!cap.IsZero()) {
+        const Time capped = entry.enqueueFirst + cap;
+        if (capped < expire) expire = capped;
+    }
+    entry.expire = expire;
     if (m_queue.size() >= m_maxLen) {
         // Drop the oldest to make room.
         m_queue.erase(m_queue.begin());

--- a/ns3/model/anthocnet-rqueue.h
+++ b/ns3/model/anthocnet-rqueue.h
@@ -65,6 +65,17 @@ public:
     /// applied after construction, in RoutingProtocol::DoInitialize).
     void SetTimeout(Time timeout) { m_timeout = timeout; }
 
+    /// Per-reason hold cap (issue #21 lever L2, the multipath drop-vs-late
+    /// trade). When `cap` is non-zero it bounds the *total* time a packet of
+    /// this reason may wait since it FIRST entered the queue (`enqueueFirst`),
+    /// independent of re-queues, and never above the global timeout. Zero (the
+    /// default) disables the cap for that reason, leaving it on QueueTimeout.
+    /// SETUP is intentionally left uncapped (first discovery legitimately takes
+    /// longer); the tail is carried by RECONV/REPAIR (#21 attribution).
+    void SetHoldCap(uint8_t reason, Time cap) {
+        if (reason < kHoldReasons) m_holdCap[reason] = cap;
+    }
+
     /// Enqueue, dropping the oldest entry if at capacity. Returns false if the
     /// packet could not be queued.
     bool Enqueue(QueueEntry& entry);
@@ -96,6 +107,7 @@ private:
     std::vector<QueueEntry> m_queue;
     uint32_t m_maxLen;
     Time m_timeout;
+    Time m_holdCap[kHoldReasons] = {Time(), Time(), Time()};  // 0 == disabled (#21 L2)
     HoldStats m_stats;
 };
 


### PR DESCRIPTION
Implements lever **L2** for #21 (tracked in #103) and ships it **default-on at 1.0 s** after the A/B — the maintainer's chosen operating point.

## Why

The #21 delay/jitter tail is queue-held packets waiting for a lost route to re-form: RECONV holds are 60–71 % of held-packet mass ([#21 attribution](https://github.com/danieljoppi/AntHocNet/issues/21#issuecomment-5018182765)), maxes pinned just under the 3 s `QueueTimeout`. Lever L1 (flush on route install, #101) was NOISE — those maxes are genuine multi-second no-route intervals nothing shortens by releasing sooner. Only **dropping them earlier** (paper §3.4 deliver-late-vs-discard) truncates the tail.

## What (adapter-only, no core/wire change)

- `RequestQueue::SetHoldCap(reason, cap)` — bounds a packet's expiry to `enqueueFirst + cap` (total wait since first enqueue, so re-queues can't extend the tail), never above `QueueTimeout`. Zero = disabled.
- ns-3 **`ReconvHoldCap`** attribute, **default 1.0 s** (primary lever), and **`RepairHoldCap`** default 0 (secondary; repair holds are near-zero already and weren't part of the validated frontier). `SETUP` holds stay uncapped. Set `ReconvHoldCap=0` to revert to pre-#103 3 s behaviour.
- No new diag — cap-induced drops land in the existing `holdDrop[reconv]`.
- `CONTEXT.md` §8 documents the default and the residual channel-model gap.

## A/B evidence (#103, paper regime, 5 seeds)

**Disk model** (`ReconvHoldCap=1.0s` vs caps-off control):

| | PDR % | delay ms | delay99 ms | jitter ms | NRL |
|---|---:|---:|---:|---:|---:|
| caps off | 90.0 | 89.3 | 1765.9 | 145.7 | 46.9 |
| **1.0 s** | 88.4 | 66.3 | **1114.9 (−37%)** | **107.4 (−26%)** | 45.5 |
| aodv | 81.4 | 43.0 | 916.5 | 67.2 | 60.8 |

**Two-ray** (paper PHY): mean delay **52.8 vs AODV 52.6 (parity)**, jitter 88.4 vs 79.6 (within 11 %), PDR +9.5 pp, NRL far lower — reproduces the paper's §4.2 story. Full frontier (1.5 s / 1.0 s / 0.75 s) on #103.

PDR cost is within run-to-run noise (capped-off packets are deep-tail holds that'd deliver very late anyway; dropping them early even lowers NRL). Marked **`feat!`** — shipped ns-3 data-path behaviour changes.

`make test` 18/18 (core unchanged); `protocol-review` PASS; ns-3 compile + e2e validated by this PR's CI matrix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_