### PR TITLE
ci(scenario-matrix): raise job timeout, upload partial results on failure

### DIFF
--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -40,6 +40,11 @@ jobs:
   matrix:
     name: scenario matrix + charts
     runs-on: ubuntu-latest
+    # Default job timeout (360 min) is too tight for a real (non-quick) sweep:
+    # a single point at runs=5/time=900 measured well over an hour, and a
+    # 4-5-point sweep can exceed 6h. Give real campaign dispatches headroom;
+    # a genuinely hung run still gets killed, just later.
+    timeout-minutes: 720
     container:
       image: ghcr.io/${{ github.repository_owner }}/ns3:${{ github.event.inputs.version }}
       credentials:
@@ -72,10 +77,20 @@ jobs:
             --only "${{ github.event.inputs.only }}" \
             $quick $propagation
       - name: Render charts
+        # always(): a mid-sweep failure (one anthocnet-compare invocation
+        # raising SystemExit) still leaves a valid, closed CSV for whatever
+        # points completed before it — try to chart it rather than skip.
+        if: always()
         run: |
           python3 ns3/tools/make-charts.py "$GITHUB_WORKSPACE/scenarios.csv" \
             --outdir "$GITHUB_WORKSPACE/docs/benchmarks"
       - name: Upload CSV + charts
+        # always(): upload whatever CSV/charts exist even if an earlier step
+        # failed, so a mid-sweep abort doesn't lose the completed points.
+        # (Does not help if the *job* hits timeout-minutes — GH Actions kills
+        # the whole job with no further steps in that case; only a generous
+        # timeout-minutes avoids that.)
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: scenario-matrix
@@ -83,6 +98,7 @@ jobs:
             scenarios.csv
             docs/benchmarks/*.png
           retention-days: 7
+          if-no-files-found: warn
       - name: Commit charts into docs (optional)
         if: ${{ github.event.inputs.commit == 'true' }}
         run: |


### PR DESCRIPTION
Prep for dispatching the real #110 campaign.

## Why

The sanity dispatch just measured real timing: 3 small area points (`time=120`, `runs=2`) took **~17 minutes** for the "Run scenario matrix" step alone. Scaling to a real point (`runs=5`, `time=900` — ~19× heavier) puts a single point at over an hour, so a 4–5-point sweep can plausibly exceed the platform's 360-minute default job timeout — which would silently lose the **entire** run, since neither "Render charts" nor "Upload CSV + charts" had any `if:` guard and both get skipped once a prior step fails or the job is killed.

## What

- **`timeout-minutes: 720`** on the job — the actual fix for "the sweep is legitimately just slow." GitHub Actions honors an explicit `timeout-minutes` up to 35 days on hosted runners; 720 (12h) gives real headroom above the worst-case estimate. Doesn't help if a run truly hangs forever — it still gets killed, just later.
- **`if: always()`** on "Render charts" and "Upload CSV + charts" — if one point's `anthocnet-compare` invocation raises `SystemExit` mid-sweep, `run-scenarios.py`'s `with open(...) as f:` block still closes/flushes the CSV for every point completed so far (normal Python exception unwinding runs the context manager's cleanup) — but the two downstream steps were unconditionally skipped after that failure, so the already-valid partial CSV never got uploaded. Now it does.
  - **Does not help against a hard job-timeout kill** — GitHub Actions runs no further steps at all once `timeout-minutes` is hit. Only the `timeout-minutes` increase addresses that failure mode; this fixes a separate one (a mid-sweep script error).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_