### PR TITLE
docs: add author ORCID

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ type: software
 authors:
   - family-names: Joppi
     given-names: Daniel Henrique
-    # orcid: "https://orcid.org/0000-0000-0000-0000"  # add if available
+    orcid: "https://orcid.org/0009-0009-6436-8174"
 version: 1.0.0
 date-released: "2026-07-23"
 license: GPL-2.0-only

--- a/paper/README.md
+++ b/paper/README.md
@@ -33,9 +33,9 @@ documentation, automated tests, CI, and community guidelines
       ready (#107).
 - [ ] Submit at <https://joss.theoj.org/papers/new> (points JOSS at the repo).
 
-No ORCID/affiliation TODO: the author has no research-organization
-affiliation or ORCID, so the byline is "Independent researcher" with no
-`orcid` field — both are optional in the JOSS `paper.md` schema.
+No affiliation TODO: the author has no research-organization affiliation,
+so the byline is "Independent researcher" (affiliation is optional in the
+JOSS `paper.md` schema). ORCID: 0009-0009-6436-8174.
 
 ## Note
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -11,6 +11,7 @@ tags:
   - C++
 authors:
   - name: Daniel Henrique Joppi
+    orcid: 0009-0009-6436-8174
     affiliation: 1
 affiliations:
   - name: Independent researcher


### PR DESCRIPTION
Fills in `CITATION.cff`'s ORCID placeholder and the JOSS `paper.md` byline now that the author has one: `0009-0009-6436-8174`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_