### PR TITLE
feat(bench): add --point for single-point sweep dispatch

### DIFF
--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -24,6 +24,9 @@ on:
       only:
         description: 'all | discrete | sweeps | <scenario/sweep name>'
         default: 'all'
+      point:
+        description: 'With only=<sweep name>: run just this one point (e.g. 1500 for area, 900 for pause, 1.4 for scale) instead of the whole sweep. Leave blank for the whole sweep.'
+        default: ''
       propagation:
         description: 'Propagation model override for every point: range (disk) | tworay. Leave blank for anthocnet-compare''s default (range).'
         default: ''
@@ -70,12 +73,16 @@ jobs:
           if [ -n "${{ github.event.inputs.propagation }}" ]; then
             propagation="--propagation=${{ github.event.inputs.propagation }}"
           fi
+          point=""
+          if [ -n "${{ github.event.inputs.point }}" ]; then
+            point="--point=${{ github.event.inputs.point }}"
+          fi
           python3 ns3/tools/run-scenarios.py /opt/ns-3 \
             --out "$GITHUB_WORKSPACE/scenarios.csv" \
             --runs "${{ github.event.inputs.runs }}" \
             --time "${{ github.event.inputs.time }}" \
             --only "${{ github.event.inputs.only }}" \
-            $quick $propagation
+            $quick $propagation $point
       - name: Render charts
         # always(): a mid-sweep failure (one anthocnet-compare invocation
         # raising SystemExit) still leaves a valid, closed CSV for whatever

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -153,10 +153,18 @@ def main():
                          "use its own default (range)")
     ap.add_argument("--only", default="all",
                     help="all|discrete|sweeps|<discrete name>|<sweep name>")
+    ap.add_argument("--point", default=None,
+                    help="with --only <sweep name>, run just the one point whose "
+                         "x value matches this (e.g. 1500 for area, 900 for pause, "
+                         "1.4 for scale) instead of the whole sweep")
     ap.add_argument("--quick", action="store_true",
                     help="cheap CI preset: time=120, runs=2, 3 points/sweep")
     ap.add_argument("--dry-run", action="store_true", help="print commands, don't run")
     args = ap.parse_args()
+
+    if args.point is not None and args.only not in SWEEPS:
+        raise SystemExit("--point requires --only <sweep name> "
+                          f"(one of {', '.join(SWEEPS)}), got --only={args.only!r}")
 
     runs, time = args.runs, args.time
     sweeps = SWEEPS
@@ -188,6 +196,14 @@ def main():
             for name, (xlabel, base, points) in sweeps.items():
                 if args.only in SWEEPS and args.only != name:
                     continue
+                if args.point is not None:
+                    matched = [(x, extra) for x, extra in points
+                               if str(x) == args.point]
+                    if not matched:
+                        valid = ", ".join(str(x) for x, _ in points)
+                        raise SystemExit(f"--point {args.point!r} not in sweep "
+                                          f"{name!r} (valid: {valid})")
+                    points = matched
                 for x, extra in points:
                     flags = dict(base)
                     flags.update(extra)


### PR DESCRIPTION
Per the #110 handoff decision: split each sweep into one dispatch per point instead of one dispatch per whole sweep.

## Why

The prior granularity (a whole sweep per workflow run) lost data whenever a run hit the ~6h external cancellation ceiling found in #110's first real dispatch — 4 of 6 runs were cut off. Even the CSV-flush fix (#119) only saves points that finished *before* the cut; points still in flight or never reached are still lost. Per-point dispatch means each run only ever risks the one point it's running.

## What

- `run-scenarios.py`: new `--point` flag, valid only combined with `--only <sweep name>` — filters that sweep's points down to the one whose `x` value matches (string comparison, so scale's float points like `1.4` work the same as area/pause's ints). Errors clearly if the value doesn't match any point in the sweep, or if used without a specific `--only <sweep>`.
- `scenario-matrix.yml`: new `point` `workflow_dispatch` input, threaded through the same way `propagation` already is.

## Verified

`--dry-run`: valid point, invalid point (clear error), misuse without `--only <sweep>`, and scale's float x-values — all behave as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3dFLcZoaRFTLUptSEuEt)_