### PR TITLE
ci(bench): correct the 6h-ceiling comment and add a step-level timeout to scenario-matrix (#125)

### DIFF
--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -43,11 +43,19 @@ jobs:
   matrix:
     name: scenario matrix + charts
     runs-on: ubuntu-latest
-    # Default job timeout (360 min) is too tight for a real (non-quick) sweep:
-    # a single point at runs=5/time=900 measured well over an hour, and a
-    # 4-5-point sweep can exceed 6h. Give real campaign dispatches headroom;
-    # a genuinely hung run still gets killed, just later.
-    timeout-minutes: 720
+    # 6 h is a HARD platform ceiling on GitHub-hosted runners: every job is
+    # killed at 360 min of execution, and jobs.<id>.timeout-minutes can only
+    # *shorten* that, never extend it. (The 35-day limit is per workflow *run*;
+    # the 5-day one is for self-hosted jobs.) A previous revision set 720 here
+    # with a comment claiming it bought headroom — it did not: all four
+    # whole-sweep runs of the first campaign died at ~360 min regardless (#121).
+    # So this is set to the truth, not to a wish.
+    #
+    # Consequence for callers: a real (non-quick) whole sweep does NOT fit. One
+    # point at runs=5/time=900 measures well over an hour, so a 4-5-point sweep
+    # exceeds 6 h. Dispatch such sweeps **one point per job** using the
+    # only=<sweep name> + point=<value> inputs (#120), or run them off-Actions.
+    timeout-minutes: 360
     container:
       image: ghcr.io/${{ github.repository_owner }}/ns3:${{ github.event.inputs.version }}
       credentials:
@@ -66,6 +74,12 @@ jobs:
       - name: Install matplotlib
         run: apt-get update && apt-get install -y python3-matplotlib
       - name: Run scenario matrix
+        # Step-level timeout, ~20 min under the platform's 6 h job kill, so the
+        # abort is one WE control: only this step is marked failed and the
+        # always() render/upload steps below still run, preserving the
+        # per-point-flushed partial scenarios.csv (#119). Waiting for the
+        # platform kill instead would end the whole job with no further steps.
+        timeout-minutes: 340
         run: |
           quick=""
           [ "${{ github.event.inputs.quick }}" = "true" ] && quick="--quick"
@@ -93,10 +107,11 @@ jobs:
             --outdir "$GITHUB_WORKSPACE/docs/benchmarks"
       - name: Upload CSV + charts
         # always(): upload whatever CSV/charts exist even if an earlier step
-        # failed, so a mid-sweep abort doesn't lose the completed points.
-        # (Does not help if the *job* hits timeout-minutes — GH Actions kills
-        # the whole job with no further steps in that case; only a generous
-        # timeout-minutes avoids that.)
+        # failed, so a mid-sweep abort doesn't lose the completed points —
+        # including the 340-min step timeout above, which is deliberately set
+        # below the 6 h job ceiling precisely so this step still gets to run.
+        # (A *job*-level timeout, ours or the platform's hard 360-min one,
+        # kills everything with no further steps; that is what we avoid.)
         if: always()
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Implements #125. `scenario-matrix.yml` claimed `timeout-minutes: 720` gave long sweeps headroom. That is false — **every job on GitHub-hosted runners is hard-capped at 6 hours; `timeout-minutes` can only shorten it, never extend it** — and it cost four whole-sweep campaign runs, each killed at ~360 min (#121, #118).

## What

- **Job timeout 720 → 360**, set explicitly rather than removed: a stated value plus a correct comment is self-documenting, and it is behaviourally identical to the default (360 *is* both the default and the hard cap).
- **New step-level timeout of 340 min** on "Run scenario matrix" — ~20 min under the platform kill, so the abort is *ours*: the `if: always()` render/upload steps still run and the #119 per-point-flushed partial `scenarios.csv` survives instead of being lost with the runner.
- **Second instance of the same false claim fixed**: the "Upload CSV + charts" comment ended with "only a generous `timeout-minutes` avoids that". Rewritten to describe the new mechanism.
- Comments now state the real rule (35 days is per *run*, 5 days is self-hosted), cross-reference #121 and the four kills, and make the per-point dispatch path explicit (`only=<sweep>` + `point=<value>`, #120) or run off-Actions.

## Validation

`yaml.safe_load` on `scenario-matrix.yml` and `paper-benchmark.yml`; parsed job timeout = 360, step timeout = 340. Verified #119's per-point flushing actually exists (`ns3/tools/run-scenarios.py:222,245`) before asserting it in a comment. No workflow dispatched — the campaign is paused for cost and this change is statically verifiable.

## Deliberately not done

`paper-benchmark.yml` is untouched: it was suspected of carrying the same wrong claim, but it sets no `timeout-minutes` at all and makes no statement about the ceiling. Nothing to correct — recorded in the commit body so the check isn't repeated.

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_