### PR TITLE
ci(core): measure and report core test coverage on every PR (#162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,63 @@ jobs:
           cmake --build core/build-san -j
           cd core/build-san && ctest --output-on-failure
 
+  core-coverage:
+    name: core test coverage (gcov, report-only)
+    runs-on: ubuntu-latest
+    # Which parts of core/ do the 18 ctest targets actually execute? The repo's
+    # expensive failures (D2 evaporation, the #19 detector-D storm, the 8-bit
+    # sequence wrap) were all behaviour in paths nothing exercised, so make that
+    # answerable instead of intuited — and use it to aim new tests.
+    #
+    # Report-only on purpose (#162): there is deliberately **no --fail-under**
+    # threshold here. Coverage is a map of untested paths, not a target; a floor
+    # chosen before a baseline exists is either meaningless or an obstacle that
+    # gets disabled the first time it bites. Observe the number across a few
+    # merges, then pick a floor from evidence in a follow-up.
+    #
+    # No container/simulator: core/ builds standalone in seconds (golden rule 1).
+    # Adapter coverage would mean instrumenting a containerized ns-3 build and is
+    # out of scope.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install toolchain
+        # gcovr is pinned so the reported baseline stays comparable across
+        # merges — its per-version gcov parsing shifts the numbers. Bump
+        # deliberately, noting the step change in the PR.
+        run: |
+          sudo apt-get update && sudo apt-get install -y cmake g++
+          pip install 'gcovr==8.6'
+      - name: Build core with gcov instrumentation
+        run: |
+          cmake -S core -B core/build-coverage -DCMAKE_BUILD_TYPE=Debug \
+            -DANTHOCNET_COVERAGE=ON
+          cmake --build core/build-coverage -j
+      - name: Run the unit tests (emits the .gcda counters)
+        run: cd core/build-coverage && ctest --output-on-failure
+      - name: Report coverage of core/src + core/include
+        # --exclude drops core/tests/ so the number measures coverage *of* the
+        # core, not of the tests (which are ~100% by construction and would
+        # dilute it). --txt gives the per-file table, --print-summary the overall
+        # line/function/branch totals; both land in the job log, and the drill-
+        # down HTML + Cobertura XML go to the artifact below.
+        run: |
+          mkdir -p coverage
+          gcovr --root . core/build-coverage \
+            --filter 'core/src/' --filter 'core/include/' \
+            --exclude 'core/tests/' \
+            --txt --print-summary \
+            --html-details coverage/index.html \
+            --xml-pretty --xml coverage/coverage.xml
+      - name: Upload the detailed report (HTML + Cobertura XML)
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-coverage-report
+          path: coverage/
+          retention-days: 14
+
   codec-fuzz:
     name: codec fuzz (libFuzzer, 60s)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,17 @@
 # Build directories
 build/
 core/build/
+core/build-*/
 ns3/build/
 *.cmake
 CMakeCache.txt
 CMakeFiles/
+
+# Coverage output (gcov counters + gcovr reports)
+coverage/
+*.gcda
+*.gcno
+*.gcov
 
 # Simulator trace output
 *.tr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,24 @@ make install-ns3  NS3DIR=/path/to/ns-3-dev # install onto a real NS-3 tree
 make clean                                 # remove core/build
 ```
 
+### Test coverage
+
+`core/` has an opt-in gcov build (default build is untouched):
+
+```bash
+cmake -S core -B core/build-coverage -DCMAKE_BUILD_TYPE=Debug -DANTHOCNET_COVERAGE=ON
+cmake --build core/build-coverage -j
+cd core/build-coverage && ctest --output-on-failure && cd -
+gcovr --root . core/build-coverage --filter 'core/src/' --filter 'core/include/' \
+      --exclude 'core/tests/' --txt --print-summary   # pip install gcovr
+```
+
+CI's `core-coverage` job reports the same line/branch numbers **on every PR**
+(per-file table in the job log, HTML + Cobertura XML as a downloadable
+artifact). It is **report-only — there is no threshold** ([#162](https://github.com/danieljoppi/AntHocNet/issues/162)); a floor gets
+chosen from evidence later. Read it as a map of untested paths to aim tests at,
+not as a number to chase (CLAUDE.md rule 2).
+
 `make test` and the NS-2 patch self-test are the two checks that run in CI
 (`.github/workflows/ci.yml`) on every push/PR and are runnable here. An actual
 NS-2/NS-3 build needs an external simulator tree and is **not** possible from

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -12,6 +12,22 @@ endif()
 
 add_compile_options(-Wall -Wextra)
 
+# Optional gcov instrumentation for coverage reporting (#162). Off by default so
+# the normal build/test is bit-for-bit unchanged; CI's `core-coverage` job turns
+# it on and post-processes the .gcda/.gcno with gcovr. Applies to the library and
+# to everything under tests/ (both need instrumenting to link):
+#   cmake -S core -B core/build-coverage -DANTHOCNET_COVERAGE=ON
+option(ANTHOCNET_COVERAGE "Build with gcov instrumentation (gcc/clang)" OFF)
+if(ANTHOCNET_COVERAGE)
+  # -O0 keeps line/branch attribution honest (inlining smears it); the options
+  # are appended after CMAKE_CXX_FLAGS_<CONFIG>, so this wins over Release's -O3.
+  add_compile_options(--coverage -O0 -g)
+  # add_link_options() needs CMake 3.13 and this project declares 3.10;
+  # link_libraries() is directory-scoped, propagates into tests/, and CMake
+  # passes a leading-dash entry through to the link line verbatim.
+  link_libraries(--coverage)
+endif()
+
 add_library(anthocnet_core STATIC
   src/pheromone_table.cpp
   src/pheromone_engine.cpp


### PR DESCRIPTION
Implements #162. `core/` had 18 test targets running on every PR — but nothing reported *which* parts of `core/` they execute, so blind spots were invisible.

## What

- **`core/CMakeLists.txt`**: opt-in `option(ANTHOCNET_COVERAGE ... OFF)` adding `--coverage -O0 -g`. Uses `link_libraries()` rather than `add_link_options()` because the project declares `cmake_minimum_required(3.10)` and `add_link_options()` needs 3.13.
- **`ci.yml`**: new `core-coverage` job (plain ubuntu-latest, no container — `core/` builds standalone in seconds). `gcovr==8.6` pinned, matching lint.yml's pinned-tool pattern *(the lesson from today's unpinned-ruff breakage)*. Per-file table + summary to the log; HTML/Cobertura to the `core-coverage-report` artifact. `--exclude 'core/tests/'` so the number measures `core/src`+`include`, not the tests themselves.
- **No `--fail-under`.** Report-only by design (#162 item 3) — pick a floor from evidence later.
- **`AGENTS.md`**: "Test coverage" subsection; **`.gitignore`**: coverage artifacts.

## Measured baseline (gcc 13.3.0, gcovr 8.6, 18/18 passing)

```
lines:     95.3%  (691 / 725)
functions: 92.7%  (102 / 110)
branches:  59.6%  (573 / 962)
```

| file | lines | branches |
|---|---|---|
| `ports.h` | 57.1% (4/7) | – |
| `ant_history.cpp` | 74.4% (29/39) | 61.1% (22/36) |
| `pheromone_engine.cpp` | 93.6% (73/78) | 61.3% (65/106) |
| `pheromone_table.cpp` | 96.0% (96/100) | 77.2% (71/92) |
| `ant_router_logic.cpp` | 97.0% (354/365) | **53.7% (335/624)** |
| `ant_message_codec.cpp` | 99.1% (107/108) | 78.0% (78/100) |

**Lines are already strong; branches are where the map is worth reading.** `ant_router_logic.cpp` at 53.7% of 624 branches is the obvious target for #155's trend tests — which is exactly what this job exists to tell us.

## Two concrete gaps it surfaced

1. **`GenerationTracker`'s `maxEntries_` eviction body (`ant_history.cpp:43-44`) never executes** — the bounded-history invariant of **golden rule 5** has no test that actually drives an eviction. Filed as its own ticket.
2. `pheromone_engine.cpp:84` (virtual-pheromone evaporation write) is unhit.

The rest of the misses are unexercised public API (`seen()`, `clear()`, `reinforce()`) and the default no-op `IRouterObserver` hooks. **No tests were added to move the number** (CLAUDE.md rule 2) — coverage is a map, not a target.

## Verification

- **Default build byte-identical**: diffed `compile_commands.json` and every `link.txt` before/after — zero delta, zero `--coverage` occurrences.
- `make test` (default): 18/18 pass, 0.07 s. Coverage build: 18/18 pass under instrumentation, report reproduced from clean.
- `ci.yml` parses; jobs: core, core-sanitizers, **core-coverage**, codec-fuzz, ns2-patch, ns2-compile, ns3-build, ns3-asan.
- `git status` before commit showed only the 4 intended files; all build dirs / `.gcda` / `.gcno` / HTML removed.

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_