### PR TITLE
fix(core): stop bounding reactive floods — a broadcast budget is a hop limit (#169)

### DIFF
--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -102,9 +102,22 @@ struct Config {
     /// collision, not a topology change, and evicting the neighbour on it
     /// destroys valid routes and triggers rediscovery floods (issue #19).
     int txFailureThreshold = 3;
-    /// Max times a reactive forward ant may be (re)broadcast in a region with no
-    /// pheromone, so route setup doesn't flood ([1] §3.2).
-    int reactiveMaxBroadcasts = 2;
+    /// Max times a reactive forward ant may be (re)broadcast in a region with
+    /// no pheromone. **-1 (default) = unbounded**, which is what the sources
+    /// specify: the 2007 Ducatelle thesis says "each intermediate node
+    /// receiving a copy of the reactive forward ant forwards it … via
+    /// broadcasting otherwise", with proliferation limited by duplicate
+    /// suppression ("subsequent copies are destroyed"), `maxPathLength`, and
+    /// the `antAcceptanceFactor` band — never by a broadcast count.
+    ///
+    /// A finite budget here is a *hop limit on discovery*: because the ant
+    /// broadcasts at every node lacking pheromone, budget 2 made destinations
+    /// more than ~5 hops away permanently undiscoverable (#169), which is what
+    /// made sparse/static fields look like an AntHocNet weakness. The 2-
+    /// broadcast bound is real but belongs to *proactive* ants ([1] §3.3,
+    /// `proactiveMaxBroadcasts`, issue #45); it was generalised here in error.
+    /// Kept configurable for sensitivity experiments only.
+    int reactiveMaxBroadcasts = -1;
     /// Multipath reactive setup ([1] §3.1, issue #96): when on, a *later*
     /// reactive forward ant of an already-seen generation is forwarded if it
     /// passes the antAcceptanceFactor band below, laying down *multiple* good

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ANTHOCNET_TESTS
   test_properties
   test_observability
   test_testbench
+  test_reactive_hop_reach
 )
 
 foreach(test ${ANTHOCNET_TESTS})

--- a/core/tests/test_data_routing.cpp
+++ b/core/tests/test_data_routing.cpp
@@ -8,6 +8,16 @@ using namespace anthocnet::core;
 using anthocnet::test::FakeClock;
 using anthocnet::test::ScriptedRng;
 
+namespace {
+/// A Config with an explicit finite reactive broadcast budget, for the tests
+/// that exercise the decrement-and-drop mechanism (#169 made the default -1).
+Config cfgWithBudget(int budget) {
+    Config c;
+    c.reactiveMaxBroadcasts = budget;
+    return c;
+}
+}  // namespace
+
 int main() {
     Config cfg;
 
@@ -46,9 +56,16 @@ int main() {
 
     // A3 — a reactive forward ant gets broadcastBudget == reactiveMaxBroadcasts
     // and is broadcast at most that many times in a pheromone-free region.
+    //
+    // The budget is set explicitly here rather than taken from the default:
+    // since #169 the shipped default is -1 (unbounded), because a finite value
+    // is a hop limit on discovery and made >5-hop destinations unreachable.
+    // This block still pins the decrement-and-drop *mechanism*, which remains
+    // correct for anyone who sets a finite budget for an experiment.
     {
         FakeClock clock;
         ScriptedRng rng({0.5});
+        Config cfg = ::cfgWithBudget(2);
         AntRouterLogic origin(/*addr*/ 1, cfg, clock, rng);
         AntMessage refa = origin.createForwardAnt(AntType::Reactive, /*dest*/ 99);
         CHECK_EQ(refa.broadcastBudget, cfg.reactiveMaxBroadcasts);

--- a/core/tests/test_reactive_hop_reach.cpp
+++ b/core/tests/test_reactive_hop_reach.cpp
@@ -1,0 +1,86 @@
+// Reactive discovery must not be hop-limited (#169).
+//
+// A reactive forward ant broadcasts at every node that has no pheromone for
+// the destination, so a finite `reactiveMaxBroadcasts` is really a *hop limit
+// on route discovery*. With the old default of 2, any destination more than
+// ~5 hops away was never discovered at all — not degraded, never found. That
+// is what made sparse/static fields look like an AntHocNet weakness: in the
+// pause sweep (areaX=2500, long paths) delivery fell to 59.9% while AODV rose
+// to 98.9%, and AntHocNet did *better* under mobility only because motion
+// intermittently brought far pairs within reach.
+//
+// The sources bound the flood by duplicate suppression, maxPathLength and the
+// acceptance band — never by a broadcast count (2007 thesis: "each
+// intermediate node receiving a copy of the reactive forward ant forwards it
+// … via broadcasting otherwise … subsequent copies are destroyed"). The
+// 2-broadcast rule belongs to *proactive* ants ([1] §3.3).
+//
+// Runs on the #154 testbench: a static line of N nodes, links never torn down,
+// one flow end to end. No simulator, deterministic, milliseconds.
+#include "test_support.h"
+#include "testbench.h"
+
+using namespace anthocnet;
+
+namespace {
+
+// Deliveries over a static `hops`-hop line with the given broadcast budget.
+// Returns {delivered, offered}.
+struct Outcome {
+    int delivered;
+    int offered;
+};
+
+Outcome runLine(int hops, int reactiveBudget) {
+    core::Config cfg;
+    cfg.reactiveMaxBroadcasts = reactiveBudget;
+    // Isolate discovery: evaporation is a separate mechanism (ADR-0012).
+    cfg.enableEvaporation = false;
+
+    const int n = hops + 1;
+    test::Testbench tb(n, cfg);
+    for (int i = 0; i + 1 < n; ++i) tb.linkUp(i, i + 1);
+
+    int offered = 0;
+    for (core::Time t = 5.0; t < 60.0; t += 1.0) {
+        tb.at(t, [&tb, &offered, n] {
+            ++offered;
+            tb.sendData(0, n - 1);
+        });
+    }
+    tb.runUntil(60.0);
+    return {tb.dataDelivered, offered};
+}
+
+}  // namespace
+
+int main() {
+    // 1. The default must discover long paths. 9 hops is comfortably beyond the
+    //    ~5-hop ceiling the old budget imposed, and well inside maxPathLength.
+    //    Allow a startup allowance for the initial reactive setup.
+    {
+        const Outcome o = runLine(/*hops=*/9, core::Config{}.reactiveMaxBroadcasts);
+        CHECK(o.offered > 50);
+        CHECK(o.delivered >= o.offered - 5);
+    }
+
+    // 2. Short paths keep working — the fix must not regress the easy case.
+    {
+        const Outcome o = runLine(/*hops=*/3, core::Config{}.reactiveMaxBroadcasts);
+        CHECK(o.delivered >= o.offered - 5);
+    }
+
+    // 3. The regression itself, pinned: a finite budget still truncates
+    //    discovery. This documents *why* the default is unbounded — if someone
+    //    reintroduces a finite default, test 1 fails and this explains it.
+    {
+        const Outcome capped = runLine(/*hops=*/9, /*reactiveBudget=*/2);
+        CHECK(capped.delivered == 0);
+    }
+
+    // 4. The default is the unbounded sentinel, not merely a large number.
+    //    A big-but-finite budget would just move the invisible ceiling.
+    CHECK(core::Config{}.reactiveMaxBroadcasts < 0);
+
+    return RUN_TESTS();
+}

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -40,6 +40,24 @@ Every pinned-down parameter and its match/deviation status is tabulated in the
 | **Overhead (NRL) below AODV** | ✅ | 45 vs 61 (disk); 44 vs 75 (two-ray) |
 | **Delay/jitter QoS advantage** (bounded tail) | 🟡 partial | **two-ray (paper PHY): mean-delay parity** with AODV (52.8 vs 52.6 ms), jitter within 11 %, after the #21 reconv hold cap (#104). **Disk model**: tail narrowed (delay99 −37 %, jitter −26 % via `ReconvHoldCap`) but still above AODV |
 
+## Correction pending re-measurement (#169, 2026-07-25)
+
+**Every benchmark number in this document was produced with
+`reactiveMaxBroadcasts = 2`**, which — because a reactive forward ant
+broadcasts at every node lacking pheromone for the destination — was a *hop
+limit on route discovery*: destinations more than ~5 hops away were never
+found at all. Both primary sources bound the reactive flood by duplicate
+suppression and `maxPathLength`, never by a broadcast count; the 2-broadcast
+rule belongs to *proactive* ants ([1] §3.3). The default is now unbounded.
+
+This most likely explains the sparse/long-path results that were previously
+read as protocol character — in particular the static-network inversion
+(delivery 59.9 % vs AODV 98.9 % at `pause=900`, while AntHocNet *led* under
+constant motion) and the decay of its advantage as the field is stretched.
+Until the sweeps are re-run, treat every result below — including the headline
+PDR/NRL figures — as **pending re-measurement**, and do not cite the
+sparse-static weakness as a property of the algorithm.
+
 ## Known deviations (honest list)
 
 1. **Delay tail on the ns-3 disk model (#21).** On the contention-dominated


### PR DESCRIPTION
Fixes #169. `reactiveMaxBroadcasts` defaulted to **2**. Because a reactive forward ant broadcasts at every node with no pheromone for the destination, that budget was in effect a **hop limit on discovery**: any destination more than ~5 hops away was **never found**. Not degraded — never found.

## Measured (#154 testbench: static line, links never torn down, 1 pkt/s for 55 s)

| budget | 5 hops | 6 hops | 7 hops | 9 hops | 13 hops |
|---|---|---|---|---|---|
| **2 (old default)** | 55 | **0** | **0** | **0** | **0** |
| 5 | 55 | 55 | 55 | 0 | 0 |
| 10 | 55 | 55 | 55 | 55 | 0 |
| **−1 (new default)** | 55 | 55 | 55 | 55 | 55 |

Route state confirms the mechanism — at 6 hops only the destination's immediate neighbour ever learns a next hop, permanently:

```
n=7 t=   6  node0->6 next=-1  pending=1  n1->-1 n2->-1 n3->-1 n4->-1 n5->6
n=7 t=  30  node0->6 next=-1  pending=1  n1->-1 n2->-1 n3->-1 n4->-1 n5->6
```

## What the sources say

**2007 thesis:** *"Each intermediate node receiving a copy of the reactive forward ant forwards it. This is done via unicasting in case the node has routing information about the ant's destination in its pheromone table, and via broadcasting otherwise. … The first copy … to reach the destination is converted into a reactive backward ant, while subsequent copies are destroyed."*

The flood is bounded by **duplicate suppression** and the visited-path cap — never by a count. The 2-broadcast bound is real, but belongs to **proactive** ants ([1] §3.3, issue #45, correctly implemented as `proactiveMaxBroadcasts`); it was generalised to reactive ants in error. The old comment cited *"[1] §3.2"* — *Stochastic data routing* — which does not support the mechanism.

## The fix

Default `reactiveMaxBroadcasts = -1`, the sentinel the code **already** treats as untracked/unbounded (`ant_router_logic.cpp:107`). No new mechanism, **no wire change** — proliferation stays bounded by `(src,seq)` dedup, `maxPathLength` and the `antAcceptanceFactor` band, exactly as the sources specify. The knob remains for sensitivity experiments.

Deliberately **not** just a larger number: that trades one invisible ceiling for another.

## Why this matters beyond a config value

It is the likely root cause of the sparse/static anomaly. The pause sweep runs at `areaX=2500`, where many pairs exceed 5 hops:

- AntHocNet **59.9%** vs AODV **98.9%** when static — yet AntHocNet **leads** under constant motion (80.1 vs 76.1). **Mobility was rescuing the protocol**, intermittently bringing far pairs into range.
- **NRL rises 46 → 65** as the network settles: undiscoverable destinations re-trigger setup forever.
- **`pdr_sd` 11.78** vs AODV's 0.60: variance tracks how many pairs land beyond reach in a given placement.
- Delivered packets were fast (16.8 ms) — short-path flows were always healthy.

## Tests

New `test_reactive_hop_reach` locks 9-hop delivery at the default, keeps the 3-hop case, **pins that a finite budget still truncates** (so a future finite default fails loudly *with the explanation attached*), and asserts the default is the unbounded sentinel rather than a large finite number.

`test_data_routing`'s A3 block exercised the decrement-and-drop mechanism seeded from the default; it now sets an explicit budget of 2 — the mechanism is still correct for anyone choosing a finite value, so the coverage is kept rather than deleted.

`make test` **21/21**; `check_invariants.sh` PASS.

## Docs

`docs/fidelity.md` gains a correction notice: every number in it was produced under the hop cap and is **pending re-measurement**, and the sparse-static weakness must not be cited as an algorithm property until the sweeps re-run. #22's closure ("underperforms under high mobility") may also deserve revisiting — its evidence predates this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_