### PR TITLE
docs: record the per-version Zenodo DOIs, which nothing tracked

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,30 @@ is blocked (the agent proxy returns 403), and the new DOI does not exist until
 after publish anyway. Ask the maintainer for the DOI (concept preferred) and
 open the `docs:` PR with the value they give you. **Never invent a DOI.**
 
+#### DOI record
+
+Because the badge and `CITATION.cff` intentionally carry the **concept** DOI,
+the per-version DOIs are not recorded anywhere else — and those are what you
+cite when referencing a *specific* version rather than "the software". This
+table is that record.
+
+| Target | DOI | Resolves to |
+|---|---|---|
+| **Concept ("all versions")** | `10.5281/zenodo.20981979` | always the latest release — this is the value in the README badge and `CITATION.cff` |
+| v1.0.0 | `10.5281/zenodo.21502372` | [record 21502372](https://zenodo.org/records/21502372) |
+| v1.1.0 | `10.5281/zenodo.21583731` | [record 21583731](https://zenodo.org/records/21583731) |
+
+**Adding a row is the whole per-release chore.** Append the new version DOI
+here; do **not** touch the README badge or `CITATION.cff`, which already point
+at the concept DOI and therefore need no update. Pinning either of them to a
+version DOI is the regression [#116](https://github.com/danieljoppi/AntHocNet/pull/116)
+fixed — the badge had been left on an earlier release's version DOI and had
+silently gone stale.
+
+Cite the **concept** DOI for the software in general, and a **version** DOI when
+reproducing a specific result — benchmark numbers in `docs/` are tied to a
+release, so a paper reproducing them should cite that release's DOI.
+
 ## Pull requests
 
 - Branch from `main`; keep PRs focused.


### PR DESCRIPTION
The README badge and `CITATION.cff` deliberately carry the **concept** DOI (`10.5281/zenodo.20981979`), which auto-resolves to the latest release — [#116](https://github.com/danieljoppi/AntHocNet/pull/116) set them that way so the post-release chore is one-time rather than per-release.

A consequence nobody had noticed: the **per-version** DOIs are then recorded nowhere, and those are exactly what you cite when referencing a *specific* version rather than "the software". This adds that record, in the section that already explains the concept-vs-version distinction.

| Target | DOI | Resolves to |
|---|---|---|
| **Concept ("all versions")** | `10.5281/zenodo.20981979` | always the latest release — the value in the badge and `CITATION.cff` |
| v1.0.0 | `10.5281/zenodo.21502372` | record 21502372 |
| v1.1.0 | `10.5281/zenodo.21583731` | record 21583731 |

**Sources.** The concept and v1.0.0 values are the ones #116 verified against the v1.0.0 Zenodo record; the v1.1.0 value was supplied by the maintainer after publish. None was invented — `zenodo.org` is proxy-blocked from the sandbox (`curl` returns `000`), so an agent cannot look these up and must be given them. `CONTRIBUTING.md` already says as much; this PR keeps to it.

## The part worth reading

The section now states plainly that **appending a row here is the entire per-release chore**, and that the badge and `CITATION.cff` must *not* be touched.

That is worth being explicit about rather than assumed: pinning either to a version DOI is exactly the regression #116 fixed — the badge had been left on an earlier release's version DOI and silently gone stale. Someone handed a fresh DOI after a release will very reasonably assume it belongs in the badge. It does not, and now the file says so at the point of temptation.

It also records *when* each form is the right citation: the concept DOI for the software in general, a version DOI when reproducing a specific result. The benchmark numbers in `docs/` are tied to a release, so a paper reproducing them should cite that release's DOI rather than the moving target — relevant to the JOSS draft in `paper/` and to the papers repo.

Docs only, one file. `README.md` and `CITATION.cff` are deliberately unchanged; the diff confirms it (`1 file changed, 24 insertions(+)`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_