### PR TITLE
docs(config): record that the thesis supersedes [1] on antAcceptanceFactor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ The `ns-3 attribute` column is the name you pass to
 | `txFailureThreshold` | `3` | consecutive failures | `TxFailureThreshold` | `repo choice` — the *debounce* is argued in [#19](https://github.com/danieljoppi/AntHocNet/issues/19)/[ADR-0008](adr/0008-neighbour-liveness-two-detectors.md) detector D; the **value 3 is not sweep-backed** (see §3.2). | How many consecutive MAC transmit failures to the same next hop (with no reception in between) count as a broken link. Lower = jumpier, more rediscovery. |
 | `reactiveMaxBroadcasts` | `2` | broadcasts per node per `(src,seq)` generation; `-1` = no bound | — | `derived` — the sources bound the reactive flood by duplicate suppression, `maxPathLength` and the acceptance band, **never by a count** ([#169](https://github.com/danieljoppi/AntHocNet/issues/169)); but with `enableMultipath` on a reactive forward ant bypasses duplicate suppression, so this restores its *intent* for that one case ([#173](https://github.com/danieljoppi/AntHocNet/issues/173)). | How many times a node re-broadcasts one discovery. **The unit changed in #173**: it was a budget carried on the ant and decremented per hop (a hop limit on reach, #169); it is now a per-node count, which bounds the flood without limiting reach. |
 | `enableMultipath` | `true` | bool | `EnableMultipath` | Mechanism `[1] §3.1` (the acceptance filter); **the gate and the linkfail churn bound** are `repo choice` ([#96](https://github.com/danieljoppi/AntHocNet/issues/96), A/B-justified: PDR 92.3 vs 89.4). | Whether later same-generation reactive ants may lay additional paths, and whether losing a best hop that leaves a usable alternate is absorbed instead of flooding a LinkFail. Off = strict `(src,seq)` dedup, single-path setup. |
-| `antAcceptanceFactor` | `1.5` | factor | `AntAcceptanceFactor` | `[1] §3.1` — "a parameter which we empirically set to **1.5**". | How many alternate paths get laid: a later ant is forwarded only if both hop count and travel time are within this factor of the generation's best. **Higher admits more copies** (up to a flood); no value reproduces single-path — use `enableMultipath=false`. |
+| `antAcceptanceFactor` | `1.5` | factor | `AntAcceptanceFactor` | `[1] §3.1` — "a parameter which we empirically set to **1.5**" — **but the thesis supersedes this**: it parameterises the same band as `a1 = 0.9` with a second factor `a2 = 2` for first-hop-disjoint ants, and records the design being dropped (§3.3, [#177](https://github.com/danieljoppi/AntHocNet/issues/177)). | How many alternate paths get laid: a later ant is forwarded only if both hop count and travel time are within this factor of the generation's best. **Higher admits more copies** (up to a flood); no value reproduces single-path — use `enableMultipath=false`. |
 | `proactiveMaxBroadcasts` | `2` | count | — | `[1] §3.3` — a proactive ant may be broadcast "at most **2**" times, else deleted (#45). | Bounds proactive exploration, including across a route gap en route. Unbounded lets proactive ants flood regions of missing routes (#45). |
 | `repairWaitFactor` | `5.0` | × estimated path delay | `RepairWaitFactor` | `[1] §3.4` — wait **5×** the estimated end-to-end delay of the lost path (`config.h` cites §3.5; see §3.3). | How long buffered packets wait for a backward repair ant before being discarded and a LinkFail sent (spec D6). |
 | `repairTimeout` | `1.0` | s | `RepairTimeout` | **`unknown`** — a fallback the paper does not define (it always has a delay estimate); the value has no recorded basis. | Flat repair wait used when the lost path has no usable delay estimate. |
@@ -241,6 +241,26 @@ setup traffic. 1.0 still admits equal-metric copies, so no value gives you
 single-path — that is what `enableMultipath=false` is for. Turning multipath off
 also turns off the linkfail churn bound that ships with it; expect more LinkFail
 volume (#96 round 1 lost 7.5 pp PDR without it).
+
+**Read the sources before tuning this one**, because they do not agree and the
+disagreement caused [#173](https://github.com/danieljoppi/AntHocNet/issues/173).
+[1] §3.1 states a single factor of 1.5. The 2007 thesis parameterises the same
+band as **`a1 = 0.9`** — "set quite low … in order to only allow the best ants
+through and avoid too much proliferation" — plus a second, looser **`a2 = 2`**
+applied *only* when an ant's **first hop** differs from previously accepted
+ants, a disjointness rule this repo does not implement. At 0.9 the band admits
+only ants better than the incumbent, so it tightens with each admission and is
+self-limiting; at 1.5 it admits ants up to 50% worse, which in a dense graph is
+nearly every neighbour's copy. That is why a discovery in a 7×7 grid cost 30,090
+ants before the per-node bound landed.
+
+The thesis then records that the authors **abandoned the mechanism entirely** —
+"high levels of overhead were often experienced … we decided to restrict
+reactive route setup to the creation of just one single route, and to rely on
+proactive route maintenance to obtain multiple routes." So the shipped default
+implements a design its own authors dropped, at a looser factor than they ever
+ran, bounded by a mechanism this repo invented. #177 is measuring the three
+options; treat this row as unsettled until it closes.
 
 ### Proactive & diffusion — `enableProactive`, `enableDiffusion`, `proactiveInterval`, `proactiveBroadcastProb`, `proactiveMaxBroadcasts`, `sessionTtl`
 


### PR DESCRIPTION
The provenance table listed `antAcceptanceFactor = 1.5` as sourced to `[1] §3.1`. That is true, and it was the whole problem: it reads as settled, so nobody looked further. The 2007 thesis parameterises the same acceptance band differently *and* records the authors dropping the mechanism — and that gap is what let [#173](https://github.com/danieljoppi/AntHocNet/issues/173) (a discovery in a 7×7 grid costing **30,090** reactive ants) hide behind a correct-looking citation.

## What the sources actually say

- **[1] (PPSN 2004) §3.1** — one factor, "a parameter which we empirically set to **1.5**".
- **2007 thesis** — `a1 = 0.9` as the base factor, *"set quite low … in order to only allow the best ants through and avoid too much proliferation of forward ants in the network"*, plus a second, less restrictive `a2 = 2` applied **only** when an ant's *first hop* differs from previously accepted ants — a disjointness rule this repo does not implement at all.
- **2007 thesis, on why it went away** — *"high levels of overhead were often experienced. Therefore, we decided to restrict reactive route setup to the creation of just one single route, and to rely on proactive route maintenance to obtain multiple routes."*

## Why the direction matters

At **0.9** the band admits only ants *better* than the incumbent, so it tightens with every admission and is self-limiting. At **1.5** it admits ants up to 50% *worse*, which in a dense graph is nearly every neighbour's copy of the generation. Measured in the testbench, one discovery on a 7×7 grid: **54** ants at `a1 = 0.9`, **30,090** at 1.5 unbounded.

So the shipped default implements a design its own authors abandoned, at a looser factor than they ever ran, bounded by a per-node mechanism this repo invented (#174). That is a defensible short-term position — it un-broke `main` — but it is not a *sourced* one, and the table must not imply otherwise.

## Changes

Two edits to `docs/configuration.md`: the `antAcceptanceFactor` row's source cell now says the thesis supersedes [1] and points at #177, and the "Reactive setup" group gains a paragraph with the quotes above and the direction explanation. [#177](https://github.com/danieljoppi/AntHocNet/issues/177) measures the three options at `runs=5` and will settle the row.

Docs only; no code touched. `make test`: **22/22**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_