### PR TITLE
feat(core): add an ILinkMetric registry mapping metric names to instances (#143)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(anthocnet_core STATIC
   src/ant_history.cpp
   src/ant_message_codec.cpp
   src/ant_router_logic.cpp
+  src/link_metric_registry.cpp
 )
 target_include_directories(anthocnet_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/core/include/anthocnet/core/link_metric_registry.h
+++ b/core/include/anthocnet/core/link_metric_registry.h
@@ -1,0 +1,77 @@
+/**
+ * Name -> ILinkMetric registry (issue #143, epic #142).
+ *
+ * The ILinkMetric seam exists but is unreachable: both adapters pass nullptr,
+ * so ClassicMetric is the only formula that can ever run. Selecting a metric
+ * needs a name -> instance mapping, and that mapping belongs in the core rather
+ * than in each adapter — otherwise NS-2 and NS-3 grow two switch statements
+ * that can disagree about what a name means.
+ *
+ * Ownership / lifetime
+ * --------------------
+ * Lookup hands back a NON-OWNING pointer/reference to a function-local static
+ * instance, one per registered name, alive for the whole process. The caller
+ * must not delete it and must not assume any per-node state.
+ *
+ * This is safe because a metric is a stateless strategy object: pheromone() is
+ * const and reads only the LinkObservation it is handed, so a single instance
+ * is shared by every node in a simulation without interference. It is also the
+ * shape AntRouterLogic already wants — its constructor takes a bare
+ * `const ILinkMetric*` and stores it without owning it, so a registry pointer
+ * drops straight in and can never dangle. Handing out unique_ptr/shared_ptr
+ * instead would push an ownership refactor through AntRouterLogic and both
+ * adapters, buying nothing for an object that holds no state.
+ *
+ * Defaults and failure
+ * --------------------
+ * The default path does not go through here at all: with no explicit
+ * selection, AntRouterLogic still falls back to its own ClassicMetric and
+ * behaviour is byte-identical to before this file existed. An unknown name is
+ * a loud error — never a quiet fall back to "classic" — because a mistyped
+ * metric would otherwise produce plausible-looking results from the wrong
+ * protocol.
+ */
+#ifndef ANTHOCNET_CORE_LINK_METRIC_REGISTRY_H
+#define ANTHOCNET_CORE_LINK_METRIC_REGISTRY_H
+
+#include <string>
+
+#include "anthocnet/core/link_metric.h"
+
+namespace anthocnet {
+namespace core {
+namespace metrics {
+
+/// Registry name of the canonical AntHocNet metric (Eq.2, ClassicMetric).
+/// This is the protocol default; the name is part of the adapter-facing
+/// configuration surface, so it is stable.
+constexpr char kClassic[] = "classic";
+
+/// Every registered name, comma-separated — for diagnostics and for the
+/// adapters' "valid values" help text (child #144).
+std::string registeredNames();
+
+/// Look up `name`; returns nullptr when it is not registered.
+///
+/// The non-throwing probe, for callers that prefer to raise the failure with
+/// their own simulator's fatal-error mechanism. It never substitutes
+/// ClassicMetric for an unknown name. Note that forwarding a nullptr on to
+/// AntRouterLogic *would* silently mean "classic", so the null case must be
+/// handled here, not passed along.
+const ILinkMetric* find(const std::string& name);
+
+/// Look up `name`, or throw std::invalid_argument naming the offending value
+/// and the registered alternatives. Use this on configuration paths that must
+/// not proceed on a typo.
+///
+/// The rest of the core is exception-free by convention (the codec reports
+/// malformed input with a bool because it runs per packet on untrusted bytes).
+/// This is one-shot configuration, not a hot path, and it must be impossible
+/// to ignore — hence the throw.
+const ILinkMetric& get(const std::string& name);
+
+} // namespace metrics
+} // namespace core
+} // namespace anthocnet
+
+#endif // ANTHOCNET_CORE_LINK_METRIC_REGISTRY_H

--- a/core/src/link_metric_registry.cpp
+++ b/core/src/link_metric_registry.cpp
@@ -1,0 +1,63 @@
+#include "anthocnet/core/link_metric_registry.h"
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace anthocnet {
+namespace core {
+namespace metrics {
+namespace {
+
+struct Entry {
+    const char*        name;
+    const ILinkMetric* metric;
+};
+
+/// The registry itself: a fixed table built on first use.
+///
+/// Function-local statics give one immutable instance per name, constructed
+/// lazily (so there is no static-initialisation-order dependency between
+/// translation units) and destroyed only at process exit — which is what makes
+/// the non-owning pointers handed to AntRouterLogic safe for the lifetime of a
+/// simulation. Registration is a compile-time table rather than a runtime
+/// register() call because every metric lives in core/ anyway; adding one
+/// (#145, #146) is one include plus one line here.
+const std::vector<Entry>& table() {
+    static const ClassicMetric classic;
+    static const std::vector<Entry> entries = {
+        {kClassic, &classic},
+    };
+    return entries;
+}
+
+}  // namespace
+
+std::string registeredNames() {
+    std::string out;
+    for (std::size_t i = 0; i < table().size(); ++i) {
+        if (i != 0) out += ", ";
+        out += table()[i].name;
+    }
+    return out;
+}
+
+const ILinkMetric* find(const std::string& name) {
+    for (std::size_t i = 0; i < table().size(); ++i) {
+        if (name == table()[i].name) return table()[i].metric;
+    }
+    return nullptr;  // unknown: never fall back to ClassicMetric
+}
+
+const ILinkMetric& get(const std::string& name) {
+    const ILinkMetric* metric = find(name);
+    if (metric == nullptr) {
+        throw std::invalid_argument("anthocnet: unknown link metric \"" + name +
+                                    "\" (registered: " + registeredNames() + ")");
+    }
+    return *metric;
+}
+
+}  // namespace metrics
+}  // namespace core
+}  // namespace anthocnet

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(ANTHOCNET_TESTS
   test_evaporation_backoff
   test_data_routing
   test_link_metric
+  test_link_metric_registry
   test_mac_metric
   test_properties
   test_observability

--- a/core/tests/test_link_metric_registry.cpp
+++ b/core/tests/test_link_metric_registry.cpp
@@ -1,0 +1,92 @@
+// Issue #143 — the name -> ILinkMetric registry. A known name resolves to the
+// right instance, the same stable non-owning instance every time; an unknown
+// name is a loud error rather than a quiet fall back to classic; and the
+// default routing path is unaffected (no selection still means ClassicMetric,
+// bit-for-bit).
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "anthocnet/core/ant_router_logic.h"
+#include "anthocnet/core/link_metric_registry.h"
+#include "test_support.h"
+
+using namespace anthocnet::core;
+using anthocnet::test::FakeClock;
+using anthocnet::test::ScriptedRng;
+
+namespace {
+
+// Pheromone a back ant would deposit for a retraced path, via the router's
+// metric (same shape as test_link_metric.cpp).
+double walk(AntRouterLogic& r, const std::vector<double>& deltas) {
+    AntMessage b;
+    b.direction = AntDirection::Down;
+    b.src = 5;
+    for (std::size_t i = 0; i < deltas.size(); ++i) {
+        b.history.push_back({static_cast<NodeAddress>(i + 1), deltas[i]});
+    }
+    return r.backAntPheromone(b);
+}
+
+}  // namespace
+
+int main() {
+    // 1. The canonical metric is registered under a stable name, and the name
+    //    is exactly "classic" (it is adapter-facing configuration).
+    CHECK(std::string(metrics::kClassic) == "classic");
+    const ILinkMetric* classic = metrics::find(metrics::kClassic);
+    CHECK(classic != nullptr);
+    CHECK(dynamic_cast<const ClassicMetric*>(classic) != nullptr);
+
+    // ...and it computes the Eq.2 formula, not merely some ILinkMetric.
+    LinkObservation o;
+    o.hops = 3;
+    o.pathTime = 0.15;
+    o.hopTime = 0.05;
+    if (classic != nullptr) {
+        CHECK_NEAR(classic->pheromone(o), ClassicMetric().pheromone(o), 1e-12);
+        CHECK_NEAR(classic->pheromone(o), std::pow((0.15 + 3 * 0.05) / 2.0, -1.0), 1e-12);
+    }
+
+    // 2. Lookup is stable: every caller gets the same process-lifetime instance,
+    //    which is what makes the non-owning raw pointer safe to hand to
+    //    AntRouterLogic (and both accessors agree).
+    CHECK(metrics::find("classic") == classic);
+    CHECK(&metrics::get("classic") == classic);
+
+    // 3. An unknown name is a loud error, never a silent ClassicMetric.
+    CHECK(metrics::find("no-such-metric") == nullptr);
+    CHECK(metrics::find("") == nullptr);
+    CHECK(metrics::find("Classic") == nullptr);  // lookup is case-sensitive
+
+    bool threw = false;
+    try {
+        metrics::get("no-such-metric");
+        CHECK(false);  // must not reach here
+    } catch (const std::invalid_argument& e) {
+        threw = true;
+        const std::string what = e.what();
+        // The message names the offending value and the valid alternatives.
+        CHECK(what.find("no-such-metric") != std::string::npos);
+        CHECK(what.find("classic") != std::string::npos);
+    }
+    CHECK(threw);
+
+    CHECK(metrics::registeredNames().find("classic") != std::string::npos);
+
+    // 4. Default path unchanged: a router with no metric injected behaves
+    //    exactly like one handed the registry's "classic".
+    FakeClock clock;
+    ScriptedRng rng({0.5});
+    Config cfg;
+    const std::vector<double> path = {0.05, 0.05, 0.05};  // hops=3, pathTime=0.15
+
+    AntRouterLogic byDefault(/*addr*/ 0, cfg, clock, rng);
+    AntRouterLogic selected(/*addr*/ 0, cfg, clock, rng, metrics::find(metrics::kClassic));
+    CHECK_NEAR(walk(byDefault, path), walk(selected, path), 1e-12);
+    CHECK_NEAR(walk(byDefault, path), std::pow((0.15 + 3 * 0.05) / 2.0, -1.0), 1e-12);
+
+    return RUN_TESTS();
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,21 @@ adapters never reimplement routing logic.
   counter. It is pure: `onReceiveAnt()` / `onDataPacket()` return
   `RouteDecision`s; they never touch a simulator.
 
+### Pluggable link metrics
+
+- **`ILinkMetric`** — the strategy that turns a backward ant's `LinkObservation`
+  into a pheromone value. `ClassicMetric` is the canonical Eq.2 formula and the
+  default; a metric is pure (const, observation-only), so it never reaches for
+  the simulator, clock, or RNG.
+- **`metrics::find` / `metrics::get`** (`link_metric_registry.h`) — the shared
+  name → instance mapping both adapters resolve through, so `"classic"` means
+  the same thing on NS-2 and NS-3. Lookup returns a **non-owning** pointer to a
+  process-lifetime instance (metrics are stateless, so one instance is shared by
+  every node, and `AntRouterLogic`'s raw `const ILinkMetric*` can never dangle).
+  An unknown name is an error — `find` returns `nullptr`, `get` throws — never a
+  silent fall back to classic. With no selection at all nothing consults the
+  registry and `AntRouterLogic` uses `ClassicMetric` as before.
+
 ### Ports
 
 The adapters implement these so the core stays I/O-free:


### PR DESCRIPTION
Implements #143, child 1 of epic #142. Item 16 added the `ILinkMetric` port and `ClassicMetric`, but the seam was unreachable — both adapters pass `nullptr`. This lands the shared selection mechanism **before** either adapter touches it, so #144 has one place to resolve names.

## API

Namespace `anthocnet::core::metrics`:

- `kClassic` = `"classic"` → `ClassicMetric`
- `find(name)` — non-throwing probe, `nullptr` for an unknown name
- `get(name)` — throws `std::invalid_argument`, naming the bad value **and** the registered alternatives
- `registeredNames()` — for diagnostics and the adapters' help text in #144

## Ownership decision

Lookup returns a **non-owning** pointer to a function-local static, one instance per name, alive for the process:

- a metric is a stateless strategy (`pheromone()` is `const`, reads only the `LinkObservation`), so one instance is safely shared by every node;
- it matches what `AntRouterLogic` already wants — a bare `const ILinkMetric*` stored non-owning — so it cannot dangle;
- function-local statics avoid static-init-order problems across translation units.

Explicitly **not** a `unique_ptr`/`shared_ptr` factory: that would push an ownership refactor through `AntRouterLogic` and both adapters for no benefit (CLAUDE.md — surgical, nothing speculative). The rationale is in the header, not just this PR.

## Loud errors, never a silent fallback

`find` returns `nullptr` with a documented rule that it must be handled, never forwarded — forwarding `nullptr` to `AntRouterLogic` *is* classic, which is exactly the silent fallback the issue forbids. `get` throws. The header records why this spot uses an exception while the codec returns `bool`: one-shot configuration versus per-packet untrusted input.

## Validation

- `make test` → **19/19 pass** (was 18), clean rebuild, no `-Wall -Wextra` warnings.
- `check_invariants.sh` → PASS on no-NS-headers-in-core, core change carries a core test, mechanical invariants.
- **Negative control**: renaming the registered entry makes the new test fail — so the test isn't vacuous.

## Scope held

No adapter file touched (#144), no new metric (#145/#146). Default behaviour is unchanged: nothing consults the registry unless something explicitly selects a metric, so existing benchmark numbers are unaffected by construction.

Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_