### PR TITLE
chore(release): exclude .github and .claude from the source archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,10 @@ ns2/tcl/scenario*/sim-*.tcl linguist-generated=true
 
 # Auto-generated benchmark charts (produced by the benchmarks workflow).
 docs/benchmarks/*.png linguist-generated=true
+
+# Keep repo-only tooling/CI dirs out of `git archive` — i.e. GitHub's
+# auto-generated "Source code (zip/tar.gz)" release archives. They are not part
+# of a release package. (The custom install-bundle in release.yml already omits
+# them: it copies only core/ ns2/ ns3/ docs/ + the top-level docs files.)
+/.github export-ignore
+/.claude export-ignore


### PR DESCRIPTION
Keeps the repo-only tooling/CI dirs out of the release package.

## Why
- The **custom install bundle** (`anthocnet-<ver>.zip`, built by `release.yml`) is already clean — it copies only `core/ ns2/ ns3/ docs/` + the top-level docs files, never `.github` or `.claude`.
- But GitHub's **auto-generated "Source code (zip/tar.gz)"** archives attached to every release use `git archive`, which includes *everything tracked* — so they were carrying `.github/` (workflows, templates) and `.claude/` (agent skills/settings).

## What
`.gitattributes`: `export-ignore` on `/.github` and `/.claude` — `git archive` (and thus the GitHub source archives) now omits them.

## Verified
`git archive --worktree-attributes HEAD | tar -t`: `.github`/`.claude` entries **23 → 0**, while `core/ns2/ns3/docs` content (186 entries) is unchanged. Docs-config only; no code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_