### PR TITLE
fix(bench): flush the CSV after every point, not just at script exit

### DIFF
--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -182,6 +182,7 @@ def main():
                                    args.dry_run)
                 emit(w, "discrete", name, "", name, klass, flags.get("pause", ""),
                      args.propagation, rows)
+                f.flush()
 
         if want_sweeps:
             for name, (xlabel, base, points) in sweeps.items():
@@ -196,6 +197,7 @@ def main():
                                        args.dry_run)
                     emit(w, "sweep", name, x, f"{name}={x}", xlabel,
                          flags.get("pause", ""), args.propagation, rows)
+                    f.flush()
 
     if not args.dry_run:
         print(f"wrote {args.out}", file=sys.stderr)


### PR DESCRIPTION
Real-world data loss bug surfaced by the first #110 campaign dispatch.

## What happened

4 of the 6 real campaign runs (`scenario-matrix.yml`, `runs=5`, `time=900`) got externally cancelled after ~6 hours — `timeout-minutes: 720` (#118) did not prevent it; something enforces roughly 360 minutes regardless (still unexplained, but empirically consistent across all 4 cancelled runs, cancelled within a ~10-second window of each other despite starting seconds apart).

One of those runs (area sweep, two-ray) had already completed 2 of 5 points before cancellation — confirmed via the job log, where the next point's `[run] anthocnet-compare ...` line only prints after the previous invocation's subprocess returns. Its uploaded `scenarios.csv` still had **zero data rows**.

## Root cause

`run-scenarios.py` holds the CSV file open for the whole script (`with open(args.out, "w") as f:`) and never flushes explicitly. Python's file buffer only reaches disk on close/exit or a full buffer — a normal script exit (including an uncaught `SystemExit` from a failed `anthocnet-compare` invocation) triggers that via the `with`-block's cleanup, but an external process cancellation does not. So completed-but-unflushed points were lost even though the process had valid results in hand.

## Fix

`f.flush()` right after each point's `emit()` call, in both the discrete and sweep loops — pushes each point's rows out of Python's buffer into the OS as soon as it's written, so a later hard kill only loses the point in flight, not everything finished before it.

Verified with `--dry-run` (unchanged command generation, no behavior change on the happy path).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_