### PR TITLE
feat(infra): publish an optimized-profile ns-3 image (ns3:&lt;ver&gt;-opt) (#123)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -18,6 +18,12 @@ name: Images
 # The rolling and :latest tags move on every default-branch push; the
 # release-pinned tag is only written when `release` is set and never overwritten.
 #
+# One extra tier exists for the plain ns-3 image only (#123):
+#   :<sim-version>-opt        e.g. :3.42-opt    — same tree, ns-3's *optimized*
+#     build profile (assertions + NS_LOG compiled out) for the benchmark
+#     campaigns. It is strictly ADDITIONAL: every tag above keeps ns-3's default
+#     profile, and CI must keep consuming those — assertions catch real bugs.
+#
 # `workflow_call` lets the Release workflow reuse this to publish the immutable
 # release-pinned tags. When `release` is set (e.g. `v0.3.0`) we check out that
 # tag and additionally push `<image>:<sim-version>-<release>`. Reusing this via
@@ -55,6 +61,12 @@ jobs:
     # (latest ns-3 version + latest AntHocNet). Bump when adding a newer version.
     env:
       NS_LATEST: '3.48'
+      # #123: the one version that additionally gets an optimized-profile base
+      # image (`ns3:<ver>-opt`). Campaigns (#110/#121) pin this version, and an
+      # extra full ns-3 compile per matrix leg is not worth spending on versions
+      # nothing runs campaigns against. Keep in sync with the `version` default
+      # in scenario-matrix.yml / paper-benchmark.yml.
+      NS_OPT: '3.42'
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +102,30 @@ jobs:
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns3:{1}-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
             ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/ns3:{1}', env.DOCKERHUB_USERNAME, matrix.version) || '' }}
             ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/ns3:{1}-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
+          push: ${{ env.PUSH == 'true' }}
+      - name: Plain ns-3, optimized profile (campaign image, ${{ env.NS_OPT }} only)
+        # #123: ADDITIONAL tag, never a replacement. The optimized profile
+        # compiles out assertions and NS_LOG (typically 2-10x faster on the
+        # simulation-heavy campaign runs of #121), but the default-profile
+        # images above are what ci.yml consumes precisely because those
+        # assertions have caught real bugs — do not point CI at `-opt`.
+        # Base stage only: the campaign workflows pull `ns3:<ver>` and build the
+        # AntHocNet module inside the job, so an optimized `anthocnet-ns3` image
+        # would cost a second full compile that nothing consumes.
+        if: ${{ matrix.version == env.NS_OPT }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.ns3
+          target: base
+          build-args: |
+            NS3_VERSION=ns-${{ matrix.version }}
+            NS3_PROFILE=optimized
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ns3:${{ matrix.version }}-opt
+            ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns3:{1}-opt-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/ns3:{1}-opt', env.DOCKERHUB_USERNAME, matrix.version) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/ns3:{1}-opt-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: ns-3 + AntHocNet
         uses: docker/build-push-action@v6

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -19,7 +19,7 @@ name: Images
 # release-pinned tag is only written when `release` is set and never overwritten.
 #
 # One extra tier exists for the plain ns-3 image only (#123):
-#   :<sim-version>-opt        e.g. :3.42-opt    — same tree, ns-3's *optimized*
+#   :<sim-version>-opt        e.g. :3.42-opt    — same tree, ns-3's *release*
 #     build profile (assertions + NS_LOG compiled out) for the benchmark
 #     campaigns. It is strictly ADDITIONAL: every tag above keeps ns-3's default
 #     profile, and CI must keep consuming those — assertions catch real bugs.
@@ -61,7 +61,7 @@ jobs:
     # (latest ns-3 version + latest AntHocNet). Bump when adding a newer version.
     env:
       NS_LATEST: '3.48'
-      # #123: the one version that additionally gets an optimized-profile base
+      # #123: the one version that additionally gets a release-profile base
       # image (`ns3:<ver>-opt`). Campaigns (#110/#121) pin this version, and an
       # extra full ns-3 compile per matrix leg is not worth spending on versions
       # nothing runs campaigns against. Keep in sync with the `version` default
@@ -103,14 +103,14 @@ jobs:
             ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/ns3:{1}', env.DOCKERHUB_USERNAME, matrix.version) || '' }}
             ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/ns3:{1}-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
-      - name: Plain ns-3, optimized profile (campaign image, ${{ env.NS_OPT }} only)
-        # #123: ADDITIONAL tag, never a replacement. The optimized profile
+      - name: Plain ns-3, release profile (campaign image, ${{ env.NS_OPT }} only)
+        # #123: ADDITIONAL tag, never a replacement. The release profile
         # compiles out assertions and NS_LOG (typically 2-10x faster on the
         # simulation-heavy campaign runs of #121), but the default-profile
         # images above are what ci.yml consumes precisely because those
         # assertions have caught real bugs — do not point CI at `-opt`.
         # Base stage only: the campaign workflows pull `ns3:<ver>` and build the
-        # AntHocNet module inside the job, so an optimized `anthocnet-ns3` image
+        # AntHocNet module inside the job, so a release-profile `anthocnet-ns3` image
         # would cost a second full compile that nothing consumes.
         if: ${{ matrix.version == env.NS_OPT }}
         uses: docker/build-push-action@v6
@@ -120,7 +120,7 @@ jobs:
           target: base
           build-args: |
             NS3_VERSION=ns-${{ matrix.version }}
-            NS3_PROFILE=optimized
+            NS3_PROFILE=release
           tags: |
             ghcr.io/${{ github.repository_owner }}/ns3:${{ matrix.version }}-opt
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns3:{1}-opt-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -83,7 +83,7 @@ jobs:
           profile="${NS3_PROFILE:-}"
           if [ -z "$profile" ]; then
             case "$VERSION_TAG" in
-              *-opt) profile=optimized ;;
+              *-opt) profile=release ;;
               *)     profile=default ;;
             esac
             echo "image has no NS3_PROFILE env (pre-#123 image); inferred from tag '$VERSION_TAG'"

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'ns-3 image tag'
+        description: 'ns-3 image tag. Suffix -opt (e.g. 3.42-opt) selects the optimized-profile image — assertions/NS_LOG compiled out, typically 2-10x faster (#123). Use it for campaign runs; use the plain tag when you want assertions on.'
         default: '3.42'
       nNodes:
         description: 'Number of nodes'
@@ -64,13 +64,47 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
+      - name: Resolve ns-3 build profile (#123)
+        # The reconfigure below must NOT silently downgrade an optimized image
+        # back to the default profile — that would quietly hand back the 2-10x
+        # speedup the -opt image exists for, and nothing in the results would
+        # say so. ns-3's `ns3 configure` only omits -DCMAKE_BUILD_TYPE (and so
+        # inherits the cached profile) while the tree is still "configured"; the
+        # moment that stops holding, the profile resets to `default`. So state
+        # it explicitly instead of relying on that inheritance.
+        #
+        # Source of truth is NS3_PROFILE, baked into the image env by
+        # docker/Dockerfile.ns3 — it travels with the image, so it stays right
+        # if the tag is renamed, mirrored or pinned to a release. Images built
+        # before #123 have no such env, hence the tag-suffix fallback.
+        env:
+          VERSION_TAG: ${{ github.event.inputs.version }}
+        run: |
+          profile="${NS3_PROFILE:-}"
+          if [ -z "$profile" ]; then
+            case "$VERSION_TAG" in
+              *-opt) profile=optimized ;;
+              *)     profile=default ;;
+            esac
+            echo "image has no NS3_PROFILE env (pre-#123 image); inferred from tag '$VERSION_TAG'"
+          fi
+          # Empty for `default`: keeps the configure line byte-identical to the
+          # pre-#123 one on the default images.
+          flag=""
+          [ "$profile" = "default" ] || flag="-d $profile"
+          echo "ns-3 build profile: $profile (configure flag: '${flag:-<none>}')"
+          echo "NS3_PROFILE=$profile" >> "$GITHUB_ENV"
+          echo "NS3_PROFILE_FLAG=$flag" >> "$GITHUB_ENV"
       - name: Configure
         run: |
           cd /opt/ns-3
-          ./ns3 configure --enable-examples \
+          # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
+          ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
             --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
       - name: Build
-        run: cd /opt/ns-3 && ./ns3 build
+        # `show profile` is recorded in the log so a run's ##PERF## wall-clock
+        # (#131) is always attributable to a build profile after the fact.
+        run: cd /opt/ns-3 && ./ns3 build && ./ns3 show profile
       - name: Run paper scenario
         # Container jobs default to plain `sh`, where `set -o pipefail` is an
         # illegal option (run 29664072922 died instantly on it). The image is

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'ns-3 image tag'
+        description: 'ns-3 image tag. Suffix -opt (e.g. 3.42-opt) selects the optimized-profile image — assertions/NS_LOG compiled out, typically 2-10x faster (#123). Use it for campaign runs; use the plain tag when you want assertions on.'
         default: '3.42'
       quick:
         description: 'Cheap preset (time=120, runs=2, 3 points/sweep)'
@@ -57,12 +57,47 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
+      - name: Resolve ns-3 build profile (#123)
+        # The reconfigure below must NOT silently downgrade an optimized image
+        # back to the default profile — that would quietly hand back the 2-10x
+        # speedup the -opt image exists for, and nothing in the results would
+        # say so. ns-3's `ns3 configure` only omits -DCMAKE_BUILD_TYPE (and so
+        # inherits the cached profile) while the tree is still "configured"; the
+        # moment that stops holding, the profile resets to `default`. So state
+        # it explicitly instead of relying on that inheritance.
+        #
+        # Source of truth is NS3_PROFILE, baked into the image env by
+        # docker/Dockerfile.ns3 — it travels with the image, so it stays right
+        # if the tag is renamed, mirrored or pinned to a release. Images built
+        # before #123 have no such env, hence the tag-suffix fallback.
+        env:
+          VERSION_TAG: ${{ github.event.inputs.version }}
+        run: |
+          profile="${NS3_PROFILE:-}"
+          if [ -z "$profile" ]; then
+            case "$VERSION_TAG" in
+              *-opt) profile=optimized ;;
+              *)     profile=default ;;
+            esac
+            echo "image has no NS3_PROFILE env (pre-#123 image); inferred from tag '$VERSION_TAG'"
+          fi
+          # Empty for `default`: keeps the configure line byte-identical to the
+          # pre-#123 one on the default images.
+          flag=""
+          [ "$profile" = "default" ] || flag="-d $profile"
+          echo "ns-3 build profile: $profile (configure flag: '${flag:-<none>}')"
+          echo "NS3_PROFILE=$profile" >> "$GITHUB_ENV"
+          echo "NS3_PROFILE_FLAG=$flag" >> "$GITHUB_ENV"
       - name: Configure + build
         run: |
           cd /opt/ns-3
-          ./ns3 configure --enable-examples \
+          # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
+          ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
             --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           ./ns3 build
+          # Recorded in the log so every campaign run is attributable to a
+          # profile after the fact (a run's cost is meaningless without it).
+          ./ns3 show profile
       - name: Install matplotlib
         run: apt-get update && apt-get install -y python3-matplotlib
       - name: Run scenario matrix

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -76,7 +76,7 @@ jobs:
           profile="${NS3_PROFILE:-}"
           if [ -z "$profile" ]; then
             case "$VERSION_TAG" in
-              *-opt) profile=optimized ;;
+              *-opt) profile=release ;;
               *)     profile=default ;;
             esac
             echo "image has no NS3_PROFILE env (pre-#123 image); inferred from tag '$VERSION_TAG'"

--- a/docker/Dockerfile.ns3
+++ b/docker/Dockerfile.ns3
@@ -7,7 +7,20 @@
 #   # ns-3 + AntHocNet:
 #   docker build -f docker/Dockerfile.ns3 \
 #                --build-arg NS3_VERSION=ns-3.42 -t anthocnet-ns3:3.42 .
+#   # plain ns-3, optimized build profile (campaign image, #123):
+#   docker build -f docker/Dockerfile.ns3 --target base \
+#                --build-arg NS3_VERSION=ns-3.42 --build-arg NS3_PROFILE=optimized \
+#                -t ns3:3.42-opt .
 #
+# NS3_PROFILE selects ns-3's build profile (`./ns3 configure -d <profile>`):
+#   default    — assertions + logging compiled in (`NS3_ASSERT=ON NS3_LOG=ON`).
+#                What CI consumes; assertions have caught real bugs, so this
+#                stays the profile of the untagged/`:latest` images.
+#   optimized  — `-O3` + native optimizations, assertions and logging compiled
+#                out. Typically 2-10x faster on simulation-heavy campaign runs
+#                (#121/#123), which is the *only* reason it exists.
+# `default` deliberately passes NO `-d` flag at all, so the default images are
+# built by byte-identical configure command lines to the ones used before #123.
 ARG UBUNTU=22.04
 
 # --- base: plain ns-3, no AntHocNet ----------------------------------------
@@ -16,6 +29,7 @@ ARG UBUNTU=22.04
 FROM ubuntu:${UBUNTU} AS base
 
 ARG NS3_VERSION=ns-3.42
+ARG NS3_PROFILE=default
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Recent ns-3 (3.47/3.48) require CMake >= 3.25, newer than Ubuntu 22.04's
@@ -32,12 +46,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # dependencies that vary by release (e.g. aodv's test needs v4ping/internet-apps
 # on ns-3.36; internet-apps' test needs csma on ns-3.47+), which would otherwise
 # force an ever-growing module list. CI exercises the test suites separately.
+#
+# `profile_flag` stays EMPTY for NS3_PROFILE=default so the configure line is
+# character-for-character the one used before #123 — `default` is also what
+# ns-3's own `ns3` script falls back to on an unconfigured tree, so the two are
+# equivalent, but keeping the flag off the default path makes that impossible to
+# regress. Unquoted on use, deliberately, so it word-splits into two argv items.
 RUN git clone --depth 1 --branch "${NS3_VERSION}" \
         https://gitlab.com/nsnam/ns-3-dev.git /opt/ns-3 \
  && cd /opt/ns-3 \
- && ./ns3 configure --enable-examples \
+ && profile_flag=$([ "${NS3_PROFILE}" = "default" ] || echo "-d ${NS3_PROFILE}") \
+ && ./ns3 configure ${profile_flag} --enable-examples \
         --enable-modules='wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point' \
- && ./ns3 build
+ && ./ns3 build \
+ && ./ns3 show profile
+
+# Record the profile in the image environment so consumers can branch on it
+# without parsing the tag. The campaign workflows read this to decide whether
+# their in-job `./ns3 configure` needs `-d optimized` (see #123).
+ENV NS3_PROFILE=${NS3_PROFILE}
 
 WORKDIR /opt/ns-3
 CMD ["bash"]
@@ -46,14 +73,21 @@ CMD ["bash"]
 # Adds the additive module and reconfigures/rebuilds; mirrors the CI ns3-build.
 FROM base AS anthocnet
 
+# No `ARG NS3_PROFILE` re-declaration here on purpose: base's ENV is inherited,
+# and an ENV always overrides an ARG of the same name, so re-declaring it would
+# be dead. Reading the inherited ENV is also the stronger guarantee — this
+# reconfigure cannot pick a different profile than the tree was built with.
+
 WORKDIR /opt/anthocnet
 COPY . .
 
 RUN make install-ns3 NS3DIR=/opt/ns-3 \
  && cd /opt/ns-3 \
- && ./ns3 configure --enable-examples \
+ && profile_flag=$([ "${NS3_PROFILE}" = "default" ] || echo "-d ${NS3_PROFILE}") \
+ && ./ns3 configure ${profile_flag} --enable-examples \
         --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point' \
  && ./ns3 build \
+ && ./ns3 show profile \
  && ./ns3 run anthocnet-example
 
 WORKDIR /opt/ns-3

--- a/docker/Dockerfile.ns3
+++ b/docker/Dockerfile.ns3
@@ -7,16 +7,16 @@
 #   # ns-3 + AntHocNet:
 #   docker build -f docker/Dockerfile.ns3 \
 #                --build-arg NS3_VERSION=ns-3.42 -t anthocnet-ns3:3.42 .
-#   # plain ns-3, optimized build profile (campaign image, #123):
+#   # plain ns-3, campaign build profile (#123):
 #   docker build -f docker/Dockerfile.ns3 --target base \
-#                --build-arg NS3_VERSION=ns-3.42 --build-arg NS3_PROFILE=optimized \
+#                --build-arg NS3_VERSION=ns-3.42 --build-arg NS3_PROFILE=release \
 #                -t ns3:3.42-opt .
 #
 # NS3_PROFILE selects ns-3's build profile (`./ns3 configure -d <profile>`):
 #   default    — assertions + logging compiled in (`NS3_ASSERT=ON NS3_LOG=ON`).
 #                What CI consumes; assertions have caught real bugs, so this
 #                stays the profile of the untagged/`:latest` images.
-#   optimized  — `-O3` + native optimizations, assertions and logging compiled
+#   release    — `-O3`, assertions and logging compiled
 #                out. Typically 2-10x faster on simulation-heavy campaign runs
 #                (#121/#123), which is the *only* reason it exists.
 # `default` deliberately passes NO `-d` flag at all, so the default images are
@@ -63,7 +63,7 @@ RUN git clone --depth 1 --branch "${NS3_VERSION}" \
 
 # Record the profile in the image environment so consumers can branch on it
 # without parsing the tag. The campaign workflows read this to decide whether
-# their in-job `./ns3 configure` needs `-d optimized` (see #123).
+# their in-job `./ns3 configure` needs `-d release` (see #123).
 ENV NS3_PROFILE=${NS3_PROFILE}
 
 WORKDIR /opt/ns-3

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,13 +16,15 @@ vendors ns-2 or ns-3.
 Published to two registries — GHCR (`ghcr.io/danieljoppi/…`) and Docker Hub
 (`docker.io/danieljoppi/…`, when the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
 secrets are set) — for `{ns3,anthocnet-ns3,ns2,anthocnet-ns2}`. One build pushes
-to both registries. Each image carries three tag tiers:
+to both registries. Each image carries three tag tiers, plus a build-profile
+tier that exists for the plain `ns3` image only:
 
 | Tag | Example | Meaning | Mutability |
 |-----|---------|---------|------------|
 | `:<sim-version>` | `:3.42` | latest build for that simulator version | rolling — moves on every merge to the default branch |
 | `:<sim-version>-<release>` | `:3.42-v0.3.0` | pinned to an AntHocNet release | **immutable** — written once, never overwritten |
 | `:latest` | `:latest` | newest simulator version + latest AntHocNet | rolling — moves on every merge to the default branch |
+| `:<sim-version>-opt` | `:3.42-opt` | `ns3` only — the same tree in ns-3's **optimized** build profile | rolling (plus `:3.42-opt-<release>` when a release is pinned) |
 
 Use `:<sim-version>-<release>` when you need a reproducible image for a citation
 (the rolling tiers track the default branch and can change under you). The
@@ -41,6 +43,12 @@ docker build -f docker/Dockerfile.ns3 --target base \
              --build-arg NS3_VERSION=ns-3.42 -t ns3:3.42 .
 docker build -f docker/Dockerfile.ns3 \
              --build-arg NS3_VERSION=ns-3.42 -t anthocnet-ns3:3.42 .
+
+# optimized build profile (the campaign image) — NS3_PROFILE applies to both
+# stages; anything other than `default` becomes `./ns3 configure -d <profile>`:
+docker build -f docker/Dockerfile.ns3 --target base \
+             --build-arg NS3_VERSION=ns-3.42 --build-arg NS3_PROFILE=optimized \
+             -t ns3:3.42-opt .
 
 # plain ns-2 vs ns-2 + AntHocNet:
 docker build -f docker/Dockerfile.ns2 --target base \
@@ -82,3 +90,16 @@ earlier attempt to append one corrupted ns-2's continued `CCOPT` line).
   pushes it to both registries, so mirroring adds no build cost.
 - ns-2.34 is the oldest supported tree; if its build needs extra fixes on the
   pinned base they go in `docker/Dockerfile.ns2` behind the `NS2_VERSION` arg.
+- **Build profiles (#123).** `NS3_PROFILE` selects ns-3's build profile.
+  `default` (assertions + `NS_LOG` compiled in) is what every image tier above
+  carries and what CI consumes — those assertions have caught real bugs, so the
+  optimized image must **never** replace them in CI. `optimized` (assertions and
+  logging compiled out, typically 2-10x faster on simulation-heavy runs) is
+  published as the extra `ns3:<ver>-opt` tag, for **ns-3.42 only**, and is
+  consumed solely by the manual `paper-benchmark` / `scenario-matrix`
+  campaigns via their `version` input. Each image records its profile in the
+  `NS3_PROFILE` environment variable (`docker inspect`), which is how those
+  workflows know whether their in-job `./ns3 configure` needs `-d optimized` —
+  see [`docs/benchmarks.md`](../docs/benchmarks.md#build-profiles-default-for-ci-optimized-for-campaigns)
+  for why that is resolved explicitly rather than inherited, and for the
+  `-march=native` caveat that comes with ns-3's `optimized` profile.

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,7 +24,7 @@ tier that exists for the plain `ns3` image only:
 | `:<sim-version>` | `:3.42` | latest build for that simulator version | rolling — moves on every merge to the default branch |
 | `:<sim-version>-<release>` | `:3.42-v0.3.0` | pinned to an AntHocNet release | **immutable** — written once, never overwritten |
 | `:latest` | `:latest` | newest simulator version + latest AntHocNet | rolling — moves on every merge to the default branch |
-| `:<sim-version>-opt` | `:3.42-opt` | `ns3` only — the same tree in ns-3's **optimized** build profile | rolling (plus `:3.42-opt-<release>` when a release is pinned) |
+| `:<sim-version>-opt` | `:3.42-opt` | `ns3` only — the same tree in ns-3's **`release`** build profile (optimized without `-march=native`) | rolling (plus `:3.42-opt-<release>` when a release is pinned) |
 
 Use `:<sim-version>-<release>` when you need a reproducible image for a citation
 (the rolling tiers track the default branch and can change under you). The
@@ -44,10 +44,10 @@ docker build -f docker/Dockerfile.ns3 --target base \
 docker build -f docker/Dockerfile.ns3 \
              --build-arg NS3_VERSION=ns-3.42 -t anthocnet-ns3:3.42 .
 
-# optimized build profile (the campaign image) — NS3_PROFILE applies to both
+# campaign build profile (release = optimized minus -march=native) — applies to both
 # stages; anything other than `default` becomes `./ns3 configure -d <profile>`:
 docker build -f docker/Dockerfile.ns3 --target base \
-             --build-arg NS3_VERSION=ns-3.42 --build-arg NS3_PROFILE=optimized \
+             --build-arg NS3_VERSION=ns-3.42 --build-arg NS3_PROFILE=release \
              -t ns3:3.42-opt .
 
 # plain ns-2 vs ns-2 + AntHocNet:
@@ -93,13 +93,13 @@ earlier attempt to append one corrupted ns-2's continued `CCOPT` line).
 - **Build profiles (#123).** `NS3_PROFILE` selects ns-3's build profile.
   `default` (assertions + `NS_LOG` compiled in) is what every image tier above
   carries and what CI consumes — those assertions have caught real bugs, so the
-  optimized image must **never** replace them in CI. `optimized` (assertions and
+  campaign image must **never** replace them in CI. `release` (assertions and
   logging compiled out, typically 2-10x faster on simulation-heavy runs) is
   published as the extra `ns3:<ver>-opt` tag, for **ns-3.42 only**, and is
   consumed solely by the manual `paper-benchmark` / `scenario-matrix`
   campaigns via their `version` input. Each image records its profile in the
   `NS3_PROFILE` environment variable (`docker inspect`), which is how those
-  workflows know whether their in-job `./ns3 configure` needs `-d optimized` —
-  see [`docs/benchmarks.md`](../docs/benchmarks.md#build-profiles-default-for-ci-optimized-for-campaigns)
+  workflows know whether their in-job `./ns3 configure` needs `-d release` —
+  see [`docs/benchmarks.md`](../docs/benchmarks.md#build-profiles-default-for-ci-release-for-campaigns)
   for why that is resolved explicitly rather than inherited, and for the
-  `-march=native` caveat that comes with ns-3's `optimized` profile.
+  rationale for `release` over ns-3's `optimized` (which adds `-march=native`).

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -82,20 +82,20 @@ PDR / mean+99th-percentile delay / NRL vs. the swept parameter:
 Unlike the paper (AODV only), every baseline (AODV/OLSR/DSDV) is run on identical
 realisations, so the classification covers all of them.
 
-## Build profiles: `default` for CI, `optimized` for campaigns
+## Build profiles: `default` for CI, `release` for campaigns
 
 ns-3 builds under a *build profile*, and until [#123](https://github.com/danieljoppi/AntHocNet/issues/123)
 every benchmark minute the project had ever spent ran under the `default` one —
 assertions **and** `NS_LOG` compiled in. For simulation-heavy runs that is
-typically **2-10x slower** than ns-3's `optimized` profile, which is the single
+typically **2-10x slower** than ns-3's optimized (`release`) profile, which is the single
 biggest cost lever on the campaign budget ([#121](https://github.com/danieljoppi/AntHocNet/issues/121)).
 
 | profile | `./ns3 configure` | what it compiles | published as |
 |---|---|---|---|
 | `default` | no `-d` flag (ns-3's own fallback) | `NS3_ASSERT=ON`, `NS3_LOG=ON`, `-O2 -g` | `ns3:<ver>`, `anthocnet-ns3:<ver>`, `:latest` |
-| `optimized` | `-d optimized` | `NS3_ASSERT=OFF`, `NS3_LOG=OFF`, `-O3` + `-march=native -mtune=native` | `ns3:<ver>-opt` (ns-3.42 only) |
+| `release` | `-d release` | `NS3_ASSERT=OFF`, `NS3_LOG=OFF`, `-O3`, **no** `-march=native` | `ns3:<ver>-opt` (ns-3.42 only) |
 
-**The optimized image is additional, never a replacement.** CI (`ci.yml`, and
+**The `-opt` image is additional, never a replacement.** CI (`ci.yml`, and
 the per-merge `benchmarks.yml` that regenerates the table below) keeps pulling
 the default-profile images on purpose: those assertions have caught real bugs,
 and a green run with assertions compiled out is a weaker statement. Only the two
@@ -120,9 +120,9 @@ and nothing in the CSV says why.
 So the workflows resolve the profile in a dedicated step and pass it explicitly:
 
 1. **`NS3_PROFILE` from the image environment** is the source of truth.
-   `docker/Dockerfile.ns3` bakes it in (`default` or `optimized`), so it travels
+   `docker/Dockerfile.ns3` bakes it in (`default` or `release`), so it travels
    with the image through renames, the Docker Hub mirror and release-pinned tags.
-2. **Tag suffix as fallback** — `*-opt` → `optimized` — for images published
+2. **Tag suffix as fallback** — `*-opt` → `release` — for images published
    before #123, which carry no such variable.
 3. The resolved profile becomes `-d <profile>`, or **the empty string for
    `default`**, so the default path runs the byte-identical configure line it ran
@@ -139,13 +139,19 @@ is always attributable to a profile after the fact.
   `--qdiag` output goes to `std::cout` via trace sources, not `NS_LOG` — so
   diagnostics survive the optimized build. PDR/delay/NRL differences between
   profiles are a red flag, not an expected effect.
-- **`-march=native` is baked in at image-build time.** ns-3 maps `optimized` to
-  `release` plus `NS3_NATIVE_OPTIMIZATIONS=ON`, which adds `-march=native
-  -mtune=native`. The prebuilt stock-module libraries in `ns3:<ver>-opt` are
-  therefore tuned for whichever runner built the image, while the in-job rebuild
-  targets the campaign runner. GitHub's hosted fleet is microarchitecturally
-  mixed, so if a campaign job ever dies with `Illegal instruction`, this is why —
-  the fix is `-d release` (identical to `optimized` minus the native flags).
+- **Why `release` and not `optimized`.** In ns-3's `ns3` script the two profiles
+  emit an *identical* CMake command line (`CMAKE_BUILD_TYPE=release`,
+  `NS3_ASSERT=OFF`, `NS3_LOG=OFF`, `NS3_WARNINGS_AS_ERRORS=OFF`) with exactly one
+  difference: `optimized` also sets `NS3_NATIVE_OPTIMIZATIONS=ON`, adding
+  `-march=native -mtune=native`. That is unsafe here — the stock-module libraries
+  inside `ns3:<ver>-opt` would be tuned for whichever runner *built* the image,
+  while campaigns run on a microarchitecturally mixed hosted fleet, so a job could
+  die mid-campaign with `Illegal instruction`. Native tuning also buys very little
+  for a pointer-chasing discrete-event simulator. ns-3 exposes no
+  `--disable-native-optimizations` flag (it is not in the `ns3` script's
+  override list, and unknown `configure` arguments are rejected), so `-d release`
+  is *the* way to express "optimized without `-march=native`". The `-opt` tag name
+  is kept: it means "the campaign image", not the literal ns-3 profile name.
 - **Never compare wall-clock across profiles as a protocol result.** Cost
   comparisons are only meaningful profile-to-profile on the same scenario; the
   sanctioned A/B speed measurement is its own ticket.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -82,6 +82,74 @@ PDR / mean+99th-percentile delay / NRL vs. the swept parameter:
 Unlike the paper (AODV only), every baseline (AODV/OLSR/DSDV) is run on identical
 realisations, so the classification covers all of them.
 
+## Build profiles: `default` for CI, `optimized` for campaigns
+
+ns-3 builds under a *build profile*, and until [#123](https://github.com/danieljoppi/AntHocNet/issues/123)
+every benchmark minute the project had ever spent ran under the `default` one —
+assertions **and** `NS_LOG` compiled in. For simulation-heavy runs that is
+typically **2-10x slower** than ns-3's `optimized` profile, which is the single
+biggest cost lever on the campaign budget ([#121](https://github.com/danieljoppi/AntHocNet/issues/121)).
+
+| profile | `./ns3 configure` | what it compiles | published as |
+|---|---|---|---|
+| `default` | no `-d` flag (ns-3's own fallback) | `NS3_ASSERT=ON`, `NS3_LOG=ON`, `-O2 -g` | `ns3:<ver>`, `anthocnet-ns3:<ver>`, `:latest` |
+| `optimized` | `-d optimized` | `NS3_ASSERT=OFF`, `NS3_LOG=OFF`, `-O3` + `-march=native -mtune=native` | `ns3:<ver>-opt` (ns-3.42 only) |
+
+**The optimized image is additional, never a replacement.** CI (`ci.yml`, and
+the per-merge `benchmarks.yml` that regenerates the table below) keeps pulling
+the default-profile images on purpose: those assertions have caught real bugs,
+and a green run with assertions compiled out is a weaker statement. Only the two
+*manual* campaign workflows — `paper-benchmark.yml` and `scenario-matrix.yml` —
+accept an `-opt` tag, via their `version` input (e.g. `3.42-opt`).
+
+Only ns-3.42 gets an `-opt` tag: it is the version campaigns pin, and each extra
+profile is a second full ns-3 compile in `images.yml`.
+
+### Why the campaign workflows resolve the profile explicitly
+
+Both campaign workflows install the AntHocNet module into the image's `/opt/ns-3`
+and **re-run `./ns3 configure`** in the job. That reconfigure is where an
+optimized image could quietly stop being optimized. ns-3's `ns3` script only
+leaves `-DCMAKE_BUILD_TYPE` off the CMake command line — and so inherits the
+cached profile — while it finds the tree already configured; on any path where it
+does not (`project_configured()` false), it falls back to `build_profile =
+"default"`. Inheriting a profile by omission is not a property worth betting a
+six-hour campaign on, and the failure is silent: the run simply costs 2-10x more
+and nothing in the CSV says why.
+
+So the workflows resolve the profile in a dedicated step and pass it explicitly:
+
+1. **`NS3_PROFILE` from the image environment** is the source of truth.
+   `docker/Dockerfile.ns3` bakes it in (`default` or `optimized`), so it travels
+   with the image through renames, the Docker Hub mirror and release-pinned tags.
+2. **Tag suffix as fallback** — `*-opt` → `optimized` — for images published
+   before #123, which carry no such variable.
+3. The resolved profile becomes `-d <profile>`, or **the empty string for
+   `default`**, so the default path runs the byte-identical configure line it ran
+   before #123.
+
+Each job then logs `./ns3 show profile`, so a run's cost (the `##PERF##`
+wall-clock line from [#131](https://github.com/danieljoppi/AntHocNet/issues/131))
+is always attributable to a profile after the fact.
+
+### Caveats when reading `-opt` numbers
+
+- **Protocol metrics should be unchanged.** The adapter's four `NS_ASSERT`s are
+  null-pointer checks with no side effects, and `anthocnet-compare`'s `--diag` /
+  `--qdiag` output goes to `std::cout` via trace sources, not `NS_LOG` — so
+  diagnostics survive the optimized build. PDR/delay/NRL differences between
+  profiles are a red flag, not an expected effect.
+- **`-march=native` is baked in at image-build time.** ns-3 maps `optimized` to
+  `release` plus `NS3_NATIVE_OPTIMIZATIONS=ON`, which adds `-march=native
+  -mtune=native`. The prebuilt stock-module libraries in `ns3:<ver>-opt` are
+  therefore tuned for whichever runner built the image, while the in-job rebuild
+  targets the campaign runner. GitHub's hosted fleet is microarchitecturally
+  mixed, so if a campaign job ever dies with `Illegal instruction`, this is why —
+  the fix is `-d release` (identical to `optimized` minus the native flags).
+- **Never compare wall-clock across profiles as a protocol result.** Cost
+  comparisons are only meaningful profile-to-profile on the same scenario; the
+  sanctioned A/B speed measurement is its own ticket.
+
 ## Validation anchors (known-expected results)
 
 A benchmark is only trustworthy if it reproduces a *known* result on a reference


### PR DESCRIPTION
Implements #123, phase 1 of the #121 campaign-cost epic. Every campaign minute so far ran ns-3's **default** profile (assertions + logging compiled in); the optimized profile is commonly 2–10× faster for simulation-heavy runs.

## What

- **`docker/Dockerfile.ns3`**: `ARG NS3_PROFILE=default` threaded into both stages' configure; the base stage bakes `ENV NS3_PROFILE` into the image; both stages log `./ns3 show profile`.
- **`images.yml`**: additionally builds/pushes `ns3:<ver>-opt` (plus Docker Hub mirror and release-pinned `-opt-<release>`), gated on a new `NS_OPT: '3.42'` job env. Existing default-profile tags untouched.
- **`scenario-matrix.yml` / `paper-benchmark.yml`**: a "Resolve ns-3 build profile" step feeding the in-job configure; the `version` input documents the `-opt` suffix.
- **Docs**: a "Build profiles" section in `docs/benchmarks.md` and a `-opt` row in `docker/README.md`, both stating that **CI must keep the default (assertion-enabled) images** — the campaign image is additional, never a replacement.

## The in-job reconfigure problem (the subtle part)

The issue suspected the in-job `./ns3 configure` resets the profile. Reading upstream's `ns3` script (identical in 3.36/3.42/3.48): `-d` defaults to `None` and `"default"` is only substituted inside the `if not project_configured(...)` branch, so today's flagless configure **inherits** the cached profile — but only while the tree still looks configured. That is inheritance by omission, and its failure mode is silent: the run just costs 2–10× more and nothing in the CSV says why.

Resolved explicitly instead, in priority order:
1. **`NS3_PROFILE` from the image env** (source of truth — it travels with the image across the Docker Hub mirror, release-pinned tags, and local retags, none of which a tag test survives);
2. **`*-opt` tag suffix** as fallback for images published before this change;
3. emitted as `-d <profile>`, or **the empty string for `default`** — so the default path runs a character-for-character identical configure line to today.

## Profile choice: `release`, not `optimized` (resolved)

The first revision used `-d optimized` and flagged a risk; the maintainer's call was **keep the optimization, drop `-march=native`**, now implemented.

Verified against upstream's `ns3` script rather than assumed: `release` and `optimized` emit an **identical** CMake command line —
`-DCMAKE_BUILD_TYPE=release -DNS3_ASSERT=OFF -DNS3_LOG=OFF -DNS3_WARNINGS_AS_ERRORS=OFF` — differing in exactly one appended flag, `-DNS3_NATIVE_OPTIMIZATIONS=ON` for `optimized`, which is what adds `-march=native -mtune=native`. There is **no** `--disable-native-optimizations` escape hatch (`NATIVE_OPTIMIZATIONS` is absent from the script's enable/disable override tuple, and `ns3` rejects unknown configure arguments, so trailing `-- -D…` is not supported either). `-d release` is therefore *the* way to express "optimized without native tuning".

Why it matters: the stock-module `.so`s baked into `ns3:<ver>-opt` are compiled on whichever runner builds the image, while campaigns rebuild and run on a different, microarchitecturally mixed hosted fleet — so native tuning risks killing a multi-hour campaign with `Illegal instruction`. It also buys very little for a pointer-chasing discrete-event simulator, so the speedup this PR exists for is retained in full.

The **`-opt` tag name is deliberately kept**: it means "the campaign image", not the literal ns-3 profile name. The reasoning is recorded in `docs/benchmarks.md` so the next reader doesn't re-derive it.

## Verification still required after merge

One `images.yml` dispatch, then confirm `ghcr.io/danieljoppi/ns3:3.42-opt` exists, its log shows `Build profile: release`, and default tags / `:latest` are unchanged. Also watch: `./ns3 show profile` now runs on every matrix leg (valid subcommand in 3.36/3.42/3.48, but it is the one new command on the default path), and 3.42's leg now performs three ns-3 compiles against the 360-min ceiling.

Also checked: the campaign build loses no diagnostics — the four `NS_ASSERT`s in `ns3/` are side-effect-free null checks, and `--diag`/`--qdiag` write to `std::cout` via trace sources, not `NS_LOG`. So PDR/delay/NRL differences between profiles would be a red flag, not an expected effect.

Unblocks #124.

Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ