### PR TITLE
fix: correct the Zenodo DOI (concept DOI, README badge + CITATION.cff)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ date-released: "2026-07-23"
 license: GPL-2.0-only
 repository-code: "https://github.com/danieljoppi/AntHocNet"
 url: "https://github.com/danieljoppi/AntHocNet"
-doi: "10.5281/zenodo.20981980"
+doi: "10.5281/zenodo.20981979"
 keywords:
   - MANET
   - ad hoc networks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/danieljoppi/AntHocNet/actions/workflows/ci.yml/badge.svg)](https://github.com/danieljoppi/AntHocNet/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/danieljoppi/AntHocNet?sort=semver&cacheSeconds=1800)](https://github.com/danieljoppi/AntHocNet/releases)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21453208.svg)](https://doi.org/10.5281/zenodo.21453208) 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20981979.svg)](https://doi.org/10.5281/zenodo.20981979) 
 [![Cite](https://img.shields.io/badge/cite-CITATION.cff-blue)](CITATION.cff)
 [![License: GPL v2](https://img.shields.io/badge/license-GPL--2.0-blue)](LICENSE)
 [![C++14](https://img.shields.io/badge/C%2B%2B-14-blue?logo=cplusplus)](CONTRIBUTING.md)

--- a/paper/README.md
+++ b/paper/README.md
@@ -29,8 +29,8 @@ documentation, automated tests, CI, and community guidelines
 
 - [ ] Funding / acknowledgements, if any.
 - [ ] Preview the PDF with `inara` and proof the citations.
-- [ ] Tag a release to submit against (v1.0.0 is out) and have the Zenodo DOI
-      ready (#107).
+- [x] Tag a release to submit against (v1.0.0 is out) and have the Zenodo DOI
+      ready: 10.5281/zenodo.20981979 (concept DOI, resolves to latest) — #107.
 - [ ] Submit at <https://joss.theoj.org/papers/new> (points JOSS at the repo).
 
 No affiliation TODO: the author has no research-organization affiliation,


### PR DESCRIPTION
Fixes #107.

Confirmed against the actual Zenodo record for v1.0.0 (https://zenodo.org/records/21502372):
- concept DOI (all versions): `10.5281/zenodo.20981979`
- v1.0.0 version DOI: `10.5281/zenodo.21502372`

Neither value currently in the repo matched the concept DOI: the README badge had `10.5281/zenodo.21453208` (stale — reads like an earlier release's version DOI that never got corrected), and `CITATION.cff` had `10.5281/zenodo.20981980` (a one-digit typo of the concept DOI, `...980` vs `...979`).

Per this repo's own documented convention (`CONTRIBUTING.md` → *Post-release: Zenodo DOI* → "Prefer the concept DOI"), both now point to the concept DOI `10.5281/zenodo.20981979` so future releases don't require touching this file again. Also marks the `paper/README.md` JOSS-submission checklist item done with the value.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_