### PR TITLE
docs: add the JOSS software-paper draft (paper/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ History of the work is in the per-phase commits; design rationale is in
 | [docs/porting-notes.md](docs/porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, wire format, version caveats. |
 | [docs/wire-format.md](docs/wire-format.md) | Canonical on-wire ant layout, version byte, and diff vs. the original and the papers. |
 | [docs/adr/](docs/adr) | Architecture Decision Records — the "why" behind the structure. |
+| [paper/](paper/) | JOSS software-paper draft (`paper.md`/`paper.bib`), for submission against this repo. |
 | [CONTEXT.md](CONTEXT.md) | Project orientation: domain background, repo map, current state, glossary, open questions. |
 | [AGENTS.md](AGENTS.md) | Build/verify/conventions and invariants for contributors and AI agents. |
 | [ns2/README.md](ns2/README.md) · [ns3/README.md](ns3/README.md) | Per-adapter install/run details. |

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,0 +1,46 @@
+# AntHocNet — JOSS software paper
+
+Submission draft for the [Journal of Open Source Software (JOSS)](https://joss.theoj.org).
+JOSS papers are short and describe the *software*, not new results.
+
+- `paper.md` — the paper (Markdown + YAML metadata; ~250–1000 words).
+- `paper.bib` — references (cited with `[@key]`).
+
+Lives in this repo (not the private `papers` repo) because JOSS review
+targets the **software repository** directly and expects `paper.md` to live
+in it.
+
+## Preview the PDF locally
+
+JOSS builds the PDF with Open Journals' `inara` container:
+
+```bash
+docker run --rm -v "$PWD":/data -u $(id -u):$(id -g) \
+  openjournals/inara -o pdf,preprint paper.md
+```
+
+(Produces `paper.pdf`. No local LaTeX needed.)
+
+## Before submitting
+
+The **software repo** already meets JOSS criteria: OSI license (GPL-2.0),
+documentation, automated tests, CI, and community guidelines
+(`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`). Remaining paper TODOs:
+
+- [ ] Funding / acknowledgements, if any.
+- [ ] Preview the PDF with `inara` and proof the citations.
+- [ ] Tag a release to submit against (v1.0.0 is out) and have the Zenodo DOI
+      ready (#107).
+- [ ] Submit at <https://joss.theoj.org/papers/new> (points JOSS at the repo).
+
+No ORCID/affiliation TODO: the author has no research-organization
+affiliation or ORCID, so the byline is "Independent researcher" with no
+`orcid` field — both are optional in the JOSS `paper.md` schema.
+
+## Note
+
+JOSS reviews the *software*; it explicitly does not require novel results.
+The fuller reproducibility / cross-simulator **study** paper is a separate,
+longer paper kept in the private `papers` repo
+(`AntHocNet/icns3-anthocnet-reproducible-cross-simulator/`, targeting
+ICNS3/SoftwareX) alongside the venue survey.

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,41 @@
+@inproceedings{anthocnet2004,
+  author    = {Di Caro, Gianni and Ducatelle, Frederick and Gambardella, Luca Maria},
+  title     = {{AntHocNet}: An Ant-Based Hybrid Routing Algorithm for Mobile Ad Hoc Networks},
+  booktitle = {Parallel Problem Solving from Nature (PPSN VIII)},
+  series    = {Lecture Notes in Computer Science},
+  volume    = {3242},
+  pages     = {461--470},
+  publisher = {Springer},
+  year      = {2004},
+  doi       = {10.1007/978-3-540-30217-9_47}
+}
+
+@inproceedings{aodv,
+  author    = {Perkins, Charles E. and Royer, Elizabeth M.},
+  title     = {Ad-hoc On-Demand Distance Vector Routing},
+  booktitle = {2nd IEEE Workshop on Mobile Computing Systems and Applications (WMCSA)},
+  pages     = {90--100},
+  year      = {1999},
+  doi       = {10.1109/MCSA.1999.749281}
+}
+
+@article{antnet,
+  author  = {Di Caro, Gianni and Dorigo, Marco},
+  title   = {{AntNet}: Distributed Stigmergic Control for Communications Networks},
+  journal = {Journal of Artificial Intelligence Research},
+  volume  = {9},
+  pages   = {317--365},
+  year    = {1998},
+  doi     = {10.1613/jair.530}
+}
+
+@article{abc,
+  author  = {Schoonderwoerd, Ruud and Holland, Owen and Bruten, Janet and Rothkrantz, Leon},
+  title   = {Ant-Based Load Balancing in Telecommunications Networks},
+  journal = {Adaptive Behavior},
+  volume  = {5},
+  number  = {2},
+  pages   = {169--207},
+  year    = {1996},
+  doi     = {10.1177/105971239700500203}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,80 @@
+---
+title: 'AntHocNet: An open, simulator-agnostic implementation of ant-colony routing for mobile ad-hoc networks'
+tags:
+  - MANET
+  - routing protocol
+  - ant colony optimization
+  - swarm intelligence
+  - network simulation
+  - ns-3
+  - ns-2
+  - C++
+authors:
+  - name: Daniel Henrique Joppi
+    affiliation: 1
+affiliations:
+  - name: Independent researcher
+    index: 1
+date: 23 July 2026
+bibliography: paper.bib
+---
+
+# Summary
+
+AntHocNet [@anthocnet2004] is a hybrid, multipath routing protocol for mobile
+ad-hoc networks (MANETs) built on ideas from ant colony optimization (ACO):
+lightweight "ant" control packets lay and follow artificial *pheromone* trails,
+so that routes are discovered reactively, maintained proactively, and repaired
+locally as the network topology changes. This software is an open, tested,
+**simulator-agnostic** implementation of AntHocNet. The routing algorithm is
+written once as a portable C++ core that has no dependency on any simulator ---
+it obtains time, randomness, neighbours, and deferred work through four narrow
+interfaces ("ports") and returns *decisions* rather than performing input or
+output. Thin adapters then install that same core onto two widely used network
+simulators: an idempotent source patch for **NS-2** and a native
+`Ipv4RoutingProtocol` module for **NS-3**. The core is covered by unit and
+randomized property tests; continuous integration builds the NS-3 module across
+ns-3.36--3.48 and compiles the NS-2 adapter against ns-2.34/2.35, each running
+an end-to-end delivery smoke test. Prebuilt simulator container images and a
+scripted benchmark harness make the reported comparisons reproducible, and the
+project is versioned and citable.
+
+# Statement of need
+
+Although AntHocNet is a well-known ant-based MANET routing protocol, no
+maintained, openly available implementation existed, and independently
+reproducing its results was difficult: the original was evaluated in a
+commercial simulator, ant-routing implementations are scarce, and outcomes
+depend on simulator- and physical-layer details that are seldom reported in
+full. Mainstream simulators reflect this gap --- NS-3, for example, ships AODV
+[@aodv], OLSR, and DSDV but no ACO-based routing protocol.
+
+This software addresses that need. Its ports-and-adapters design lets the
+*same* algorithm run on two simulators --- a rare capability that turns
+cross-simulator behaviour into something one can re-validate rather than
+re-implement --- and its containerized harness reproduces the protocol's
+headline advantages over AODV in packet delivery ratio and routing overhead.
+It is intended for networking and swarm-intelligence researchers who need a
+tested, reproducible ACO-routing baseline or an experimentation platform, and
+for educators teaching nature-inspired networking. Because the algorithm core
+is isolated from simulator specifics, it is also a foundation for porting the
+protocol to further simulators and for controlled studies of how routing
+behaviour depends on the underlying MAC/PHY models.
+
+# State of the field
+
+Ant-based routing began with wired-network algorithms such as ABC [@abc] and
+AntNet [@antnet], which sample paths with ant-like agents and bias routing
+toward better paths via pheromone. Adaptations to MANETs (e.g., ARA and PERA)
+reduced ant overhead but lost much of the proactive sampling that makes these
+methods adaptive; AntHocNet restored it in a hybrid, multipath design.
+Open, maintained, and *tested* implementations of these protocols remain rare,
+and implementations that run one algorithm unchanged across multiple simulators
+are rarer still --- which is the gap this software fills.
+
+# Acknowledgements
+
+The AntHocNet algorithm is due to Di Caro, Ducatelle, and Gambardella
+[@anthocnet2004]. <!-- TODO: funding acknowledgements, if any. -->
+
+# References


### PR DESCRIPTION
Companion PR to danieljoppi/papers#3 — that PR removes this content from the private authoring repo.

## Why

The JOSS paper draft (`paper.md`/`paper.bib`) was originally authored in the private `danieljoppi/papers` repo, alongside the other AntHocNet papers. But JOSS review targets the **software repository** directly and expects the paper to be committed there — conventionally under a `paper/` directory — so the paper and the code it describes are reviewed together, in the same repo history, rather than copied over at submission time.

## What

- Added `paper/paper.md`, `paper/paper.bib`, `paper/README.md` — unchanged content from the papers repo, except the author-metadata TODO is now resolved.
- Added a `paper/` row to the top-level `README.md` documentation table.
- **Author metadata resolved:** no research-organization affiliation, no ORCID — byline is "Independent researcher" with the `orcid` field omitted (both optional in JOSS's `paper.md` schema). This matches `CITATION.cff`'s existing commented-out `# orcid: ... # add if available` note.

## Before submitting (tracked in `paper/README.md`)

- [ ] Funding / acknowledgements, if any.
- [ ] Preview the PDF with `inara` and proof citations.
- [ ] Zenodo DOI ready against a tagged release (#107).
- [ ] Submit at joss.theoj.org.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_