### PR TITLE
fix(core): bound the reactive flood per (node, generation), not per ant path

### DIFF
--- a/core/include/anthocnet/core/ant_history.h
+++ b/core/include/anthocnet/core/ant_history.h
@@ -61,10 +61,23 @@ public:
     bool accept(NodeAddress src, std::uint32_t seqNum, std::uint32_t hops,
                 Time time, double factor);
 
+    /// Claim one broadcast of this generation *at this node* (#173). Returns
+    /// false once `maxBroadcasts` have already been claimed; `maxBroadcasts < 0`
+    /// means unlimited.
+    ///
+    /// This is the flood bound for reactive forward ants. `accept()` cannot
+    /// serve as one: it admits rather than suppresses, so in a dense graph a
+    /// node keeps re-broadcasting the same generation as comparable copies
+    /// arrive from each neighbour, and each re-broadcast seeds more admissible
+    /// copies. Counting *per (node, generation)* bounds that without limiting
+    /// reach — unlike a budget carried on the ant and decremented at each hop,
+    /// which is a hop limit on discovery (#169).
+    bool allowBroadcast(NodeAddress src, std::uint32_t seqNum, int maxBroadcasts);
+
     void clear();
 
 private:
-    struct Best { std::uint32_t hops; Time time; };
+    struct Best { std::uint32_t hops; Time time; int broadcasts; };
     using Key = std::pair<NodeAddress, std::uint32_t>;
 
     std::size_t        maxEntries_;

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -102,22 +102,35 @@ struct Config {
     /// collision, not a topology change, and evicting the neighbour on it
     /// destroys valid routes and triggers rediscovery floods (issue #19).
     int txFailureThreshold = 3;
-    /// Max times a reactive forward ant may be (re)broadcast in a region with
-    /// no pheromone. **-1 (default) = unbounded**, which is what the sources
-    /// specify: the 2007 Ducatelle thesis says "each intermediate node
-    /// receiving a copy of the reactive forward ant forwards it … via
-    /// broadcasting otherwise", with proliferation limited by duplicate
-    /// suppression ("subsequent copies are destroyed"), `maxPathLength`, and
-    /// the `antAcceptanceFactor` band — never by a broadcast count.
+    /// Max times **one node** may broadcast **one reactive generation**
+    /// `(src, seqNum)`. `-1` = unbounded. Default 2.
     ///
-    /// A finite budget here is a *hop limit on discovery*: because the ant
-    /// broadcasts at every node lacking pheromone, budget 2 made destinations
-    /// more than ~5 hops away permanently undiscoverable (#169), which is what
-    /// made sparse/static fields look like an AntHocNet weakness. The 2-
-    /// broadcast bound is real but belongs to *proactive* ants ([1] §3.3,
-    /// `proactiveMaxBroadcasts`, issue #45); it was generalised here in error.
-    /// Kept configurable for sensitivity experiments only.
-    int reactiveMaxBroadcasts = -1;
+    /// **The unit of this field changed in #173 — read this before comparing it
+    /// to an older run or an older sweep.** It used to be a budget carried on
+    /// the ant and decremented at every hop, i.e. per *ant path*; it is now a
+    /// counter held at each node per generation. Same name, same default,
+    /// different meaning — the `alpha`/ADR-0012 trap, so it is spelled out
+    /// here (see `docs/configuration.md`).
+    ///
+    /// Why per node. A reactive forward ant broadcasts wherever there is no
+    /// pheromone for the destination, so a *per-path* budget is a hop limit on
+    /// discovery: at 2, destinations more than ~5 hops away were permanently
+    /// undiscoverable (#169), which is what made sparse/static fields look like
+    /// an AntHocNet weakness. A *per-node* count does not limit reach at all —
+    /// the ant may still travel arbitrarily far, each node along the way simply
+    /// does not re-broadcast the same generation indefinitely.
+    ///
+    /// Why a bound is needed at all, given the sources describe none. The 2007
+    /// thesis bounds proliferation by duplicate suppression ("subsequent copies
+    /// are destroyed"), `maxPathLength` and the `antAcceptanceFactor` band. But
+    /// with `enableMultipath` on (the default) a reactive forward ant is
+    /// admitted by the acceptance band *instead of* `(src,seq)` duplicate
+    /// suppression, and the band admits rather than suppresses. Removing the
+    /// per-path budget in #169 therefore left no bound: one discovery on a
+    /// 7x7 grid cost 30,090 ants, and ns-3 `large-scale` fell to 21.7% PDR at
+    /// NRL 3071 (#173). This restores duplicate suppression's *intent* for the
+    /// one ant type that bypasses it.
+    int reactiveMaxBroadcasts = 2;
     /// Multipath reactive setup ([1] §3.1, issue #96): when on, a *later*
     /// reactive forward ant of an already-seen generation is forwarded if it
     /// passes the antAcceptanceFactor band below, laying down *multiple* good

--- a/core/src/ant_history.cpp
+++ b/core/src/ant_history.cpp
@@ -36,7 +36,7 @@ bool GenerationTracker::accept(NodeAddress src, std::uint32_t seqNum,
     auto it = best_.find(key);
     if (it == best_.end()) {
         // First ant of this generation: always forward and record its metrics.
-        best_.emplace(key, Best{hops, time});
+        best_.emplace(key, Best{hops, time, 0});
         insertionOrder_.push_back(key);
         if (maxEntries_ != 0) {
             while (insertionOrder_.size() > maxEntries_) {
@@ -57,6 +57,29 @@ bool GenerationTracker::accept(NodeAddress src, std::uint32_t seqNum,
         return true;
     }
     return false;
+}
+
+bool GenerationTracker::allowBroadcast(NodeAddress src, std::uint32_t seqNum,
+                                      int maxBroadcasts) {
+    if (maxBroadcasts < 0) return true;               // unlimited
+    const Key key{src, seqNum};
+    auto it = best_.find(key);
+    if (it == best_.end()) {
+        // No accept() record (multipath off, or an originating ant): track the
+        // generation so its broadcasts are still counted.
+        best_.emplace(key, Best{0, 0.0, 0});
+        insertionOrder_.push_back(key);
+        if (maxEntries_ != 0) {
+            while (insertionOrder_.size() > maxEntries_) {
+                best_.erase(insertionOrder_.front());
+                insertionOrder_.pop_front();
+            }
+        }
+        it = best_.find(key);
+    }
+    if (it->second.broadcasts >= maxBroadcasts) return false;
+    it->second.broadcasts += 1;
+    return true;
 }
 
 void GenerationTracker::clear() {

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -326,11 +326,19 @@ AntMessage AntRouterLogic::createForwardAnt(AntType type, NodeAddress dest) {
     m.dst       = dest;
     m.seqNum    = nextSeq();
     m.timeStart = clock_.now();
-    // Every forward-ant type caps its broadcasts: reactive/repair per
-    // [1] §3.2/§3.5, and proactive too (issue #45) — an unbounded proactive
-    // budget let route gaps turn the path monitor into a network-wide flood.
+    // Repair and proactive ants carry a per-path broadcast budget, decremented
+    // at each hop ([1] §3.2/§3.5, and proactive per issue #45 — an unbounded
+    // proactive budget let route gaps turn the path monitor into a network-wide
+    // flood). Both are *maintenance* ants exploring near a known path, so
+    // bounding the path is the right unit for them.
+    //
+    // A reactive ant carries **no** per-path budget (#169): it broadcasts at
+    // every node lacking pheromone, so decrementing per hop is a hop limit on
+    // discovery. Its flood is bounded per (node, generation) instead, at the
+    // broadcast site in onReceiveAnt (#173) — config_.reactiveMaxBroadcasts is
+    // consumed there, not here.
     if (type == AntType::Repair)        m.broadcastBudget = config_.repairMaxBroadcasts;
-    else if (type == AntType::Reactive) m.broadcastBudget = config_.reactiveMaxBroadcasts;
+    else if (type == AntType::Reactive) m.broadcastBudget = -1;  // see above
     else                                m.broadcastBudget = config_.proactiveMaxBroadcasts;
     m.visited.push_back({address_, 0.0});  // source node enters the stack
     return m;
@@ -534,10 +542,13 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
 
     if (ant.isForward()) {
         // 6.2 hop cap ([1] §4.2): an ant that has already traversed
-        // maxPathLength hops is dropped rather than forwarded further. Propagation
-        // is also bounded by broadcastBudget (A3) and (src,seq) dedup, but this is
-        // the explicit per-ant hop ceiling the spec calls for, and — living in the
-        // core — it caps ant reach on every adapter without a per-simulator TTL.
+        // maxPathLength hops is dropped rather than forwarded further. This is
+        // the explicit per-ant hop ceiling the spec calls for, and — living in
+        // the core — it caps ant reach on every adapter without a per-simulator
+        // TTL. It is not, on its own, a flood bound: a *reactive* forward ant
+        // under multipath bypasses (src,seq) dedup (see the acceptance filter
+        // above) and carries no broadcast budget since #169, so its flood is
+        // bounded per (node, generation) at the broadcast site below (#173).
         if (ant.visited.size() >= config_.maxPathLength) {
             return {RouteDecision::drop()};
         }
@@ -556,6 +567,15 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
 
         NodeAddress next = selectNextHop(ant.dst, proactive);
         if (next == kInvalidAddress) {
+            // No pheromone for the destination: the ant explores by broadcast.
+            // For a reactive forward ant that is the flood, and it must be
+            // bounded *per (node, generation)* — see allowBroadcast (#173).
+            // Bounding it on the ant instead makes it a hop limit (#169).
+            if (ant.type == AntType::Reactive &&
+                !genQuality_.allowBroadcast(ant.src, ant.seqNum,
+                                            config_.reactiveMaxBroadcasts)) {
+                return {RouteDecision::drop()};
+            }
             return {broadcastForward(ant)};  // bounded per type (drop at budget 0)
         }
         // A proactive ant with a route is normally unicast, but with a small

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ANTHOCNET_TESTS
   test_observability
   test_testbench
   test_reactive_hop_reach
+  test_reactive_flood_bound
 )
 
 foreach(test ${ANTHOCNET_TESTS})

--- a/core/tests/test_data_routing.cpp
+++ b/core/tests/test_data_routing.cpp
@@ -54,21 +54,24 @@ int main() {
         CHECK_EQ(router.nextHopForData(9, /*prevHop*/ kInvalidAddress), kInvalidAddress);
     }
 
-    // A3 — a reactive forward ant gets broadcastBudget == reactiveMaxBroadcasts
-    // and is broadcast at most that many times in a pheromone-free region.
+    // A3 — the per-path decrement-and-drop mechanism: a forward ant carrying a
+    // finite broadcastBudget is broadcast at most that many times in a
+    // pheromone-free region, then dropped.
     //
-    // The budget is set explicitly here rather than taken from the default:
-    // since #169 the shipped default is -1 (unbounded), because a finite value
-    // is a hop limit on discovery and made >5-hop destinations unreachable.
-    // This block still pins the decrement-and-drop *mechanism*, which remains
-    // correct for anyone who sets a finite budget for an experiment.
+    // Exercised on a **repair** ant. This block used to use a reactive ant, but
+    // reactive ants no longer carry a per-path budget: decrementing per hop is a
+    // hop limit on discovery (#169), and since #173 their flood is bounded per
+    // (node, generation) instead — createForwardAnt gives them -1. Repair and
+    // proactive ants still use this mechanism (they explore near a known path,
+    // so bounding the path is the right unit), so the coverage moves here rather
+    // than being deleted.
     {
         FakeClock clock;
         ScriptedRng rng({0.5});
         Config cfg = ::cfgWithBudget(2);
         AntRouterLogic origin(/*addr*/ 1, cfg, clock, rng);
-        AntMessage refa = origin.createForwardAnt(AntType::Reactive, /*dest*/ 99);
-        CHECK_EQ(refa.broadcastBudget, cfg.reactiveMaxBroadcasts);
+        AntMessage refa = origin.createForwardAnt(AntType::Repair, /*dest*/ 99);
+        CHECK_EQ(refa.broadcastBudget, cfg.repairMaxBroadcasts);
 
         auto step = [&](AntMessage ant, NodeAddress addr, NodeAddress prevHop) {
             FakeClock c;
@@ -85,6 +88,17 @@ int main() {
         CHECK_EQ(d2[0].message.broadcastBudget, 0);
         auto d3 = step(d2[0].message, 13, 12);
         CHECK(d3[0].action == RouteAction::Drop);
+    }
+
+    // A3.1 — and a reactive ant explicitly does *not* carry one, so no per-hop
+    // decrement can reintroduce the #169 hop limit.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        Config cfg = ::cfgWithBudget(2);
+        AntRouterLogic origin(/*addr*/ 1, cfg, clock, rng);
+        AntMessage refa = origin.createForwardAnt(AntType::Reactive, /*dest*/ 99);
+        CHECK(refa.broadcastBudget < 0);
     }
 
     return RUN_TESTS();

--- a/core/tests/test_reactive_flood_bound.cpp
+++ b/core/tests/test_reactive_flood_bound.cpp
@@ -70,24 +70,39 @@ std::uint64_t discoveryCost(int side, int reactiveBudget, bool multipath) {
 }  // namespace
 
 int main() {
-    const int side = 5, n = side * side;   // 25 nodes, corner-to-corner 4 hops
-    const std::uint64_t bounded   = discoveryCost(side, 2, true);
-    const std::uint64_t unbounded = discoveryCost(side, -1, true);
-    const std::uint64_t dedup     = discoveryCost(side, -1, false);
+    const core::Config def;
 
-    std::printf("%dx%d grid (8-connected, %d nodes), one discovery 0 -> %d:\n"
-                "  budget=2,  multipath=on   -> %llu reactive ants\n"
-                "  budget=-1, multipath=on   -> %llu reactive ants   (current default)\n"
-                "  budget=-1, multipath=off  -> %llu reactive ants\n",
-                side, side, n, n - 1,
-                static_cast<unsigned long long>(bounded),
-                static_cast<unsigned long long>(unbounded),
-                static_cast<unsigned long long>(dedup));
+    // The invariant, at the *default* configuration: one discovery costs O(n)
+    // control packets, because each node puts a given generation on the medium
+    // at most reactiveMaxBroadcasts times. Checked as the grid grows, since the
+    // defect was combinatorial — a single size could pass by luck.
+    std::printf("8-connected grid, one discovery corner to corner:\n"
+                "%-6s %-7s %14s %14s %14s\n",
+                "side", "nodes", "default", "budget=-1", "multipath=off");
+    for (int side = 3; side <= 7; ++side) {
+        const int n = side * side;
+        const std::uint64_t dflt      = discoveryCost(side, def.reactiveMaxBroadcasts, true);
+        const std::uint64_t unbounded = discoveryCost(side, -1, true);
+        const std::uint64_t dedup     = discoveryCost(side, -1, false);
+        std::printf("%-6d %-7d %14llu %14llu %14llu\n", side, n,
+                    static_cast<unsigned long long>(dflt),
+                    static_cast<unsigned long long>(unbounded),
+                    static_cast<unsigned long long>(dedup));
 
-    // The invariant: one discovery costs O(n) control packets, because each
-    // node should put the generation on the medium a bounded number of times.
-    // 4n is generous headroom over the ideal n.
-    CHECK(unbounded <= 4 * static_cast<std::uint64_t>(n));
-    CHECK(dedup <= 4 * static_cast<std::uint64_t>(n));
+        // 8n is generous headroom: the per-node bound allows
+        // reactiveMaxBroadcasts broadcasts each, and the count also includes
+        // unicast forwards along established pheromone (which do not flood).
+        // The point is that it stays a small multiple of n as the grid grows —
+        // at 7x7 the unbounded column is 614n.
+        CHECK(dflt <= 8 * static_cast<std::uint64_t>(n));
+        // Strict dedup bounds it too, and always did — the defect was that
+        // reactive forward ants under multipath never reach that branch.
+        CHECK(dedup <= 4 * static_cast<std::uint64_t>(n));
+    }
+
+    // The default must be a finite per-node bound. `-1` is retained for
+    // sensitivity experiments and genuinely is unbounded — that column is
+    // printed above as the contrast, deliberately not asserted on.
+    CHECK(def.reactiveMaxBroadcasts > 0);
     return RUN_TESTS();
 }

--- a/core/tests/test_reactive_flood_bound.cpp
+++ b/core/tests/test_reactive_flood_bound.cpp
@@ -1,0 +1,93 @@
+// Reactive discovery must stay bounded in a *dense* graph (#169 follow-up).
+//
+// PR #170 removed the reactive broadcast budget because, implemented as a
+// counter carried on the ant and decremented at every broadcast, it was a *hop
+// limit on discovery*: destinations more than ~5 hops away were never found.
+// That diagnosis holds. The question this test answers is what is left bounding
+// the flood afterwards, because #96 had already routed reactive forward ants
+// around the other bound:
+//
+//   onReceiveAnt(): with enableMultipath (default on) a *reactive forward* ant
+//   is admitted by GenerationTracker::accept() and never touches history_, so
+//   strict (src,seq) duplicate suppression does not apply to it. The acceptance
+//   band admits rather than suppresses — a later same-generation copy is
+//   forwarded whenever it is within antAcceptanceFactor of the best so far.
+//
+// A line topology (test_reactive_hop_reach.cpp) cannot show this: with two
+// neighbours per node there is nothing to multiply. A fully-connected mesh
+// cannot either — the destination is a direct neighbour, so discovery never
+// runs. It needs a graph that is dense *and* has a distant destination, which
+// is what a grid gives: interior degree 8, corner-to-corner 4 hops.
+#include "test_support.h"
+#include "testbench.h"
+
+using namespace anthocnet;
+
+namespace {
+
+// Reactive ants put on the medium while node 0 discovers the opposite corner
+// of a `side` x `side` grid (8-connected: orthogonal + diagonal neighbours).
+std::uint64_t discoveryCost(int side, int reactiveBudget, bool multipath) {
+    core::Config cfg;
+    cfg.reactiveMaxBroadcasts = reactiveBudget;
+    cfg.enableMultipath = multipath;
+    // Isolate reactive discovery from the periodic mechanisms.
+    cfg.enableEvaporation = false;
+    cfg.enableProactive = false;
+    cfg.enableDiffusion = false;
+
+    const int n = side * side;
+    test::Testbench tb(n, cfg);
+    auto id = [side](int r, int c) { return r * side + c; };
+    for (int r = 0; r < side; ++r) {
+        for (int c = 0; c < side; ++c) {
+            for (int dr = -1; dr <= 1; ++dr) {
+                for (int dc = -1; dc <= 1; ++dc) {
+                    const int nr = r + dr, nc = c + dc;
+                    if ((dr == 0 && dc == 0) || nr < 0 || nc < 0 ||
+                        nr >= side || nc >= side) continue;
+                    tb.linkUp(id(r, c), id(nr, nc));
+                }
+            }
+        }
+    }
+
+    // Establish neighbours, then measure a window containing no hello tick —
+    // otherwise n beacons per second swamp the counter and every configuration
+    // reads alike.
+    tb.runUntil(cfg.helloInterval * 3.5);
+    std::uint64_t before = 0;
+    for (int i = 0; i < n; ++i) before += tb.node(i).antsSent(core::AntType::Reactive);
+
+    tb.sendData(0, n - 1);
+    tb.runUntil(cfg.helloInterval * 3.9);   // discovery takes ms; next hello at 4.0
+
+    std::uint64_t after = 0;
+    for (int i = 0; i < n; ++i) after += tb.node(i).antsSent(core::AntType::Reactive);
+    return after - before;
+}
+
+}  // namespace
+
+int main() {
+    const int side = 5, n = side * side;   // 25 nodes, corner-to-corner 4 hops
+    const std::uint64_t bounded   = discoveryCost(side, 2, true);
+    const std::uint64_t unbounded = discoveryCost(side, -1, true);
+    const std::uint64_t dedup     = discoveryCost(side, -1, false);
+
+    std::printf("%dx%d grid (8-connected, %d nodes), one discovery 0 -> %d:\n"
+                "  budget=2,  multipath=on   -> %llu reactive ants\n"
+                "  budget=-1, multipath=on   -> %llu reactive ants   (current default)\n"
+                "  budget=-1, multipath=off  -> %llu reactive ants\n",
+                side, side, n, n - 1,
+                static_cast<unsigned long long>(bounded),
+                static_cast<unsigned long long>(unbounded),
+                static_cast<unsigned long long>(dedup));
+
+    // The invariant: one discovery costs O(n) control packets, because each
+    // node should put the generation on the medium a bounded number of times.
+    // 4n is generous headroom over the ideal n.
+    CHECK(unbounded <= 4 * static_cast<std::uint64_t>(n));
+    CHECK(dedup <= 4 * static_cast<std::uint64_t>(n));
+    return RUN_TESTS();
+}

--- a/core/tests/test_reactive_hop_reach.cpp
+++ b/core/tests/test_reactive_hop_reach.cpp
@@ -70,17 +70,23 @@ int main() {
         CHECK(o.delivered >= o.offered - 5);
     }
 
-    // 3. The regression itself, pinned: a finite budget still truncates
-    //    discovery. This documents *why* the default is unbounded — if someone
-    //    reintroduces a finite default, test 1 fails and this explains it.
+    // 3. The value is now a *per-node, per-generation* broadcast count, not a
+    //    per-path budget, so a finite value no longer truncates discovery: 9
+    //    hops still deliver at 2 (#173 changed the unit — see config.h). Under
+    //    the old per-path semantics this same call delivered 0, which is the
+    //    regression #169 fixed and this pins against reintroduction.
     {
         const Outcome capped = runLine(/*hops=*/9, /*reactiveBudget=*/2);
-        CHECK(capped.delivered == 0);
+        CHECK(capped.delivered >= capped.offered - 5);
     }
 
-    // 4. The default is the unbounded sentinel, not merely a large number.
-    //    A big-but-finite budget would just move the invisible ceiling.
-    CHECK(core::Config{}.reactiveMaxBroadcasts < 0);
+    // 4. Reach must not depend on the bound at all. A per-node count cannot be
+    //    a hop limit, so tightening it to 1 must still deliver over 9 hops —
+    //    the property that distinguishes the #173 bound from the #169 one.
+    {
+        const Outcome tight = runLine(/*hops=*/9, /*reactiveBudget=*/1);
+        CHECK(tight.delivered >= tight.offered - 5);
+    }
 
     return RUN_TESTS();
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,9 +55,26 @@ struct had no traceable source, so nobody could tell it was wrong by reading it.
   sparse/static results that were being read as protocol character (see the
   correction notice in [`fidelity.md`](fidelity.md)).
 
-Both cost a benchmark campaign to detect and invalidated published numbers. The
-job of §3 below is to make the next one catchable **by reading**: each default
-carries the category of evidence behind it, and where there is none, it says so.
+- **`reactiveMaxBroadcasts`, again** ([#173](https://github.com/danieljoppi/AntHocNet/issues/173)).
+  Removing that budget exposed a second defect underneath it, and this one is
+  the more instructive of the two: **no single change was wrong.**
+  [#96](https://github.com/danieljoppi/AntHocNet/issues/96) made reactive
+  forward ants take the multipath acceptance band *instead of* `(src,seq)`
+  duplicate suppression — reasonable, since the band is the paper's multipath
+  rule. #169 then removed the broadcast budget — also reasonable, and correct.
+  But the band *admits* rather than suppresses, so between them the two changes
+  left reactive discovery with no flood bound at all: one discovery on a 7×7
+  grid cost **30,090** ants, and ns-3 `large-scale` fell from 75.8% to **21.7%**
+  PDR at NRL 3071. The fix bounds broadcasts per *(node, generation)*, which
+  bounds the flood without reintroducing a hop limit.
+
+The first two cost a benchmark campaign to detect and invalidated published
+numbers. The third was invisible to *every* existing test because each change
+was locally justified and the invariant they jointly broke — "a reactive flood
+is bounded by something" — was written only in a code comment, which silently
+became false. The job of §3 below is to make the next one catchable **by
+reading**: each default carries the category of evidence behind it, and where
+there is none, it says so.
 
 > **Rule of thumb.** If you cannot name the source of a number you are about to
 > rely on, treat it as a suspect, not as a setting.
@@ -106,14 +123,14 @@ The `ns-3 attribute` column is the name you pass to
 | `repairMaxBroadcasts` | `2` | count | — | `[1] §3.4` — route repair ant, "max **2** broadcasts" (`config.h` cites §3.5; see §3.3). | Re-broadcast budget for repair ants **and** for LinkFail notifications, so local repair cannot storm. |
 | `linkfailNotifyInterval` | `5.0` | s | `LinkfailNotifyInterval` | `repo choice` — the [#20](https://github.com/danieljoppi/AntHocNet/issues/20) sweep picked 5.0 (1 s misses the ~3 s flap cycle; 10 s costs PDR/delay). [1] has **no** rate limit. | Minimum spacing between LinkFail notices this node originates about the same destination. `0` disables (spec-faithful). |
 | `txFailureThreshold` | `3` | consecutive failures | `TxFailureThreshold` | `repo choice` — the *debounce* is argued in [#19](https://github.com/danieljoppi/AntHocNet/issues/19)/[ADR-0008](adr/0008-neighbour-liveness-two-detectors.md) detector D; the **value 3 is not sweep-backed** (see §3.2). | How many consecutive MAC transmit failures to the same next hop (with no reception in between) count as a broken link. Lower = jumpier, more rediscovery. |
-| `reactiveMaxBroadcasts` | `-1` (unbounded) | count, `-1` = no bound | — | `[1] §3.1` + `thesis` — the sources bound the reactive flood by duplicate suppression, `maxPathLength` and the acceptance band, **never by a count** ([#169](https://github.com/danieljoppi/AntHocNet/issues/169), PR #170). Kept configurable for sensitivity experiments only. | Reach of route discovery. **Any finite value is a hop limit** — 2 made destinations >~5 hops away undiscoverable. |
+| `reactiveMaxBroadcasts` | `2` | broadcasts per node per `(src,seq)` generation; `-1` = no bound | — | `derived` — the sources bound the reactive flood by duplicate suppression, `maxPathLength` and the acceptance band, **never by a count** ([#169](https://github.com/danieljoppi/AntHocNet/issues/169)); but with `enableMultipath` on a reactive forward ant bypasses duplicate suppression, so this restores its *intent* for that one case ([#173](https://github.com/danieljoppi/AntHocNet/issues/173)). | How many times a node re-broadcasts one discovery. **The unit changed in #173**: it was a budget carried on the ant and decremented per hop (a hop limit on reach, #169); it is now a per-node count, which bounds the flood without limiting reach. |
 | `enableMultipath` | `true` | bool | `EnableMultipath` | Mechanism `[1] §3.1` (the acceptance filter); **the gate and the linkfail churn bound** are `repo choice` ([#96](https://github.com/danieljoppi/AntHocNet/issues/96), A/B-justified: PDR 92.3 vs 89.4). | Whether later same-generation reactive ants may lay additional paths, and whether losing a best hop that leaves a usable alternate is absorbed instead of flooding a LinkFail. Off = strict `(src,seq)` dedup, single-path setup. |
 | `antAcceptanceFactor` | `1.5` | factor | `AntAcceptanceFactor` | `[1] §3.1` — "a parameter which we empirically set to **1.5**". | How many alternate paths get laid: a later ant is forwarded only if both hop count and travel time are within this factor of the generation's best. **Higher admits more copies** (up to a flood); no value reproduces single-path — use `enableMultipath=false`. |
 | `proactiveMaxBroadcasts` | `2` | count | — | `[1] §3.3` — a proactive ant may be broadcast "at most **2**" times, else deleted (#45). | Bounds proactive exploration, including across a route gap en route. Unbounded lets proactive ants flood regions of missing routes (#45). |
 | `repairWaitFactor` | `5.0` | × estimated path delay | `RepairWaitFactor` | `[1] §3.4` — wait **5×** the estimated end-to-end delay of the lost path (`config.h` cites §3.5; see §3.3). | How long buffered packets wait for a backward repair ant before being discarded and a LinkFail sent (spec D6). |
 | `repairTimeout` | `1.0` | s | `RepairTimeout` | **`unknown`** — a fallback the paper does not define (it always has a delay estimate); the value has no recorded basis. | Flat repair wait used when the lost path has no usable delay estimate. |
 | `networkDiameter` | `30` | hops | — | **`unknown`** — legacy constant. **No `core/` code reads this field**; only the NS-2 adapter uses its `AHN_NETWORK_DIAMETER` macro, and it uses the macro directly (as the IP TTL of ant packets), not the `Config` field. | Nothing, in `core/`. See §3.3. |
-| `maxPathLength` | `100` | nodes | — | `repo choice` — golden rule 5 (bounded structures); pinned to the wire format (`kMaxVisitedOnWire == 100`). Number is a deliberately generous cap, not a tuned value. | Caps the visited-node stack an ant carries, **and** is one of the two real bounds on the reactive flood (with duplicate suppression) now that `reactiveMaxBroadcasts` is unbounded. Changing it is a wire-format change (golden rule 4). |
+| `maxPathLength` | `100` | nodes | — | `repo choice` — golden rule 5 (bounded structures); pinned to the wire format (`kMaxVisitedOnWire == 100`). Number is a deliberately generous cap, not a tuned value. | Caps the visited-node stack an ant carries, **and** is a backstop on the reactive flood (with duplicate suppression and, since #173, the per-node broadcast count). Changing it is a wire-format change (golden rule 4). |
 | `maxHistory` | `4096` | entries | — | `repo choice` — golden rule 5; digest §6 records that dedup bounds are "not in [1]". Number is a generous cap, not tuned. | FIFO cap on the `(src,seq)` dedup history and the generation-quality tracker. Too small aliases dedup and re-admits old ants. |
 
 ### 3.2 Parameters with no recorded provenance
@@ -202,10 +219,21 @@ purely because no benchmark has yet justified flipping it.
 
 ### Reactive setup — `reactiveMaxBroadcasts`, `enableMultipath`, `antAcceptanceFactor`, `reactiveRetryInterval`, `maxPathLength`
 
-How routes are discovered. **Do not put a finite budget back into
-`reactiveMaxBroadcasts`** except as a deliberate sensitivity experiment: it is a
-hop limit, and that is exactly the #169 bug. The flood is bounded by duplicate
-suppression, `maxPathLength`, and — with multipath on — the acceptance band.
+How routes are discovered. `reactiveMaxBroadcasts` bounds how often **one
+node** re-broadcasts **one generation** (default 2). Read its history before
+touching it, because the same name has meant two different things:
+
+- As a budget *carried on the ant* and decremented at each hop it was a **hop
+  limit on discovery** — destinations beyond ~5 hops were never found (#169).
+  Never reintroduce that form.
+- As a per-node count it does not limit reach at all, and it is **required**:
+  with multipath on, a reactive forward ant is admitted by the acceptance band
+  *instead of* `(src,seq)` duplicate suppression, and the band admits rather
+  than suppresses. Without the per-node count one discovery on a 7x7 grid cost
+  30,090 ants and ns-3 `large-scale` fell to 21.7% PDR (#173).
+
+Setting it to `-1` restores the unbounded behaviour and is a sensitivity
+experiment, not a configuration.
 
 `antAcceptanceFactor` is the multipath dial and its direction is
 counter-intuitive: **higher admits more ant copies**, i.e. more paths and more

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -61,6 +61,19 @@ Until the sweeps are re-run, treat every result below — including the headline
 PDR/NRL figures — as **pending re-measurement**, and do not cite the
 sparse-static weakness as a property of the algorithm.
 
+**Confirmed, and it exposed a second defect.** The first taxonomy run after the
+fix bears the diagnosis out: `sparse-static` rose 83.8 → **93.0 %**, overtaking
+AODV (81.9 %), and the inversion is gone. But `large-scale` fell 75.8 → 21.7 %
+and `heavy-load` 85.0 → 51.4 %, with NRL rising 99.9 → 3071. Cause
+([#173](https://github.com/danieljoppi/AntHocNet/issues/173)): with
+`enableMultipath` on, a reactive forward ant is admitted by the acceptance band
+*instead of* `(src,seq)` duplicate suppression, so removing the broadcast budget
+left the reactive flood unbounded in dense graphs. `reactiveMaxBroadcasts` is
+now a **per-(node, generation)** broadcast count (default 2) rather than a
+per-path budget — bounding the flood without reintroducing the #169 hop limit.
+Numbers measured between those two fixes carry the flood and are not
+representative either.
+
 ## Known deviations (honest list)
 
 1. **Delay tail on the ns-3 disk model (#21).** On the contention-dominated


### PR DESCRIPTION
Fixes #173. **Draft until the ns-3 taxonomy confirms recovery** — the core testbench uses an ideal MAC, so it can prove the flood is bounded but not that PDR recovers under contention.

## The defect

Since PR #170, one route discovery in a dense graph is unbounded: **30,090 reactive ants** on a 7×7 grid, and in ns-3 `large-scale` fell to 21.7% PDR at NRL 3071 (from 75.8 / 99.9), `heavy-load` to 51.4% (from 85.0).

## Why it happened — no single change was wrong

Two correct changes each removed one bound:

- **#96** made a *reactive forward* ant take the multipath acceptance band **instead of** `(src,seq)` duplicate suppression. Reasonable — the band is the paper's multipath rule — but the band **admits** rather than suppresses: any later same-generation copy within `antAcceptanceFactor` of the best is forwarded. `history_` stopped applying to this one ant type.
- **#169 / PR #170** removed its broadcast budget. Also reasonable, and correct: carried on the ant and decremented every hop, it was a hop limit on discovery (>5 hops undiscoverable).

Between them, reactive discovery had no flood bound but `maxPathLength = 100` — no bound at all at 25–100 nodes. Each node re-broadcasts as comparable copies arrive from every neighbour, and each re-broadcast seeds more admissible copies.

The invariant they jointly broke was written **only in a code comment** (`propagation is also bounded by broadcastBudget (A3) and (src,seq) dedup`), which silently became false on both counts. Corrected here.

## The fix

`GenerationTracker::allowBroadcast()` counts broadcasts per **(node, generation)**, reusing the key, lifetime and FIFO bound the acceptance filter already keeps. `onReceiveAnt` consults it at the broadcast site — the only place a reactive ant can flood.

`reactiveMaxBroadcasts` is reused **with a changed unit**: broadcasts per ant *path* → broadcasts per *node per generation*, default back to `2`. That is deliberately the ADR-0012/`alpha` trap (same name, same value, new meaning), so it is spelled out at the declaration, in `docs/configuration.md` and in `fidelity.md` instead of being left for the next reader to find. Reactive ants now carry `broadcastBudget = -1` so the per-hop decrement cannot reintroduce #169; repair and proactive ants keep the per-path budget, the right unit for maintenance ants exploring near a known path.

**Why a per-node count is not a hop limit:** it does not travel with the ant, so an ant may still cross arbitrarily many hops — each node simply stops re-broadcasting the same discovery. Verified rather than assumed: a 9-hop line delivers 55/55 at the default, and still 55/55 with the bound tightened to **1**.

## Measured (core testbench, 8-connected grid, one discovery corner to corner)

| side | nodes | default | `budget=-1` | `multipath=off` |
|---|---|---|---|---|
| 3 | 9 | 10 | 10 | 10 |
| 4 | 16 | 36 | 76 | 18 |
| 5 | 25 | 94 | 420 | 28 |
| 6 | 36 | 160 | 4,094 | 40 |
| 7 | 49 | **236** | **30,090** | 54 |

Bounded and near-linear at the default. The `-1` column is retained for sensitivity experiments and is genuinely unbounded.

## Tests

- **`test_reactive_flood_bound.cpp`** (new) — asserts `O(n)` cost at the **default** config across growing grids, because the defect was combinatorial and a single size could pass by luck. A line topology cannot show it (degree 2, nothing to multiply); a full mesh cannot either (the destination is a neighbour, so discovery never runs). Hence the grid. One non-obvious measurement detail: counting `controlPacketsSent()` over a window containing a hello tick reads ~n beacons/second and every configuration looks identical — the window sits between hello ticks and counts reactive ants only.
- **`test_reactive_hop_reach.cpp`** — cases 3 and 4 pinned the *old* per-path semantics ("a finite budget delivers 0 at 9 hops"). Under the new unit that expectation is simply wrong, so they now pin the property that actually matters: reach is independent of the bound, at 2 and at 1.
- **`test_data_routing.cpp`** A3 exercised decrement-and-drop through a reactive ant, which no longer carries a budget. Retargeted to a **repair** ant, which still uses that mechanism, so coverage moves rather than disappears; new A3.1 pins that a reactive ant carries no per-path budget.

`make test`: **22/22**. `check_invariants.sh`: **PASS**.

## Remaining verification

ns-3 discrete taxonomy dispatched on this branch (`runs=5`, `time=900`, `propagation=range`). Merge criteria, from #173:

1. `large-scale` and `heavy-load` recover to at least their pre-#170 values (75.8 / 99.9 and 85.0 / 6.1);
2. `sparse-static` keeps its #169 gain (~93%, ahead of AODV) — the fix must not reintroduce a reach limit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_