### PR TITLE
fix(bench): correct the thesis scenario preset from the source, and let scenario-matrix pass extraArgs

### DIFF
--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -30,6 +30,9 @@ on:
       propagation:
         description: 'Propagation model override for every point: range (disk) | tworay. Leave blank for anthocnet-compare''s default (range).'
         default: ''
+      extraArgs:
+        description: 'Extra anthocnet-compare args appended verbatim to every point — mainly ns-3 attribute overrides, so protocol variants can be A/B''d from a dispatch instead of a branch per arm (#177). e.g. --ns3::anthocnet::RoutingProtocol::BetaData=20 --ns3::anthocnet::RoutingProtocol::EnableMultipath=false'
+        default: ''
       commit:
         description: 'Commit regenerated charts + CSV into docs/ on this ref'
         type: boolean
@@ -126,11 +129,20 @@ jobs:
           if [ -n "${{ github.event.inputs.point }}" ]; then
             point="--point=${{ github.event.inputs.point }}"
           fi
+          # #177: extraArgs must reach anthocnet-compare as ONE argv element
+          # here, so it is quoted — unlike $quick/$propagation/$point above,
+          # which are single tokens deliberately left unquoted to expand to
+          # nothing when empty. run-scenarios.py splices the string into its
+          # `./ns3 run "anthocnet-compare ..."` command line, where the shell
+          # word-splits it — the same place paper-benchmark.yml's extraArgs is
+          # split, so multi-argument values behave identically in both
+          # workflows. Empty is the default and is a no-op.
           python3 ns3/tools/run-scenarios.py /opt/ns-3 \
             --out "$GITHUB_WORKSPACE/scenarios.csv" \
             --runs "${{ github.event.inputs.runs }}" \
             --time "${{ github.event.inputs.time }}" \
             --only "${{ github.event.inputs.only }}" \
+            --extra-args "${{ github.event.inputs.extraArgs }}" \
             $quick $propagation $point
       - name: Render charts
         # always(): a mid-sweep failure (one anthocnet-compare invocation

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -28,6 +28,49 @@ cd /path/to/ns-3-dev
 bash /path/to/AntHocNet/ns3/tools/run-comparison.sh "$PWD" 10 20 40 300 5
 ```
 
+### Reproducing a *thesis* run
+
+`--scenario=paper` is the **calibration** field ([#24](https://github.com/danieljoppi/AntHocNet/issues/24));
+`--scenario=thesis` is AntHocNet's **own evaluation** field, and is what a
+fidelity claim runs on. Its constants come from Ducatelle, *Adaptive Routing in
+Ad Hoc Wireless Multi-hop Networks* (PhD thesis, 2007) **§5.1.3**, read from the
+PDF ([#58](https://github.com/danieljoppi/AntHocNet/issues/58)):
+
+| axis | thesis §5.1.3 | set by the preset? |
+|---|---|---|
+| nodes | 100 | ✅ |
+| area | 2400 × 800 m | ✅ |
+| mobility | random waypoint, speed U[0, **10**] m/s, pause 30 s | ✅ |
+| duration | 900 s | ✅ |
+| **repetitions** | **20** | ✅ *only when `--runs` is not passed* — see below |
+| sessions | 20 UDP, start uniform in [0, 180] s | ✅ |
+| traffic | **4 packets/s × 64 B = 2048 bps** per session | ✅ |
+| radio | 802.11 DCF, 2 Mbit/s, range **250 m** | ✅ |
+| **propagation** | **two-ray** | ❌ — harness default is the `range` disk model |
+
+Two axes therefore need care, and **both must be set explicitly to reproduce a
+thesis figure**:
+
+- **Propagation.** The harness defaults to `--propagation=range` (the disk
+  model) for every scenario. That is a deliberate #24 disentangler and is *not*
+  overridden per-preset, so the thesis's two-ray PHY must be asked for.
+- **Repetitions.** `--runs` defaults to **20 under `--scenario=thesis`** (1
+  otherwise), but an explicit `--runs=N` always wins — and
+  `run-scenarios.py`, `paper-benchmark.yml` and `scenario-matrix.yml` *always*
+  pass one. Through any of those paths you must set **`runs=20`** yourself; the
+  preset default only applies to a bare command line.
+
+```bash
+# the thesis field, faithfully (20 repetitions × 900 s — hours, not minutes):
+./ns3 run "anthocnet-compare --scenario=thesis --propagation=tworay --runs=20"
+```
+
+Averaging over fewer than 20 runs is a legitimate cheap probe, but it is not a
+thesis reproduction: several arguments in this repo have turned on differences
+smaller than the dispersion at low run counts, and `pdr_sd` as high as 6.43 has
+been observed ([#173](https://github.com/danieljoppi/AntHocNet/issues/173)).
+Record the run count next to any number quoted against a thesis figure.
+
 Publishing the results back into these pages is
 [`ns3/tools/update-benchmarks.py`](../../ns3/tools/update-benchmarks.py)'s job:
 it rewrites the generated block of every page in place, so hand-written prose

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -115,7 +115,10 @@ representative either.
 - **Parameters vs 2007 thesis**: 🟡 partial — thesis obtained 2026-07-25.
   `T_hop` ✅ adopted (3 ms). Jitter estimator ✅ *defined* in the thesis
   (eq. 5.1, `Σ|(tᵢ−tᵢ₋₁)−(tᵢ₋₁−tᵢ₋₂)|`) but **not yet reconciled** with our
-  FlowMonitor `jitterSum` metric (#89). Full field table ⏳ (#58).
+  FlowMonitor `jitterSum` metric (#89). Full field table ✅ read from §5.1.3 and
+  adopted into `--scenario=thesis` (#58) — five constants corrected
+  (2400×800 m, 10 m/s, 2048 bps, 250 m range, 20 repetitions); the thesis's
+  two-ray propagation still has to be asked for with `--propagation=tworay`.
 - **Numbers on the paper's own 900 s / large-scale field**: ⏳ `--scenario=thesis`
   preset exists; the multi-hour run is future work.
 

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -612,14 +612,14 @@ int main(int argc, char* argv[]) {
     double   speed = -1, pause = -1, range = -1, cbrBps = -1;
     int32_t  nFlows = 0;
     int32_t  sink = -1;
-    uint32_t runs = 1;
+    uint32_t runs = 0;  // 0 = unset; resolved below (preset-dependent, #58)
     bool csv = false;
     std::string protocols = "anthocnet,aodv,olsr,dsdv";
 
     CommandLine cmd(__FILE__);
     cmd.AddValue("scenario", "Preset: 'paper' (Broch/CMU calibration field) or "
-                             "'thesis' (the AntHocNet papers' own evaluation "
-                             "field, provisional values — #58)", scenario);
+                             "'thesis' (AntHocNet's own evaluation field, "
+                             "Ducatelle PhD 2007 §5.1.3 — #58)", scenario);
     cmd.AddValue("nNodes", "Number of nodes", nNodes);
     cmd.AddValue("time", "Simulation time (s)", simTime);
     cmd.AddValue("area", "Square area side (m); shorthand for areaX=areaY", area);
@@ -632,7 +632,8 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("cbrBps", "Per-flow CBR rate (bits/s)", cbrBps);
     cmd.AddValue("sink", "If >=0, all flows converge on this node (gateway "
                          "hotspot, #71) instead of i->(n-1-i) pairing", sink);
-    cmd.AddValue("runs", "Number of RNG runs to average (seeds 1..runs)", runs);
+    cmd.AddValue("runs", "Number of RNG runs to average (seeds 1..runs); unset "
+                         "= 1, or 20 for --scenario=thesis (#58)", runs);
     cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
     cmd.AddValue("protocols", "Comma-separated list", protocols);
     cmd.AddValue("diag", "Emit per-run '# diag' lines (ant tallies, first delivery)", g_diag);
@@ -647,30 +648,58 @@ int main(int argc, char* argv[]) {
                  "DSSS rate; default constant2, the paper's radio) | arf | ideal "
                  "(ns-3 default; loses ~50% single-hop, #51)", rateManager);
     cmd.Parse(argc, argv);
-    if (runs < 1) runs = 1;
 
     // 'paper' = the Broch/CMU MobiCom'98 field (the literature *calibration*
-    // anchor, #24). 'thesis' = the AntHocNet papers' own evaluation field
-    // (ETT 2005 / Ducatelle PhD 2007): 100 nodes on 3000x1000 m, otherwise the
-    // same radio/traffic/mobility regime. Fidelity claims run on 'thesis',
-    // calibration on 'paper'. VALUES ARE PROVISIONAL (#58): reconstructed from
-    // secondary knowledge because the primary PDFs are network-blocked here —
-    // verify against the thesis parameter table before publishing.
+    // anchor, #24). 'thesis' = AntHocNet's own evaluation field, read from
+    // Ducatelle, "Adaptive Routing in Ad Hoc Wireless Multi-hop Networks"
+    // (PhD thesis, 2007) **§5.1.3** — quoted values, no longer reconstructed
+    // (#58). Fidelity claims run on 'thesis', calibration on 'paper'.
+    //
+    //   nodes        100
+    //   area         2400 x 800 m   ("move in a rectangular area of 2400 x 800m²")
+    //   mobility     RWP, speed U[0,10] m/s, pause 30 s  ("a minimum and maximum
+    //                speed of respectively 0 and 10 m/s, and a pause time of 30 s")
+    //   duration     900 s, repeated 20 times  ("Each experiment has a duration
+    //                of 900 s, and is repeated 20 times")
+    //   traffic      20 UDP sessions, 4 x 64-byte packets/s = 2048 bps  ("Each
+    //                session generates 4 packets of 64 bytes per second")
+    //   start window uniform in [0, 180] s
+    //   radio        802.11 DCF at 2 Mbit/s; range 250 m  ("The estimated radio
+    //                range is 250 m")
+    //
+    // Before #58's PDF pass this preset carried five wrong constants (3000x1000 m,
+    // 20 m/s, 512 bps, 300 m range, 5 runs), all inherited from 'paper' or from a
+    // secondary-source reconstruction. Provenance is spelled out inline on
+    // purpose: unsourced numbers caused #88, #169 and #173.
+    //
+    // Two axes are deliberately NOT forced by the preset:
+    //  - **propagation**: the thesis uses a **two-ray** model; this harness
+    //    defaults to the `range` disk model (the #24 calibration disentangler,
+    //    a global default we do not change per-preset). Pass
+    //    `--propagation=tworay` to match §5.1.3.
+    //  - **repetitions**: `--runs` defaults to 20 for this preset only (see
+    //    below), but any explicit `--runs=N` wins — and run-scenarios.py and
+    //    both benchmark workflows always pass one. Reproducing a thesis figure
+    //    through those means setting runs=20 there.
+    // See docs/benchmarks/methodology.md ("Reproducing a thesis run").
     const bool thesis = (scenario == "thesis");
     const bool paper = (scenario == "paper") || thesis;
+    // #58: the thesis averages 20 repetitions; everything else keeps the
+    // historical default of 1. Explicit --runs=N always overrides.
+    if (runs < 1) runs = thesis ? 20 : 1;
     Params P;
     P.nNodes  = nNodes > 0 ? static_cast<uint32_t>(nNodes)
                            : (thesis ? 100 : paper ? 50 : 20);
     P.simTime = simTime >= 0 ? simTime : (paper ? 900.0 : 40.0);
     P.areaX   = areaX >= 0 ? areaX
-                           : (area >= 0 ? area : (thesis ? 3000.0 : paper ? 1500.0 : 300.0));
+                           : (area >= 0 ? area : (thesis ? 2400.0 : paper ? 1500.0 : 300.0));
     P.areaY   = areaY >= 0 ? areaY
-                           : (area >= 0 ? area : (thesis ? 1000.0 : paper ? 300.0 : 300.0));
-    P.speed   = speed >= 0 ? speed : (paper ? 20.0 : 5.0);
+                           : (area >= 0 ? area : (thesis ? 800.0 : paper ? 300.0 : 300.0));
+    P.speed   = speed >= 0 ? speed : (thesis ? 10.0 : paper ? 20.0 : 5.0);
     P.pause   = pause >= 0 ? pause : (paper ? 30.0 : 1.0);
-    P.range   = range >= 0 ? range : (paper ? 300.0 : 0.0);
+    P.range   = range >= 0 ? range : (thesis ? 250.0 : paper ? 300.0 : 0.0);
     P.nFlows  = nFlows > 0 ? static_cast<uint32_t>(nFlows) : (paper ? 20 : 5);
-    P.cbrBps  = cbrBps >= 0 ? cbrBps : (paper ? 512.0 : 8000.0);
+    P.cbrBps  = cbrBps >= 0 ? cbrBps : (thesis ? 2048.0 : paper ? 512.0 : 8000.0);
     P.startWindow = paper ? 180.0 : 5.0;
     P.propagation = propagation;
     P.rateManager = rateManager;

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -92,7 +92,7 @@ OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + METRICS)
 
 
-def build_args(flags, runs, time, protocols, propagation):
+def build_args(flags, runs, time, protocols, propagation, extra_args=""):
     """Turn a flags dict into an anthocnet-compare argument string."""
     merged = dict(flags)
     merged.setdefault("runs", runs)
@@ -104,6 +104,13 @@ def build_args(flags, runs, time, protocols, propagation):
     parts = ["--csv"]
     for k, v in merged.items():
         parts.append(f"--{k}={v}")
+    # #177: caller-supplied args, appended verbatim and LAST so they override
+    # the taxonomy's own flags (ns-3's CommandLine takes the last occurrence).
+    # Same contract as paper-benchmark.yml's extraArgs input: the string is
+    # spliced into the `./ns3 run "anthocnet-compare ..."` command line and
+    # word-split there, so it may carry several space-separated arguments.
+    if extra_args:
+        parts.append(extra_args)
     return " ".join(parts)
 
 
@@ -180,6 +187,14 @@ def main():
                     help="override propagation model for every point: "
                          "range (disk) | tworay; default lets anthocnet-compare "
                          "use its own default (range)")
+    ap.add_argument("--extra-args", default="",
+                    help="extra anthocnet-compare arguments, appended verbatim "
+                         "to every point (pass the whole thing as ONE shell "
+                         "argument). Mainly ns-3 attribute overrides, so a "
+                         "protocol variant can be A/B'd from a workflow "
+                         "dispatch instead of a throwaway branch (#177), e.g. "
+                         "'--ns3::anthocnet::RoutingProtocol::BetaData=20 "
+                         "--ns3::anthocnet::RoutingProtocol::EnableMultipath=false'")
     ap.add_argument("--only", default="all",
                     help="all|discrete|sweeps|<discrete name>|<sweep name>")
     ap.add_argument("--point", default=None,
@@ -215,7 +230,7 @@ def main():
                     continue
                 rows = run_compare(args.ns3dir,
                                    build_args(flags, runs, sim_time, args.protocols,
-                                              args.propagation),
+                                              args.propagation, args.extra_args),
                                    args.dry_run, label=name)
                 emit(w, "discrete", name, "", name, klass, flags.get("pause", ""),
                      args.propagation, rows)
@@ -238,7 +253,7 @@ def main():
                     flags.update(extra)
                     rows = run_compare(args.ns3dir,
                                        build_args(flags, runs, sim_time, args.protocols,
-                                                  args.propagation),
+                                                  args.propagation, args.extra_args),
                                        args.dry_run, label=f"{name}={x}")
                     emit(w, "sweep", name, x, f"{name}={x}", xlabel,
                          flags.get("pause", ""), args.propagation, rows)

--- a/scenarios.csv
+++ b/scenarios.csv
@@ -1,0 +1,1 @@
+kind,group,x,scenario,class,protocol,runs,nNodes,areaX,speed,pause,flows,propagation,pdr_pct,delay_ms,delay99_ms,throughput_kbps,nrl,jitter_ms,delay_off50_ms,delay_off90_ms,pdr_sd,delay_sd,delay99_sd,nrl_sd,nrl_bytes


### PR DESCRIPTION
Two benchmark-harness fixes that were blocking honest comparison against the thesis.

## Part 1 — `--scenario=thesis` had five wrong constants ([#58](https://github.com/danieljoppi/AntHocNet/issues/58))

The preset's own comment admitted *"VALUES ARE PROVISIONAL (#58) … reconstructed from secondary knowledge"*. The thesis has now been read directly (§5.1.3), and five of them were wrong:

| axis | old → new |
|---|---|
| `P.areaX` | `3000.0` → **`2400.0`** |
| `P.areaY` | `1000.0` → **`800.0`** |
| `P.speed` | `20.0` (inherited from `paper`) → **`10.0`** |
| `P.range` | `300.0` (inherited) → **`250.0`** |
| `P.cbrBps` | `512.0` (inherited) → **`2048.0`** (4 pkt/s × 64 B) |

**They did not cancel** — larger area and 2× speed made our field harder, longer range and ¼ traffic made it easier — so absolute numbers from this preset were not comparable to a thesis figure in either direction. That is the one thing the preset exists to provide.

Correct and unchanged: 100 nodes, pause 30 s, duration 900 s, 20 sessions, start window 0-180 s, 802.11 @ 2 Mbit/s DCF, UDP. Only the `thesis` preset is touched; `paper` and every other scenario are untouched.

The "PROVISIONAL / reconstructed" comment is replaced by a parameter block quoting the thesis inline and citing §5.1.3 — provenance travelling with the value, since unsourced numbers caused #88, #169 and #173.

### `runs=20`, and an honest limit on the fix

The thesis averages **20** realisations; we defaulted to 1. Rather than change the global default (which would affect every scenario), `runs` becomes an unset-sentinel filled in per preset:

```cpp
if (runs < 1) runs = thesis ? 20 : 1;
```

This is the file's own existing idiom — its header comment already documents sentinels meaning "unset so a preset fills in" — so it adds no new mechanism. Explicit `--runs=N` still wins. One behaviour change to note: `--runs=0` previously clamped to 1 and now selects the preset value.

**The important caveat:** `run-scenarios.py`, `paper-benchmark.yml` and `scenario-matrix.yml` all pass `--runs` explicitly, so this default only ever applies to a bare command line. Through any workflow path the caller must still set `runs=20` themselves. That is stated in the preset comment and in `docs/benchmarks/methodology.md` rather than left for someone to discover.

Propagation is likewise documented, not silently changed: the thesis uses two-ray, our global default is the `range` disk model, and the preset does not override it — `--propagation=tworay` must be asked for.

Also updated: the `--scenario` and `--runs` CLI help, a new "Reproducing a thesis run" section in `docs/benchmarks/methodology.md` with the full table and both caveats, and one stale line in `docs/fidelity.md` claiming the field table was still pending.

## Part 2 — `extraArgs` for `scenario-matrix.yml` ([#177](https://github.com/danieljoppi/AntHocNet/issues/177))

`paper-benchmark.yml` has an `extraArgs` input; `scenario-matrix.yml` did not. That gap has a real cost: comparing protocol variants currently needs **a separate git branch per arm** purely to change a default, which is exactly what #177's four arms are doing right now.

`ns3/tools/run-scenarios.py` had no pass-through, so it gains `--extra-args` (default `""`), threaded through `build_args()` to all three call sites (discrete scenarios and both sweep paths). Appended **last** and verbatim, so it overrides the taxonomy's own flags — ns-3's `CommandLine` takes the last occurrence.

**One deliberate deviation from `paper-benchmark.yml`, because copying it exactly would have been a bug.** paper-benchmark interpolates `extraArgs` *unquoted*, which is right there: it composes a single command string that `./ns3 run "$cmd"` splits later. scenario-matrix invokes python directly, so an unquoted interpolation would word-split at the **shell** and only the first token would reach `--extra-args`. It is therefore quoted at the call site, and `run-scenarios.py` splices it into its own `./ns3 run "anthocnet-compare …"` string — splitting at the same point paper-benchmark's does. End-to-end semantics identical. Neighbouring `$quick $propagation $point` stay unquoted (single tokens that must vanish when empty).

## Verification

`make test` 22/22 · `check_invariants.sh` clean · `ruff check ns3/tools` clean under the **CI-pinned 0.16.0** (note: the `ruff` on PATH is 0.15.8 and shadows it — run via `python3 -m ruff`) · `ast.parse` OK · `yaml.safe_load` of the workflow OK. A `--dry-run` confirms extra args land last and verbatim, and that an empty value reproduces the previous command byte-for-byte.

**Not verified here:** `anthocnet-compare` does not compile in this environment (no ns-3 tree) — the C++ changes need the CI matrix. The workflow change cannot be exercised until dispatched. And no thesis-preset benchmark has been run, so the corrected preset's actual numbers are unknown; per #58 a mismatch against published figures is still expected while #179, #180 and #181 remain open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_