### PR TITLE
docs: record the two-step release / post-release Zenodo DOI procedure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,5 +134,5 @@ results.
 | Inspect protocol internals | NS-3 `Tx`/`Rx`/`RouteChanged` trace sources; core counters via `IRouterObserver` |
 | Compare benchmark A/B runs (deltas + noise verdict) | `benchmark-results` skill (`.claude/skills/benchmark-results/bench_parse.py`) |
 | Pre-push invariant check on a diff | `protocol-review` skill (`.claude/skills/protocol-review/check_invariants.sh`) |
-| Cut a release | run the `Release` workflow (Commitizen); see `CONTRIBUTING.md` |
+| Cut a release | run the `Release` workflow (Commitizen); see `CONTRIBUTING.md`. **Post-release the Zenodo DOI is a manual human step** — `zenodo.org` is proxy-blocked (403) and the DOI is minted async after publish, so an agent must ask the maintainer for it (never invent one) then update the README badge + `CITATION.cff` in a `docs:` PR |
 | Tune defaults | `core/include/anthocnet/core/config.h` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,32 @@ Releases are cut by running the **Release** workflow (manual dispatch):
 [Commitizen](https://commitizen-tools.github.io/commitizen/) computes the next
 version from the commit history, updates `VERSION` / `CITATION.cff` / the CMake
 version + `CHANGELOG.md`, tags it, and publishes the install bundle. Don't bump
-the version by hand.
+the version by hand. (The `major_version_zero` gate in `.cz.toml` was flipped to
+`false` at v1.0.0, so from 1.0 on a breaking `feat!`/`fix!` bumps the **major**.)
+
+### Post-release: Zenodo DOI (manual — the release's second step)
+
+The Release workflow does **not** set the DOI. With the repo linked to
+[Zenodo](https://zenodo.org), Zenodo archives each published GitHub release
+**asynchronously** and mints a new DOI a few minutes *after* publish. That value
+must then be pasted, by hand, into two places:
+
+1. the **README DOI badge** (top of `README.md`), and
+2. the **`doi:`** field in `CITATION.cff`.
+
+So a release is two steps: **(1)** run the Release workflow (automated), then
+**(2)** once Zenodo has archived the tag, update the DOI in those two files via a
+small `docs:` PR. Keep the two in sync — they have drifted apart before.
+
+**Prefer the concept DOI.** Zenodo issues a per-version DOI *and* a stable
+**concept DOI** ("all versions", which auto-resolves to the latest release).
+Point the badge and `CITATION.cff` at the **concept DOI** so step 2 becomes a
+one-time setup instead of a per-release chore.
+
+**Note for AI agents:** you **cannot** do step 2 from the sandbox — `zenodo.org`
+is blocked (the agent proxy returns 403), and the new DOI does not exist until
+after publish anyway. Ask the maintainer for the DOI (concept preferred) and
+open the `docs:` PR with the value they give you. **Never invent a DOI.**
 
 ## Pull requests
 


### PR DESCRIPTION
Records the **post-release Zenodo DOI update** as an explicit, manual second step of cutting a release — so it isn't forgotten, and especially so AI agents know it's a human step they can't do from the sandbox.

## Why
The Release workflow doesn't set the DOI. Zenodo archives a published release **asynchronously** and mints the DOI minutes *after* publish. `zenodo.org` is also **blocked from the agent sandbox** (proxy 403), so an agent can neither fetch the DOI nor know it before publish. This was undocumented.

## What (docs only)
- **`CONTRIBUTING.md`**: new *"Post-release: Zenodo DOI"* subsection — the two-step flow (run Release → then update the DOI), a recommendation to use the stable **concept DOI** so it becomes a one-time setup, and an explicit **AI-agent note** (ask the maintainer for the value, never invent one). Also records the v1.0.0 `major_version_zero` flip.
- **`AGENTS.md`**: the "Cut a release" where-to-look row now flags the manual Zenodo DOI step + the proxy block.

## Follow-up (step 2, needs the maintainer)
The actual v1.0.0 DOI update is tracked separately — the badge (`README.md`) and `CITATION.cff` currently hold older, drifted version DOIs and need the v1.0.0 (ideally concept) DOI, which only you can read from Zenodo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_