### PR TITLE
fix(core): adopt T_hop = 3 ms from the 2007 thesis, replacing the provisional 50 ms (#88)

### DIFF
--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -33,7 +33,11 @@ struct Config {
     /// Per-hop time estimate used by the back-ant pheromone formula (Eq.2):
     /// the time to take one hop in unloaded conditions. In seconds, matching
     /// IClock, so it is comparable in magnitude to the measured path time.
-    double hopTimeSec = 0.05;  ///< HOP_TIME (50 ms)
+    /// Value from the primary source (#88): Ducatelle, *Adaptive Routing in Ad
+    /// Hoc Wireless Multi-hop Networks*, PhD thesis, USI Lugano, 2007 — "we
+    /// kept thop on 0.003 sec". [1] (PPSN 2004) defines the constant but gives
+    /// no number, which is why this was a provisional 50 ms until 2026-07-25.
+    double hopTimeSec = 0.003;  ///< T_hop = 3 ms (2007 thesis)
 
     /// Congestion-aware per-hop cost (item 10/A2, [1] §3.2): when on and an
     /// ILinkState is injected, a forward ant records each node's expected

--- a/core/tests/test_backant_metric.cpp
+++ b/core/tests/test_backant_metric.cpp
@@ -31,8 +31,16 @@ double fullPathPheromone(AntRouterLogic& router, const std::vector<double>& delt
 int main() {
     FakeClock clock;
     ScriptedRng rng({0.5});
-    Config cfg;  // hopTimeSec = 0.05
+    Config cfg;  // hopTimeSec = T_hop default (3 ms, 2007 thesis, #88)
     AntRouterLogic router(/*address*/ 0, cfg, clock, rng);
+
+    // 0. T_hop default is the value from the primary source (#88): Ducatelle,
+    //    PhD thesis, USI Lugano 2007 — "we kept thop on 0.003 sec". [1] (PPSN
+    //    2004) defines the constant but states no number, so this was a
+    //    provisional 50 ms until the thesis was checked. Pinned here because
+    //    it scales every pheromone deposit: a silent edit changes all routing
+    //    goodness values at once.
+    CHECK_NEAR(Config{}.hopTimeSec, 0.003, 1e-12);
 
     // 1. Time influences pheromone: equal hop count, different per-hop times ->
     //    the faster path earns strictly higher pheromone. (Pre-fix they tied,
@@ -42,11 +50,15 @@ int main() {
     CHECK(fast > slow);
 
     // 2. Units sane: a 3-hop path at ~50 ms/hop yields tau^-1 in a plausible
-    //    seconds band (not ~1e-4). tau = ((3*0.05 + 0.15)/2)^-1 -> tau^-1 = 0.15.
+    //    seconds band (not ~1e-4). Expected value is derived from the config's
+    //    T_hop rather than a literal, so changing the default (#88 moved it
+    //    from 50 ms to the thesis's 3 ms) cannot break this check spuriously:
+    //    tau^-1 = (measured + h*hopTimeSec)/2.
     const double tau = fullPathPheromone(router, {0.05, 0.05, 0.05});
-    CHECK(1.0 / tau > 0.05);
+    const double expected = (0.15 + 3 * cfg.hopTimeSec) / 2.0;
+    CHECK(1.0 / tau > 0.01);
     CHECK(1.0 / tau < 0.5);
-    CHECK_NEAR(1.0 / tau, 0.15, 1e-9);
+    CHECK_NEAR(1.0 / tau, expected, 1e-9);
 
     // 3. Hop term still present: with ~zero measured time, tau ~= (h*hopTimeSec/2)^-1.
     const double tauHopOnly = fullPathPheromone(router, {1e-9, 1e-9, 1e-9});

--- a/core/tests/test_link_metric.cpp
+++ b/core/tests/test_link_metric.cpp
@@ -40,8 +40,8 @@ int main() {
     LinkObservation o;
     o.hops = 3;
     o.pathTime = 0.15;
-    o.hopTime = 0.05;
-    CHECK_NEAR(classic.pheromone(o), std::pow((0.15 + 3 * 0.05) / 2.0, -1.0), 1e-12);
+    o.hopTime = 0.05;  // explicit observation value, not the Config default
+    CHECK_NEAR(classic.pheromone(o), std::pow((0.15 + 3 * o.hopTime) / 2.0, -1.0), 1e-12);
 
     FakeClock clock;
     ScriptedRng rng({0.5});
@@ -52,7 +52,8 @@ int main() {
     {
         AntRouterLogic r(/*addr*/ 0, cfg, clock, rng);
         const double ph = walk(r, {0.05, 0.05, 0.05});  // hops=3, pathTime=0.15
-        CHECK_NEAR(ph, std::pow((0.15 + 3 * 0.05) / 2.0, -1.0), 1e-12);
+        // T_hop comes from the Config default (#88), not a literal.
+        CHECK_NEAR(ph, std::pow((0.15 + 3 * cfg.hopTimeSec) / 2.0, -1.0), 1e-12);
     }
 
     // 3. A custom metric changes the deposit, with no edit to the state machine.

--- a/core/tests/test_link_metric_registry.cpp
+++ b/core/tests/test_link_metric_registry.cpp
@@ -86,7 +86,8 @@ int main() {
     AntRouterLogic byDefault(/*addr*/ 0, cfg, clock, rng);
     AntRouterLogic selected(/*addr*/ 0, cfg, clock, rng, metrics::find(metrics::kClassic));
     CHECK_NEAR(walk(byDefault, path), walk(selected, path), 1e-12);
-    CHECK_NEAR(walk(byDefault, path), std::pow((0.15 + 3 * 0.05) / 2.0, -1.0), 1e-12);
+    // T_hop from the Config default (#88), not a literal.
+    CHECK_NEAR(walk(byDefault, path), std::pow((0.15 + 3 * cfg.hopTimeSec) / 2.0, -1.0), 1e-12);
 
     return RUN_TESTS();
 }

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -47,12 +47,19 @@ Every pinned-down parameter and its match/deviation status is tabulated in the
    after the multipath (#96), backward-ant flush (#101) and reconv hold-cap
    (#104) work. On **two-ray** — the paper's actual PHY — the gap closes to
    parity on mean delay. The residual is a **channel-model artefact**
-   (CONTEXT.md §8), compounded by the unverified `T_hop` (see 2), not an
-   algorithmic gap. Mitigated by `ReconvHoldCap=1.0 s` (default).
-2. **`T_hop` value unverified (#88).** [1] gives no numeric `T_hop`; the repo
-   uses a provisional 50 ms. A sweep suggests a few-ms value would cut
-   delay/jitter ~12 %. Pending the **2007 Ducatelle thesis** (the designated
-   primary source; #58/#88/#89 track the remaining thesis cross-checks).
+   (CONTEXT.md §8), not an algorithmic gap. Mitigated by `ReconvHoldCap=1.0 s`
+   (default). **Note (2026-07-25):** the `T_hop` co-lever named in item 2 has
+   now been corrected to the thesis value; the benchmark impact on this tail is
+   pending a re-run (#88).
+2. **`T_hop` — resolved from the primary source (#88, 2026-07-25).** [1] defines
+   the constant but states no number. The **2007 Ducatelle thesis** does: *"we
+   kept thop on 0.003 sec"*. The repo's provisional **50 ms was 16.7× too
+   large** and is now corrected to **3 ms**. Because `T_hop` weights hop count
+   against measured delay in every pheromone deposit, this changes all routing
+   goodness values — **every benchmark number in this document predates the fix
+   and must be re-measured** before being cited as current. A prior sweep
+   suggested a few-ms value cuts delay/jitter ~12 %, so the #21 delay tail may
+   improve.
 3. **Evaporation** (`enableEvaporation`, default on; ADR-0012) — a time-decay
    safety net **not present in [1]** (whose reinforcement is a pure running
    average). Config-gated so the paper-faithful ablation is available.
@@ -71,8 +78,10 @@ Every pinned-down parameter and its match/deviation status is tabulated in the
 - **Algorithm mechanisms**: ✅ covered by `core/tests` (unit + randomized
   property/invariant sweeps), NS-2/NS-3 e2e delivery smokes in CI.
 - **Parameters vs [1] (2004 paper)**: ✅ verified — see the digest table.
-- **Parameters vs 2007 thesis**: ⏳ pending PDF (T_hop #88, jitter estimator
-  #89, full field table #58).
+- **Parameters vs 2007 thesis**: 🟡 partial — thesis obtained 2026-07-25.
+  `T_hop` ✅ adopted (3 ms). Jitter estimator ✅ *defined* in the thesis
+  (eq. 5.1, `Σ|(tᵢ−tᵢ₋₁)−(tᵢ₋₁−tᵢ₋₂)|`) but **not yet reconciled** with our
+  FlowMonitor `jitterSum` metric (#89). Full field table ⏳ (#58).
 - **Numbers on the paper's own 900 s / large-scale field**: ⏳ `--scenario=thesis`
   preset exists; the multi-hour run is future work.
 

--- a/docs/publications/papers/2004-ppsn-anthocnet.md
+++ b/docs/publications/papers/2004-ppsn-anthocnet.md
@@ -111,7 +111,7 @@ neighbour notification.
 | MAC-time running-average weight α | **0.7** | 3.1 | `macServiceAlpha` (ns-3 attr) = 0.7 | ✅ matches (#70) |
 | Pheromone running-average weight γ | **0.7** | 3.1 | `gamma = 0.7` | ✅ matches |
 | Per-hop cost formula | `(Q_mac + 1)·T̂_mac` | 3.1 | `enableMacMetric` path | ✅ formula confirmed (#70); repo default **off** (A2 gated) |
-| `T_hop` (unloaded one-hop time) | **not stated** | 3.1 | `hopTimeSec = 0.05` (provisional) | ⏳ thesis (#88) |
+| `T_hop` (unloaded one-hop time) | **not stated** | 3.1 | `hopTimeSec = 0.003` | ✅ from the 2007 thesis, not [1] (#88) |
 | Data routing exponent | **2** (squared) | 3.2 | `betaData = 2` | ✅ aligned (#70, A/B run 29708190748) |
 | Ant routing exponent | **1** (unsquared) | 3.3 | `betaAnts = 1` | ✅ aligned (#70, A/B run 29708190748) |
 | Proactive ant rate | 1 per n data packets | 3.3 | `proactiveInterval` (time-based) | ❗ deviation (rate- vs time-clocked), #26 item 04 area |

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -53,7 +53,7 @@ RoutingProtocol::RoutingProtocol()
       m_enableMacFailureDetector(true),
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
-      m_hopTime(0.05),
+      m_hopTime(0.003),
       m_enableMultipath(true),
       m_antAcceptanceFactor(1.5),
       m_linkfailNotifyInterval(5.0),
@@ -146,10 +146,10 @@ TypeId RoutingProtocol::GetTypeId() {
                           "Fixed unloaded-hop reference time T_hop (s): weights "
                           "hop count against measured delay in the goodness "
                           "(T_d + h*T_hop)/2, and is the A2 fallback service "
-                          "time. Default is the core's 50 ms; issue #88 "
-                          "suspects the papers meant a few ms — this attribute "
-                          "exists for that sensitivity sweep.",
-                          DoubleValue(0.05),
+                          "time. Default 3 ms, the value from the 2007 "
+                          "Ducatelle thesis (#88); it was a provisional 50 ms "
+                          "before that source was checked.",
+                          DoubleValue(0.003),
                           MakeDoubleAccessor(&RoutingProtocol::m_hopTime),
                           MakeDoubleChecker<double>(0.0))
             .AddAttribute("EnableMultipath",


### PR DESCRIPTION
The primary source finally answers #88. From Ducatelle, *Adaptive Routing in Ad Hoc Wireless Multi-hop Networks*, PhD thesis, USI Lugano, 2007:

> "here we use a different constant value, namely thop. This is a fixed estimate of the time needed to take one hop in unloaded conditions (**we kept thop on 0.003 sec**)."

[1] (PPSN 2004) defines the constant but states **no number** — verified against both the conference version *and* the IDSIA tech report — which is why the repo carried a provisional 50 ms. **That value was 16.7× too large.**

## Why this is not a cosmetic default change

`T_hop` weights hop count against measured delay in the back-ant deposit `τ = ((T̂ + h·T_hop)/2)⁻¹`, so it scales **every pheromone value in the table**. At 50 ms a 3-hop path contributed 0.15 s of synthetic hop cost against a measured path time of the same order — roughly doubling effective cost and flattening the distinction between fast and slow paths. At 3 ms the measured time dominates, which is the thesis's stated intent: *"allows to scale the number of hops to the same order of magnitude as the time estimation."*

## Changes

- `Config::hopTimeSec` 0.05 → **0.003**, with the source quoted at the declaration so provenance travels with the value.
- ns-3 `m_hopTime` ctor default and the `HopTime` attribute default likewise. The attribute doc no longer says #88 *"suspects the papers meant a few ms"* — it is now the sourced value.
- **Three tests failed** (`test_backant_metric`, `test_link_metric`, `test_link_metric_registry`) because they hardcoded `0.05` in their expected arithmetic. Fixed by deriving expectations from `cfg.hopTimeSec` (or the explicit `LinkObservation` field) rather than a literal — the failures were the tests being *over-specified*, not the change being wrong, and this stops a future default change breaking them spuriously.
- **New assertion** pins `Config{}.hopTimeSec` to 0.003 with the citation, so a silent edit to a value that scales all routing goodness fails loudly (golden rule 7).
- `docs/fidelity.md`: deviation 2 moves from "unverified" to resolved, and now states plainly that **every benchmark number in that document predates this fix and must be re-measured**. The 2004 digest table row updated to show the value comes from the thesis, not [1].

## Deliberately not done here

**Benchmarks are not re-run in this PR.** The #110 campaign currently in flight is measuring the old default — it becomes the honest `T_hop = 50 ms` **control arm** rather than wasted compute. Re-measurement on the corrected default is the follow-up, and it matters: #21 (the last open P1) names `T_hop` as a co-lever, with a prior sweep suggesting ~12% delay/jitter improvement at a few-ms value.

## Validation

`make test` **20/20**; `check_invariants.sh` PASS (no NS headers in core, core change carries a core test, docs updated).

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_