### PR TITLE
chore(infra): park the Docker Hub mirror — GHCR is the only published registry (#158)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -51,7 +51,16 @@ permissions:
 env:
   # Push on default-branch pushes, or whenever a release pin is requested.
   PUSH: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) || (inputs.release || '') != '' }}
-  # Docker Hub namespace; empty (secret unset) disables the Docker Hub mirror.
+  # Docker Hub mirroring is OFF (maintainer decision, 2026-07-24, #158).
+  # GHCR is the only registry anything depends on: ci.yml, the campaign
+  # workflows and docker/README.md all pull ghcr.io. The mirror was a
+  # convenience copy (#77/#79) whose token expired, and re-enabling it means
+  # maintaining a Docker Hub PAT that expires again. The steps are kept intact
+  # rather than deleted so turning it back on is a one-line change: set this to
+  # 'true' and store a Read & Write Docker Hub PAT in the DOCKERHUB_TOKEN
+  # secret (plus DOCKERHUB_USERNAME for the namespace).
+  MIRROR_DOCKERHUB: 'false'
+  # Docker Hub namespace; empty (secret unset) also disables the mirror.
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
@@ -86,7 +95,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -120,7 +129,7 @@ jobs:
       # so it publishes the same artifact. To turn mirroring off entirely, clear
       # the DOCKERHUB_USERNAME secret.
       - name: Mirror plain ns-3 to Docker Hub (non-fatal)
-        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
         uses: docker/build-push-action@v6
         with:
@@ -155,7 +164,7 @@ jobs:
             ${{ (inputs.release || '') != '' && format('ghcr.io/{0}/ns3:{1}-opt-{2}', github.repository_owner, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: Mirror release-profile ns-3 to Docker Hub (non-fatal)
-        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' && matrix.version == env.NS_OPT }}
+        if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' && matrix.version == env.NS_OPT }}
         continue-on-error: true
         uses: docker/build-push-action@v6
         with:
@@ -182,7 +191,7 @@ jobs:
             ${{ matrix.version == env.NS_LATEST && format('ghcr.io/{0}/anthocnet-ns3:latest', github.repository_owner) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: Mirror ns-3 + AntHocNet to Docker Hub (non-fatal)
-        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
         uses: docker/build-push-action@v6
         with:
@@ -218,7 +227,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -236,7 +245,7 @@ jobs:
           push: ${{ env.PUSH == 'true' }}
       # Same split as the ns-3 job — see the mirror rationale there (#158).
       - name: Mirror plain ns-2 to Docker Hub (non-fatal)
-        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
         uses: docker/build-push-action@v6
         with:
@@ -261,7 +270,7 @@ jobs:
             ${{ matrix.version == env.NS_LATEST && format('ghcr.io/{0}/anthocnet-ns2:latest', github.repository_owner) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: Mirror ns-2 + AntHocNet to Docker Hub (non-fatal)
-        if: ${{ env.PUSH == 'true' && env.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
         uses: docker/build-push-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ Current results, regenerated on every merge to the default branch, are in
 ### Container images
 
 Prefer not to install a simulator yourself? Pre-built images are published to
-GHCR (`ghcr.io/danieljoppi/…`) and mirrored to Docker Hub
-(`docker.io/danieljoppi/…`) — for **each supported version**, a plain simulator
+GHCR (`ghcr.io/danieljoppi/…`) — for **each supported version**, a plain simulator
 and the same simulator with AntHocNet built in (so you can compare against a
 clean baseline):
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,11 +13,12 @@ vendors ns-2 or ns-3.
 | `ns2` | `2.34`, `2.35` | Plain ns-allinone-2.3x built from source, **no AntHocNet**. |
 | `anthocnet-ns2` | `2.34`, `2.35` | The same ns-2 **plus** the AntHocNet patch applied and **compiled** (the only place the ns-2 adapter is actually built). |
 
-Published to two registries — GHCR (`ghcr.io/danieljoppi/…`) and Docker Hub
-(`docker.io/danieljoppi/…`, when the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
-secrets are set) — for `{ns3,anthocnet-ns3,ns2,anthocnet-ns2}`. One build pushes
-to both registries. Each image carries three tag tiers, plus a build-profile
-tier that exists for the plain `ns3` image only:
+Published to **GHCR** (`ghcr.io/danieljoppi/…`) for
+`{ns3,anthocnet-ns3,ns2,anthocnet-ns2}`. A Docker Hub mirror exists in
+`images.yml` but is **off** (`MIRROR_DOCKERHUB: 'false'`, #158) — GHCR is the
+only registry CI, the campaign workflows and this README depend on. Each image
+carries three tag tiers, plus a build-profile tier that exists for the plain
+`ns3` image only:
 
 | Tag | Example | Meaning | Mutability |
 |-----|---------|---------|------------|
@@ -84,10 +85,13 @@ earlier attempt to append one corrupted ns-2's continued `CCOPT` line).
   `GITHUB_TOKEN` does not trigger other workflows, so a `push: tags` job would
   never fire — a `workflow_call` job dependency runs in the same release run and
   needs no PAT.
-- The **Docker Hub mirror** is gated on the `DOCKERHUB_USERNAME` secret: when
-  unset (e.g. forks) the Docker Hub login and `docker.io/…` tags drop out and
-  only GHCR is pushed. `docker/build-push-action` builds each image once and
-  pushes it to both registries, so mirroring adds no build cost.
+- The **Docker Hub mirror is disabled** (`MIRROR_DOCKERHUB: 'false'` in
+  `images.yml`; maintainer decision on #158). Its steps are kept rather than
+  deleted, each `continue-on-error: true` and separate from the GHCR push, so a
+  dead mirror can never again fail a publish or skip later steps — the #158 bug,
+  which silently prevented `ns3:<ver>-opt` from being published at all. To turn
+  it back on: set `MIRROR_DOCKERHUB: 'true'` and store a Docker Hub PAT with
+  **Read & Write** scope in `DOCKERHUB_TOKEN` (plus `DOCKERHUB_USERNAME`).
 - ns-2.34 is the oldest supported tree; if its build needs extra fixes on the
   pinned base they go in `docker/Dockerfile.ns2` behind the `NS2_VERSION` arg.
 - **Build profiles (#123).** `NS3_PROFILE` selects ns-3's build profile.


### PR DESCRIPTION
Closes the second half of #158 with the maintainer's decision (2026-07-24): **keep publishing to GHCR, leave Docker Hub for the future** — the mirror isn't required, and it isn't worth maintaining a Docker Hub PAT that expires again.

## What

Rather than rely on the *absence* of a secret to express this, the decision is explicit in code: a new **`MIRROR_DOCKERHUB: 'false'`** workflow env gates the Docker Hub login and all five mirror steps — 7 conditions in total. The steps themselves are kept intact, so re-enabling is a one-line flip plus a Read & Write PAT in `DOCKERHUB_TOKEN`. The capability is **parked, not deleted**.

## Why it's safe

Nothing depends on Docker Hub: `ci.yml`, `paper-benchmark.yml`, `scenario-matrix.yml` and the docs all pull `ghcr.io`. The mirror was a convenience copy (#77/#79) whose token lost write scope — and that expired token *is* what caused #158: because Docker Hub tags rode along in the same buildx invocation as the GHCR tags, its `insufficient scopes` error failed the step **after** GHCR had already succeeded, which skipped every later step in the job, including the #123 step that publishes `ns3:<ver>-opt`.

With the mirror off, image publishes are **green rather than yellow**, and the step split from #159 means a future re-enable can never reintroduce that failure mode.

## Docs

- `docker/README.md`: GHCR-only, documents the switch and exactly how to turn mirroring back on.
- `README.md`: drops the "mirrored to Docker Hub" promise, which is no longer true.

## Validation

`images.yml` parses; a structural dump confirms `MIRROR_DOCKERHUB` is `'false'` and that all 7 Docker Hub conditions (2 logins + 5 mirrors) carry `env.MIRROR_DOCKERHUB == 'true'`, with the mirrors keeping `continue-on-error: true` and the release-profile mirror keeping its `matrix.version == env.NS_OPT` gate. No GHCR tag or step touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_