### PR TITLE
chore: ignore .claude/worktrees/, the agent isolation checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ rtable.txt
 # Python bytecode (ns3/tools/*.py, .claude/skills/*.py)
 __pycache__/
 *.pyc
+
+# Agent worktrees (Claude Code `isolation: worktree`). Each entry is a full
+# checkout of this repo created for a subagent to work in isolation, so it must
+# never be committed into the repo it is a copy of.
+.claude/worktrees/


### PR DESCRIPTION
Running subagents with worktree isolation creates `.claude/worktrees/agent-<id>/`, each a **full checkout of this repository**. Left untracked they show up as dirty state on whichever branch happens to be checked out, and a careless `git add -A` would commit a recursive copy of the repo into itself — 26 MB for the three worktrees live when this was written.

They are transient harness-owned state, not project files, so they belong in `.gitignore` next to `__pycache__`.

Four lines, comment included. No other change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_