### PR TITLE
feat(skills): campaign-loop tooling, scenario validation (#134), and ADR-0014

### DIFF
--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark-results
-description: Run the full AntHocNet benchmark loop — dispatch paper-benchmark / scenario-matrix, fetch results cheaply, parse and A/B-compare runs, and summarize classified campaign CSVs — with automatic run-to-run-noise verdicts. Use whenever dispatching benchmark workflows or collecting/comparing AntHocNet benchmark numbers (including docs/benchmarks/campaign/*.csv sweeps) so parsing, deltas, filtering, and the noise call are done by scripts instead of by hand in context.
+description: Run the full AntHocNet benchmark loop — pre-flight-validate scenario configs, dispatch paper-benchmark / scenario-matrix, fetch results cheaply, check result plausibility and anchor floors, parse and A/B-compare runs, and summarize classified campaign CSVs — with automatic run-to-run-noise verdicts. Use whenever dispatching benchmark workflows, validating a scenario or its results, or collecting/comparing AntHocNet benchmark numbers (including docs/benchmarks/campaign/*.csv sweeps) so validation, parsing, deltas, filtering, and the noise call are done by scripts instead of by hand in context.
 ---
 
 # benchmark-results
@@ -62,6 +62,10 @@ deterministic on identical seeds).
 
 The cross-session procedure (formerly buried in issue #91's session notes):
 
+0. **Pre-flight** the scenario before spending a dispatch (#121 budget):
+   `scenario_check.py preflight` with the knobs you intend to override —
+   flags partitioned fields, channel saturation, accidental single-hop,
+   too-short sim time (see below).
 1. **Dispatch** `paper-benchmark.yml` (single point, ##BENCH## output) or
    `scenario-matrix.yml` (taxonomy/sweeps → classified CSV artifact) via
    `mcp__github__actions_run_trigger` on `main` or a branch ref. For
@@ -76,9 +80,14 @@ The cross-session procedure (formerly buried in issue #91's session notes):
    a file, one per run. `scenario-matrix`: the CSV artifact is
    proxy-blocked; use `commit=true` on dispatch, or the `rescue-artifacts`
    workflow, then read `docs/benchmarks/campaign/<runid>-*.csv` from the ref.
-4. **Parse by script, never by eye**: `bench_parse.py` for `##BENCH##` cells,
+4. **Validate before comparing**: `scenario_check.py results` on the saved
+   cell/CSV — plausibility invariants (PDR bounds, delay99 ≥ mean, negative
+   metrics) and, for anchor-shaped scenarios, the `ns3/tools/anchors.yml`
+   floors (#59). A FAIL here means harness/channel regression (#51-class):
+   do not compare, publish, or quote the numbers.
+5. **Parse by script, never by eye**: `bench_parse.py` for `##BENCH##` cells,
    `sweep_summary.py` for campaign CSVs (below).
-5. **Record** the verdict + run IDs on the relevant issue (ADR-0013).
+6. **Record** the verdict + run IDs on the relevant issue (ADR-0013).
 
 ## Campaign CSVs (`sweep_summary.py`)
 
@@ -100,3 +109,24 @@ delay99/NRL ±10%); `~sd` marks a material PDR delta still inside
 2·RSS(`pdr_sd`) — run-to-run dispersion, treat as noise and bump `--runs`.
 `--export-sweeps` is the bridge to the papers repo's `figures` skill
 (`plot_sweeps.py` reads that schema directly).
+
+## Scenario validation (`scenario_check.py`, #134)
+
+Pre-flight a config before dispatching; sanity-check results after fetching.
+Both exit non-zero on FAIL.
+
+```bash
+S=.claude/skills/benchmark-results/scenario_check.py
+python3 $S preflight                              # paper base defaults, OK
+python3 $S preflight --areaX 2500 --flows 40      # override what you'd dispatch
+python3 $S results cell.txt                       # ##BENCH## cell or campaign CSV
+python3 $S results --anchor broch-low-mobility cell.txt   # enforce #59 floor
+```
+
+`preflight` checks: expected mean node degree (strip-geometry aware) vs the
+ln(n) connectivity threshold, offered load vs the pinned 2 Mbit/s channel
+(#84), `range ≥ area` single-hop degeneracy, short-sim and static-field
+warnings. `results` checks: PDR ∈ [0,100], delay99 ≥ mean delay, negative
+metrics, dead cells (#28), and — with `--anchor` — the AODV floors read from
+`ns3/tools/anchors.yml` (never duplicated). A `results` FAIL is a #51-class
+harness regression: fix the harness before trusting any number from that run.

--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark-results
-description: Parse anthocnet-compare / paper-benchmark output and A/B-compare runs (EnableMacMetric on/off, protocol vs baseline, load sweeps) with an automatic run-to-run-noise verdict. Use whenever collecting or comparing AntHocNet benchmark numbers so the parsing, per-metric deltas, and noise call are done by a script instead of by hand in context.
+description: Run the full AntHocNet benchmark loop — dispatch paper-benchmark / scenario-matrix, fetch results cheaply, parse and A/B-compare runs, and summarize classified campaign CSVs — with automatic run-to-run-noise verdicts. Use whenever dispatching benchmark workflows or collecting/comparing AntHocNet benchmark numbers (including docs/benchmarks/campaign/*.csv sweeps) so parsing, deltas, filtering, and the noise call are done by scripts instead of by hand in context.
 ---
 
 # benchmark-results
@@ -57,3 +57,46 @@ scenario knobs through the `extraArgs` input, e.g.
 `--cbrBps=8000 --sink=25 --flows=30 --ns3::anthocnet::RoutingProtocol::EnableMacMetric=true`.
 Pair every ON run with an identical OFF run for a clean A/B (baselines are
 deterministic on identical seeds).
+
+## The full campaign loop (dispatch → fetch → parse)
+
+The cross-session procedure (formerly buried in issue #91's session notes):
+
+1. **Dispatch** `paper-benchmark.yml` (single point, ##BENCH## output) or
+   `scenario-matrix.yml` (taxonomy/sweeps → classified CSV artifact) via
+   `mcp__github__actions_run_trigger` on `main` or a branch ref. For
+   `scenario-matrix`, `only=<sweep>` + `point=<x>` runs one point;
+   `commit=true` writes CSV+charts into `docs/benchmarks/` on that ref.
+2. **Wait** — a real sweep point can exceed an hour (job timeout 720 min).
+   Poll `mcp__github__actions_get` occasionally or schedule a check-in; do
+   not spin.
+3. **Fetch cheap.** `paper-benchmark`: `get_job_logs` with `tail_lines: 15`
+   (the `##BENCH##` block is last; `# stddev` / `# diag hold[...]` lines sit
+   just above — fetch ~55 lines if you need those). Save the tail verbatim to
+   a file, one per run. `scenario-matrix`: the CSV artifact is
+   proxy-blocked; use `commit=true` on dispatch, or the `rescue-artifacts`
+   workflow, then read `docs/benchmarks/campaign/<runid>-*.csv` from the ref.
+4. **Parse by script, never by eye**: `bench_parse.py` for `##BENCH##` cells,
+   `sweep_summary.py` for campaign CSVs (below).
+5. **Record** the verdict + run IDs on the relevant issue (ADR-0013).
+
+## Campaign CSVs (`sweep_summary.py`)
+
+Classified CSVs (`run-scenarios.py` schema, e.g.
+`docs/benchmarks/campaign/*.csv`) are hundreds of cells — schema check,
+per-point deltas, and the stddev-aware noise call happen in the script; only
+its compact grid should reach context.
+
+```bash
+S=.claude/skills/benchmark-results/sweep_summary.py
+python3 $S docs/benchmarks/campaign/*.csv        # anthocnet vs aodv per point
+python3 $S --baseline olsr --group pause FILE    # other baseline / one group
+python3 $S --export-sweeps sweeps.csv FILE...    # emit the papers-repo
+                                                 #   plots/data/sweeps.csv schema
+```
+
+Per-point verdict uses bench_parse's materiality thresholds (PDR ±1pp,
+delay99/NRL ±10%); `~sd` marks a material PDR delta still inside
+2·RSS(`pdr_sd`) — run-to-run dispersion, treat as noise and bump `--runs`.
+`--export-sweeps` is the bridge to the papers repo's `figures` skill
+(`plot_sweeps.py` reads that schema directly).

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Scenario validation (#134): pre-flight config checks + result plausibility.
+
+Two failure classes this script catches before they cost a dispatch cycle
+(#121 budget) or a corrupted conclusion:
+- a degenerate scenario config (partitioned field, overloaded channel,
+  accidental single-hop, too-short sim) dispatched as if meaningful;
+- an implausible or anchor-violating result trusted, compared, or quoted.
+
+All arithmetic happens here; only the verdict lines reach LLM context.
+
+Usage:
+    scenario_check.py preflight [--nodes 50] [--areaX 1500] [--areaY 300]
+                                [--range 300] [--time 300] [--pause 30]
+                                [--speed 20] [--flows 20] [--pktBytes 64]
+                                [--pktPerSec 1] [--rateMbps 2]
+        # defaults = the paper base scenario; override what your dispatch
+        # overrides. Exit 1 on any FAIL-level degeneracy.
+
+    scenario_check.py results FILE [FILE ...] [--anchor single-hop|broch-low-mobility]
+        # FILE = a saved ##BENCH## cell / results-table text, or a classified
+        # campaign CSV (sniffed by header). --anchor additionally enforces
+        # the ns3/tools/anchors.yml floor on AODV rows (#59, single source
+        # of thresholds). Exit 1 on any FAIL.
+"""
+import argparse
+import csv
+import math
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ANCHORS_YML = os.path.normpath(
+    os.path.join(HERE, "..", "..", "..", "ns3", "tools", "anchors.yml"))
+ANCHOR_KEY = {"single-hop": "single_hop_pdr_min",
+              "broch-low-mobility": "broch_low_mobility_aodv_pdr_min"}
+
+ROW = re.compile(r"^\s*(?:##BENCH##\s+)?([a-z][\w-]*)((?:\s+[-\d.]+|\s+inf)+)\s*$")
+
+issues = []
+
+
+def report(level, msg):
+    issues.append(level)
+    print(f"{level}: {msg}")
+
+
+def anchor_floor(anchor):
+    key = ANCHOR_KEY[anchor]
+    with open(ANCHORS_YML) as fh:
+        for line in fh:
+            if line.split(":")[0].strip() == key:
+                return float(line.split(":")[1].split("#")[0])
+    sys.exit(f"FAIL: {key} not found in {ANCHORS_YML}")
+
+
+def cmd_preflight(a):
+    area = a.areaX * a.areaY
+    # Mean node degree on a random geometric graph: n * (disk ∩ area) / area.
+    # Cap the disk by the area's short edge (the 1500x300 field is a strip).
+    disk = math.pi * a.range ** 2
+    # In a strip narrower than the disk (the paper's 1500x300 field), a
+    # node's in-range area is ~2r x short-edge, not the full disk.
+    reach = min(disk, 2 * a.range * min(a.areaY, a.areaX), area)
+    degree = (a.nodes - 1) * reach / area
+    print(f"field {a.areaX}x{a.areaY} m, {a.nodes} nodes, range {a.range} m")
+    print(f"  expected mean degree ~{degree:.1f} "
+          f"(connectivity wants >~{math.log(max(a.nodes, 2)):.1f})")
+    if a.range >= max(a.areaX, a.areaY):
+        report("WARN", "range >= long edge — effectively single-hop "
+                       "(fine only for an anchor scenario)")
+    if degree < math.log(max(a.nodes, 2)):
+        report("FAIL", "expected degree below ln(n) — field likely "
+                       "partitioned; results will measure connectivity, "
+                       "not routing")
+    elif degree < 2 * math.log(max(a.nodes, 2)):
+        report("WARN", "expected degree < 2·ln(n) — intermittent partitions "
+                       "likely (sparse regime; intended for the paper field, "
+                       "but don't read absolute PDR as protocol quality)")
+    offered = a.flows * a.pktBytes * 8 * a.pktPerSec  # bps at the app layer
+    frac = offered / (a.rateMbps * 1e6)
+    print(f"  offered load {offered/1000:.1f} kbps = {frac*100:.1f}% of the "
+          f"{a.rateMbps} Mbit/s channel (single collision domain)")
+    if frac > 0.5:
+        report("FAIL", "offered load >50% of channel rate — MAC saturation; "
+                       "every protocol will collapse (#121: don't dispatch)")
+    elif frac > 0.2:
+        report("WARN", "offered load >20% of channel rate — contention-"
+                       "dominated; deltas will mix routing with MAC effects")
+    if a.time < 120:
+        report("WARN", f"time={a.time}s — shorter than the convergence "
+                       "horizon used for the quick CI preset; PDR includes "
+                       "a large startup transient")
+    if a.pause >= a.time:
+        report("WARN", "pause >= sim time — the field is static; that is "
+                       "the sparse-static regime (a known AntHocNet weak "
+                       "spot), not the paper's mobile one")
+    verdict()
+
+
+def parse_results(path):
+    """Yield dicts with proto/pdr/delay/delay99/nrl/jitter (+context) per row."""
+    with open(path) as fh:
+        text = fh.read()
+    first = text.lstrip().splitlines()[0] if text.strip() else ""
+    if first.startswith("kind,") or ",protocol," in first:
+        for r in csv.DictReader(text.splitlines()):
+            yield {"where": f"{r.get('group')}={r.get('x')}",
+                   "proto": r.get("protocol"),
+                   "pdr": r.get("pdr_pct"), "delay": r.get("delay_ms"),
+                   "delay99": r.get("delay99_ms"), "nrl": r.get("nrl"),
+                   "jitter": r.get("jitter_ms")}
+        return
+    for line in text.splitlines():
+        m = ROW.match(line)
+        if not m:
+            continue
+        proto, nums = m.group(1), m.group(2).split()
+        if proto in ("protocol",) or len(nums) < 5:
+            continue
+        row = {"where": os.path.basename(path), "proto": proto,
+               "pdr": nums[0], "delay": nums[1], "delay99": nums[2],
+               "nrl": nums[4]}
+        if len(nums) >= 6:
+            row["jitter"] = nums[5]
+        yield row
+
+
+def cmd_results(a):
+    floor = anchor_floor(a.anchor) if a.anchor else None
+    n = 0
+    for path in a.files:
+        for r in parse_results(path):
+            n += 1
+            tag = f"{r['where']}/{r['proto']}"
+
+            def num(k):
+                try:
+                    return float(r.get(k))
+                except (TypeError, ValueError):
+                    return None
+            pdr, delay, d99 = num("pdr"), num("delay"), num("delay99")
+            nrl, jit = num("nrl"), num("jitter")
+            if pdr is None or not (0.0 <= pdr <= 100.0):
+                report("FAIL", f"{tag}: PDR {r.get('pdr')} outside [0,100]")
+            if delay is not None and d99 is not None and d99 < delay:
+                report("FAIL", f"{tag}: delay99 {d99} < mean delay {delay}")
+            for k, v in (("delay", delay), ("nrl", nrl), ("jitter", jit)):
+                if v is not None and v < 0:
+                    report("FAIL", f"{tag}: negative {k} ({v})")
+            if pdr is not None and pdr == 0.0:
+                report("WARN", f"{tag}: PDR 0 — dead scenario or harness "
+                               "failure (#28 empty-table class)")
+            if floor is not None and r["proto"] == "aodv" and pdr is not None:
+                if pdr < floor:
+                    report("FAIL", f"{tag}: anchor '{a.anchor}' floor "
+                                   f"{floor} violated (AODV PDR {pdr}) — "
+                                   "#51-class harness/channel regression; "
+                                   "do not trust or publish these numbers")
+                else:
+                    print(f"ok: {tag}: anchor '{a.anchor}' floor {floor} "
+                          f"met (AODV PDR {pdr})")
+    if n == 0:
+        report("FAIL", "no result rows parsed from the input")
+    else:
+        print(f"checked {n} rows")
+    verdict()
+
+
+def verdict():
+    fails = issues.count("FAIL")
+    print(f"verdict: {'FAIL' if fails else 'WARN' if issues else 'OK'} "
+          f"({fails} fail, {issues.count('WARN')} warn)")
+    sys.exit(1 if fails else 0)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("preflight")
+    p.add_argument("--nodes", type=int, default=50)
+    p.add_argument("--areaX", type=float, default=1500)
+    p.add_argument("--areaY", type=float, default=300)
+    p.add_argument("--range", type=float, default=300)
+    p.add_argument("--time", type=float, default=300)
+    p.add_argument("--pause", type=float, default=30)
+    p.add_argument("--speed", type=float, default=20)
+    p.add_argument("--flows", type=int, default=20)
+    p.add_argument("--pktBytes", type=int, default=64)
+    p.add_argument("--pktPerSec", type=float, default=1)
+    p.add_argument("--rateMbps", type=float, default=2)
+    r = sub.add_parser("results")
+    r.add_argument("files", nargs="+")
+    r.add_argument("--anchor", choices=sorted(ANCHOR_KEY))
+    args = ap.parse_args()
+    (cmd_preflight if args.cmd == "preflight" else cmd_results)(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/benchmark-results/sweep_summary.py
+++ b/.claude/skills/benchmark-results/sweep_summary.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Validate + summarize classified campaign CSVs (run-scenarios.py schema).
+
+The scenario-matrix / campaign CSVs (docs/benchmarks/campaign/*.csv, or a
+fresh `run-scenarios.py --out` file) are hundreds of cells wide; never load
+them into LLM context to compare by eye. This script does the schema check,
+the per-point AntHocNet-vs-baseline deltas, the stddev-aware noise call, and
+prints a compact grid — the only thing that should reach context.
+
+Usage:
+    sweep_summary.py FILE [FILE ...]              # summarize, anthocnet vs aodv
+    sweep_summary.py --baseline olsr FILE         # different baseline
+    sweep_summary.py --group area FILE            # one sweep/scenario group only
+    sweep_summary.py --export-sweeps out.csv F..  # emit the papers-repo
+                                                  #   sweeps.csv schema
+                                                  #   (sweep,x,proto,pdr,
+                                                  #    delay_ms,delay99_ms)
+
+Verdict per point (same materiality thresholds as bench_parse.py): PDR ±1pp,
+delay99 ±10%, NRL ±10%; a material PDR delta inside 2·RSS(pdr_sd) is tagged
+`~sd` (within run-to-run dispersion — treat as noise, bump --runs).
+"""
+import argparse
+import csv
+import math
+import sys
+
+REQUIRED = ["kind", "group", "x", "protocol", "runs",
+            "pdr_pct", "delay_ms", "delay99_ms", "nrl"]
+
+
+def load(path):
+    with open(path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    if not rows:
+        sys.exit(f"FAIL {path}: empty CSV")
+    missing = [c for c in REQUIRED if c not in rows[0]]
+    if missing:
+        sys.exit(f"FAIL {path}: missing columns {missing} — not a "
+                 f"run-scenarios.py classified CSV")
+    return rows
+
+
+def f(row, col, default=None):
+    v = row.get(col, "")
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def key(row):
+    return (row["kind"], row["group"], f(row, "x", 0.0))
+
+
+def verdict(a, b):
+    """AntHocNet row a vs baseline row b -> (tag, dPDR, d99%, dNRL%)."""
+    dp = f(a, "pdr_pct", 0) - f(b, "pdr_pct", 0)
+    d99 = ((f(a, "delay99_ms", 0) - f(b, "delay99_ms", 0))
+           / f(b, "delay99_ms", 1) * 100 if f(b, "delay99_ms") else 0.0)
+    dn = ((f(a, "nrl", 0) - f(b, "nrl", 0))
+          / f(b, "nrl", 1) * 100 if f(b, "nrl") else 0.0)
+    sig = []
+    if abs(dp) >= 1.0:  sig.append(1 if dp > 0 else -1)
+    if abs(d99) >= 10:  sig.append(1 if d99 < 0 else -1)
+    if abs(dn) >= 10:   sig.append(1 if dn < 0 else -1)
+    if not sig:
+        tag = "NOISE"
+    elif all(s > 0 for s in sig):
+        tag = "BETTER"
+    elif all(s < 0 for s in sig):
+        tag = "WORSE"
+    else:
+        tag = "MIXED"
+    # stddev gate on the PDR delta: material but within joint dispersion?
+    sda, sdb = f(a, "pdr_sd"), f(b, "pdr_sd")
+    if abs(dp) >= 1.0 and sda is not None and sdb is not None:
+        if abs(dp) < 2 * math.hypot(sda, sdb):
+            tag += " ~sd"
+    return tag, dp, d99, dn
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("files", nargs="+")
+    ap.add_argument("--baseline", default="aodv")
+    ap.add_argument("--proto", default="anthocnet")
+    ap.add_argument("--group", help="only this group (e.g. area, pause, scale)")
+    ap.add_argument("--export-sweeps", metavar="OUT",
+                    help="write the papers-repo sweeps.csv schema "
+                         "(sweep rows, anthocnet+baseline only)")
+    args = ap.parse_args()
+
+    cells = {}   # (kind, group, x) -> {protocol: row}
+    for path in args.files:
+        for row in load(path):
+            if args.group and row["group"] != args.group:
+                continue
+            cells.setdefault(key(row), {})[row["protocol"]] = row
+    if not cells:
+        sys.exit("FAIL: no rows matched")
+
+    print(f"{'group':<10}{'x':>8}  {'runs':>4}  "
+          f"{'PDR':>6}{'vs':>7}  {'dPDR':>7}{'d99%':>8}{'dNRL%':>8}  verdict")
+    for k in sorted(cells):
+        kind, group, x = k
+        a = cells[k].get(args.proto)
+        b = cells[k].get(args.baseline)
+        if a is None or b is None:
+            have = ",".join(sorted(cells[k]))
+            print(f"{group:<10}{x:>8g}  -- missing {args.proto}/"
+                  f"{args.baseline} (have: {have})")
+            continue
+        tag, dp, d99, dn = verdict(a, b)
+        print(f"{group:<10}{x:>8g}  {f(a,'runs',0):>4.0f}  "
+              f"{f(a,'pdr_pct',0):>6.1f}{f(b,'pdr_pct',0):>7.1f}  "
+              f"{dp:>+7.1f}{d99:>+8.1f}{dn:>+8.1f}  {tag}")
+
+    if args.export_sweeps:
+        with open(args.export_sweeps, "w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(["sweep", "x", "proto", "pdr", "delay_ms", "delay99_ms"])
+            n = 0
+            for k in sorted(cells):
+                kind, group, x = k
+                if kind != "sweep":
+                    continue
+                for proto in (args.proto, args.baseline):
+                    row = cells[k].get(proto)
+                    if row is None:
+                        continue
+                    w.writerow([group, f"{x:g}", proto,
+                                row["pdr_pct"], row["delay_ms"],
+                                row["delay99_ms"]])
+                    n += 1
+        print(f"exported {n} sweep rows -> {args.export_sweeps}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ CMakeFiles/
 *.tr
 *.nam
 rtable.txt
+
+# Python bytecode (ns3/tools/*.py, .claude/skills/*.py)
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,11 @@ results.
 | Work on the NS-3 adapter | `ns3/model/`, `ns3/helper/`, `ns3/examples/` |
 | Run / read benchmarks | `docs/benchmarks.md`, `ns3/tools/run-scenarios.py` + `make-charts.py`, `anthocnet-compare --diag` |
 | Inspect protocol internals | NS-3 `Tx`/`Rx`/`RouteChanged` trace sources; core counters via `IRouterObserver` |
+| Run the benchmark campaign loop (dispatch → fetch → parse) | `benchmark-results` skill (SKILL.md documents the whole procedure) |
 | Compare benchmark A/B runs (deltas + noise verdict) | `benchmark-results` skill (`.claude/skills/benchmark-results/bench_parse.py`) |
+| Summarize / export campaign sweep CSVs | `benchmark-results` skill (`sweep_summary.py`; `--export-sweeps` feeds the papers repo) |
+| Validate a scenario config or result plausibility | `benchmark-results` skill (`scenario_check.py`, #134): `preflight` before dispatching, `results [--anchor …]` before trusting numbers |
 | Pre-push invariant check on a diff | `protocol-review` skill (`.claude/skills/protocol-review/check_invariants.sh`) |
+| Understand why skills are script-first (and add a new analysis loop) | [ADR-0014](docs/adr/0014-agent-skills-are-script-first.md) — raw data stays out of LLM context; extend a skill script, don't eyeball |
 | Cut a release | run the `Release` workflow (Commitizen); see `CONTRIBUTING.md`. **Post-release the Zenodo DOI is a manual human step** — `zenodo.org` is proxy-blocked (403) and the DOI is minted async after publish, so an agent must ask the maintainer for it (never invent one) then update the README badge + `CITATION.cff` in a `docs:` PR |
 | Tune defaults | `core/include/anthocnet/core/config.h` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,6 +145,11 @@ These were latent in the original NS-2 module and are fixed in `core/`:
   `CHANGELOG.md`, a Commitizen-driven `Release` workflow that builds an
   install-bundle zip (Zenodo-ready); Conventional-Commit PR titles are
   CI-enforced (item 14).
+- **Agent tooling is script-first** (ADR-0014): the `.claude/skills/` scripts
+  do benchmark parsing/A/B noise calls (`bench_parse.py`), campaign-CSV
+  summaries (`sweep_summary.py`), scenario pre-flight + result-plausibility
+  validation (`scenario_check.py`, #134), and diff invariant checks — raw
+  tables and logs stay out of LLM context; only script verdicts are read.
 - **Open work is tracked in GitHub issues** — per-area epics #26–#31 and the
   open defects (#20–#23, #51), prioritized via `priority:P1..P3` labels
   (see §10).

--- a/docs/adr/0014-agent-skills-are-script-first.md
+++ b/docs/adr/0014-agent-skills-are-script-first.md
@@ -1,0 +1,82 @@
+# ADR-0014: Agent skills are script-first — analysis and validation run in scripts, not in LLM context
+
+- **Status:** Accepted — tooling tracked in #134 (scenario validation),
+  consumers in #128 (paired stats), #131 (##PERF## pass-through)
+- **Date:** 2026-07-24
+
+## Context
+
+Much of the recurring agent work in this repo is not code change but *data
+work*: parsing benchmark tables, computing A/B deltas, judging run-to-run
+noise, validating scenario configs and result plausibility, transforming
+campaign CSVs for the papers repo. Done "in context" — the model reading raw
+tables and doing arithmetic in its head — this work is:
+
+1. **Error-prone.** The #47/#68/#71 EnableMacMetric episode showed the exact
+   failure: eyeballed deltas with opposite signs across pairs read as signal
+   when they were noise. A scripted, thresholded verdict does not make that
+   mistake twice.
+2. **Token-expensive.** A classified campaign CSV is ~25 columns × dozens of
+   rows; a CI job log is hundreds of lines. Loading them into context on
+   every session burns budget the CLAUDE.md token-economy policy exists to
+   save — and the numbers themselves must stay byte-exact, which summarising
+   in prose does not guarantee.
+3. **Non-reproducible across sessions.** An in-context judgement leaves no
+   artifact; the next session (any model) re-derives it, possibly
+   differently. ADR-0013 solved this for *findings* (issues); this ADR
+   solves it for *procedures*.
+
+## Decision
+
+Recurring parse/analysis/validation loops ship as **executable scripts inside
+the agent skills** (`.claude/skills/`), and the skill instructions direct the
+model to run the script and read only its compact output. Rules:
+
+1. **Raw data stays out of context.** Job-log tails and CSVs are saved to
+   files and handed to scripts; only verdict lines (a delta grid, a
+   FAIL/WARN/OK summary) should be read back. Never eyeball tables, compute
+   deltas by hand, or hand-type result numbers.
+2. **Scripts are stdlib-only Python** (or POSIX shell), runnable in any
+   sandbox with no installs, and are **validated against real repo data**
+   before landing (e.g. the rescued #122 campaign CSVs, the committed
+   `##BENCH##` formats).
+3. **Thresholds live in one place.** Scripts read shared threshold files
+   (e.g. `ns3/tools/anchors.yml`, #59) rather than duplicating constants
+   that would drift.
+4. **New recurring analysis extends a script** rather than being performed
+   in context; one-off exploration is fine in context but graduates to a
+   script the second time it recurs.
+
+Current inventory:
+
+| Script | Skill | Job |
+|---|---|---|
+| `bench_parse.py` | `benchmark-results` | parse `##BENCH##` cells, A/B deltas, noise verdict |
+| `sweep_summary.py` | `benchmark-results` | campaign-CSV schema check, per-point deltas, stddev-aware noise call, papers export |
+| `scenario_check.py` | `benchmark-results` | pre-flight scenario degeneracy checks; result plausibility + anchor floors (#134) |
+| `check_invariants.sh` | `protocol-review` | golden-rule checks on a diff |
+| `figdata.py` | `figures` (papers repo) | campaign CSV / `##BENCH##` → paper plot data, diff report, preliminary-flag audit |
+
+## Alternatives considered
+
+- **Keep procedures in prose (SKILL.md/issue notes only).** The procedure
+  survives, but the arithmetic still happens in context — the #47-class
+  errors and the token cost remain. Rejected.
+- **A single monolithic CLI tool in `tools/`.** Couples agent workflow
+  tooling to the shipped software; skills keep agent-facing tooling
+  discoverable at the point of use and out of release artifacts. Rejected.
+- **CI-only enforcement (no local scripts).** CI gates (e.g. #59 anchors)
+  catch regressions post-push but cannot do pre-flight checks before an
+  expensive dispatch (#121) or ad-hoc A/B analysis mid-session. The two are
+  complementary; CI enforcement alone is insufficient.
+
+## Consequences
+
+- Session context spends tokens on decisions, not on tables; verdicts are
+  identical across sessions and models.
+- The scripts are themselves code: they need the same review care, and their
+  formats (e.g. `##BENCH##`, the classified CSV schema) become interfaces —
+  a harness output change must update the parsers in the same PR.
+- The papers repo participates via its `figures` skill (`figdata.py`), so
+  numbers cross the repo boundary only through validated transforms
+  (papers-repo golden rules 1–3), never by hand.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -212,7 +212,11 @@ floor (PDR ≥ 85, vs. ≈ 92.5 measured, ~90 literature) run in `benchmarks.yml
 *before* the results table/charts are regenerated — a regressed anchor fails the
 workflow and blocks the publish step, so a #51-style channel/config regression can
 no longer silently corrupt the published numbers. Recalibration is a one-line
-edit to `anchors.yml`.
+edit to `anchors.yml`. For ad-hoc runs outside CI, the same floors (plus
+result-plausibility invariants and pre-dispatch scenario sanity checks) are
+enforced locally by
+[`.claude/skills/benchmark-results/scenario_check.py`](../.claude/skills/benchmark-results/scenario_check.py)
+(#134), which reads `anchors.yml` rather than duplicating it.
 
 **Determinism anchor ([#129](https://github.com/danieljoppi/AntHocNet/issues/129)).**
 One further anchor's expected result is not a number but *identity*: golden


### PR DESCRIPTION
Lands the agent-tooling work that has been referenced all session but never reached `main` — including the code behind #134, which I closed prematurely (see below).

## What

**`benchmark-results` skill — the full campaign loop.** The dispatch → fetch → parse procedure lived only in issue #91's session notes, so every cold session re-derived it. SKILL.md now documents it end to end: `actions_run_trigger` dispatch, cheap `get_job_logs` tail fetch (`##BENCH##` block; `commit=true`/`rescue-artifacts` for CSVs, since artifact downloads are proxy-blocked), script-only parsing, ADR-0013 recording.

**`sweep_summary.py` (new).** Classified campaign CSVs (`run-scenarios.py` schema, ~25 columns × dozens of rows) had no parser, inviting in-context eyeballing. Does schema validation, per-point anthocnet-vs-baseline deltas (`dPDR`/`d99%`/`dNRL%`), and a stddev-aware noise call (`~sd` = material PDR delta inside 2·RSS(`pdr_sd`)), printing one compact line per point. `--export-sweeps` emits the papers repo's `plots/data/sweeps.csv` schema.

**`scenario_check.py` (new, #134).** Two failure classes that cost dispatch cycles or corrupt conclusions:
- `preflight` — expected mean node degree (strip-geometry aware) vs the ln(n) connectivity threshold, offered load vs the pinned 2 Mbit/s channel (#84), `range ≥ area` single-hop degeneracy, short-sim/static warnings. Exits 1 on FAIL.
- `results` — plausibility invariants on `##BENCH##` cells or campaign CSVs (PDR ∈ [0,100], delay99 ≥ mean, negative metrics, dead cells #28), and with `--anchor` the AODV floors read live from `ns3/tools/anchors.yml` (#59 stays the single threshold source).

**ADR-0014 — agent skills are script-first.** Records why: the #47/#68/#71 eyeballing trap, token economy per CLAUDE.md, and cross-session reproducibility (ADR-0013 solved this for *findings*; this does it for *procedures*). Rules: raw data stays out of context, stdlib-only scripts validated against real repo data, thresholds in one place. AGENTS.md where-to-look rows, CONTEXT.md §7, and the `docs/benchmarks.md` anchors section point at the tooling.

## Validation (re-run after rebasing onto today's `main`)

- `scenario_check.py results` on the rescued #122 campaign CSVs: 40 rows, `verdict: OK`.
- `preflight` on the paper base → OK; on `areaX=2500 --flows=40 --pktPerSec=20 --time=60` → contention + transient WARNs; on the 2-node #59 anchor shape → the intended single-hop/static WARNs.
- Crafted bad cell (delay99 < mean delay, negative NRL) → FAIL, exit 1; AODV PDR 62.0 vs the `broch-low-mobility` floor 85.0 → FAIL, exit 1.
- `py_compile` on all skill scripts; `ruff check ns3/tools` clean.

## Note on #134

I marked #134 completed on the strength of a commit whose branch was never merged, so the issue was closed while its code sat off `main`. Reopening it is unnecessary — merging this PR makes the closure true — but flagging it explicitly rather than letting it pass silently.

Rebased onto `main` after today's merges (#128–#133, #123, #125, #158); the docs edits sit alongside the build-profile, sanitizer and `nrl_bytes` sections added by those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_