### PR TITLE
feat(bench): add a --propagation override to run-scenarios.py

### DIFF
--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -24,6 +24,9 @@ on:
       only:
         description: 'all | discrete | sweeps | <scenario/sweep name>'
         default: 'all'
+      propagation:
+        description: 'Propagation model override for every point: range (disk) | tworay. Leave blank for anthocnet-compare''s default (range).'
+        default: ''
       commit:
         description: 'Commit regenerated charts + CSV into docs/ on this ref'
         type: boolean
@@ -58,12 +61,16 @@ jobs:
         run: |
           quick=""
           [ "${{ github.event.inputs.quick }}" = "true" ] && quick="--quick"
+          propagation=""
+          if [ -n "${{ github.event.inputs.propagation }}" ]; then
+            propagation="--propagation=${{ github.event.inputs.propagation }}"
+          fi
           python3 ns3/tools/run-scenarios.py /opt/ns-3 \
             --out "$GITHUB_WORKSPACE/scenarios.csv" \
             --runs "${{ github.event.inputs.runs }}" \
             --time "${{ github.event.inputs.time }}" \
             --only "${{ github.event.inputs.only }}" \
-            $quick
+            $quick $propagation
       - name: Render charts
         run: |
           python3 ns3/tools/make-charts.py "$GITHUB_WORKSPACE/scenarios.csv" \

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -83,16 +83,19 @@ METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
            "pdr_sd", "delay_sd", "delay99_sd", "nrl_sd"]
 PARAMS = ["runs", "nNodes", "area", "speed", "flows"]
 OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
-               + ["runs", "nNodes", "areaX", "speed", "pause", "flows"] + METRICS)
+               + ["runs", "nNodes", "areaX", "speed", "pause", "flows", "propagation"]
+               + METRICS)
 
 
-def build_args(flags, runs, time, protocols):
+def build_args(flags, runs, time, protocols, propagation):
     """Turn a flags dict into an anthocnet-compare argument string."""
     merged = dict(flags)
     merged.setdefault("runs", runs)
     if time is not None:
         merged.setdefault("time", time)
     merged.setdefault("protocols", protocols)
+    if propagation is not None:
+        merged.setdefault("propagation", propagation)
     parts = ["--csv"]
     for k, v in merged.items():
         parts.append(f"--{k}={v}")
@@ -121,7 +124,7 @@ def run_compare(ns3dir, arg_str, dry_run):
     return list(csv.DictReader(io.StringIO("\n".join(keep))))
 
 
-def emit(writer, kind, group, x, scenario, klass, pause, rows):
+def emit(writer, kind, group, x, scenario, klass, pause, propagation, rows):
     for r in rows:
         out = {
             "kind": kind, "group": group, "x": x, "scenario": scenario,
@@ -129,6 +132,7 @@ def emit(writer, kind, group, x, scenario, klass, pause, rows):
             "runs": r.get("runs", ""), "nNodes": r.get("nNodes", ""),
             "areaX": r.get("area", ""), "speed": r.get("speed", ""),
             "pause": pause, "flows": r.get("flows", ""),
+            "propagation": propagation or "range",
         }
         for m in METRICS:
             out[m] = r.get(m, "")
@@ -143,6 +147,10 @@ def main():
     ap.add_argument("--time", type=int, default=None,
                     help="sim time (s) override; default uses each scenario's own")
     ap.add_argument("--protocols", default="anthocnet,aodv,olsr,dsdv")
+    ap.add_argument("--propagation", default=None,
+                    help="override propagation model for every point: "
+                         "range (disk) | tworay; default lets anthocnet-compare "
+                         "use its own default (range)")
     ap.add_argument("--only", default="all",
                     help="all|discrete|sweeps|<discrete name>|<sweep name>")
     ap.add_argument("--quick", action="store_true",
@@ -169,9 +177,11 @@ def main():
                 if args.only in DISCRETE and args.only != name:
                     continue
                 rows = run_compare(args.ns3dir,
-                                   build_args(flags, runs, time, args.protocols),
+                                   build_args(flags, runs, time, args.protocols,
+                                              args.propagation),
                                    args.dry_run)
-                emit(w, "discrete", name, "", name, klass, flags.get("pause", ""), rows)
+                emit(w, "discrete", name, "", name, klass, flags.get("pause", ""),
+                     args.propagation, rows)
 
         if want_sweeps:
             for name, (xlabel, base, points) in sweeps.items():
@@ -181,10 +191,11 @@ def main():
                     flags = dict(base)
                     flags.update(extra)
                     rows = run_compare(args.ns3dir,
-                                       build_args(flags, runs, time, args.protocols),
+                                       build_args(flags, runs, time, args.protocols,
+                                                  args.propagation),
                                        args.dry_run)
                     emit(w, "sweep", name, x, f"{name}={x}", xlabel,
-                         flags.get("pause", ""), rows)
+                         flags.get("pause", ""), args.propagation, rows)
 
     if not args.dry_run:
         print(f"wrote {args.out}", file=sys.stderr)


### PR DESCRIPTION
Prep for the #110 full benchmark campaign.

## Why

#110 needs the paper's area/pause/scale sweeps on **both PHYs** (disk + two-ray), but `run-scenarios.py` (driven by the `scenario-matrix.yml` manual workflow) had no way to select a propagation model — every point always ran with `anthocnet-compare`'s `range` (disk) default. The two-ray half of the campaign couldn't be dispatched through the matrix tool at all.

## What

- `ns3/tools/run-scenarios.py`: new `--propagation` flag (`range`|`tworay`), threaded through `build_args()` the same way `--protocols` already is. Recorded as a new `propagation` column in the output CSV so a single `scenarios.csv` unambiguously distinguishes PHY runs.
- `.github/workflows/scenario-matrix.yml`: new `propagation` `workflow_dispatch` input, passed through when non-empty.

## Verified

Omitting `--propagation` is byte-for-byte unchanged from before (confirmed via `--dry-run` diff — no `--propagation` on the generated `anthocnet-compare` command line, same as today). With `--propagation tworay`, every generated command carries `--propagation=tworay`.

No ns-3 build in this sandbox, so this is CLI/dry-run verified only — the real check is the first live `scenario-matrix` dispatch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_