### PR TITLE
feat(bench): measure packet reordering, the documented cost of multipath

### DIFF
--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -157,6 +157,9 @@ warnings. `results` checks: PDR ∈ [0,100], delay99 ≥ mean delay, negative
 metrics, dead cells (#28), the #209 energy invariants (total energy positive
 and finite, energy-per-delivered-packet finite and non-negative — and non-zero
 whenever PDR is, residual energy within [0, initial]; all skipped for inputs
-predating energy instrumentation), and — with `--anchor` — the AODV floors read from
+predating energy instrumentation), the #212 reordering bounds (out-of-order
+ratios in [0,1]; extents and reorder-buffer occupancies finite and
+non-negative — all skipped for inputs predating reordering instrumentation),
+and — with `--anchor` — the AODV floors read from
 `ns3/tools/anchors.yml` (never duplicated). A `results` FAIL is a #51-class
 harness regression: fix the harness before trusting any number from that run.

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -108,6 +108,12 @@ def parse_results(path):
     columns (energy(J), J/pkt) at positions 10/11; the residual spread, the
     configured initial energy and the first-death time live in the CSV only
     (the human output puts them on a '# energy' line, which ROW does not match).
+
+    Reordering fields (#212) exist only in CSVs produced after the reordering
+    instrumentation landed; older inputs simply omit them and the reordering
+    rules below are skipped. They are CSV-only by design — anthocnet-compare
+    prints them on a '# reorder' line rather than widening the fixed-width
+    results table, and ROW does not match a '# ' line.
     """
     with open(path) as fh:
         text = fh.read()
@@ -123,7 +129,12 @@ def parse_results(path):
                    "energy_per_pkt": r.get("energy_per_pkt_j"),
                    "res_min": r.get("energy_res_min_j"),
                    "res_mean": r.get("energy_res_mean_j"),
-                   "energy_init": r.get("energy_init_j")}
+                   "energy_init": r.get("energy_init_j"),
+                   "reorder_ratio": r.get("reorder_ratio"),
+                   "reorder_ratio_max": r.get("reorder_ratio_max"),
+                   "reorder_extent_mean": r.get("reorder_extent_mean"),
+                   "reorder_extent_max": r.get("reorder_extent_max"),
+                   "reorder_buf_max": r.get("reorder_buf_max")}
         return
     for line in text.splitlines():
         m = ROW.match(line)
@@ -200,6 +211,25 @@ def cmd_results(a):
                     if v < 0.0:
                         report("FAIL", f"{tag}: negative residual energy "
                                        f"{k}={v} J")
+            # #212 reordering plausibility. These are definitional bounds, not
+            # protocol expectations: the ratios are fractions of received
+            # packets, and extents/occupancies are counts of packets. A
+            # violation means the sequence tracking at the sink is broken (flows
+            # merged under one key, sequence numbers not carried, aggregation
+            # divided by the wrong denominator), so it is a harness regression —
+            # hence FAIL. A *high* but in-range reordering figure for AntHocNet
+            # is expected multipath behaviour and is deliberately not flagged.
+            for k in ("reorder_ratio", "reorder_ratio_max"):
+                v = num(k)
+                if v is not None and not (math.isfinite(v) and 0.0 <= v <= 1.0):
+                    report("FAIL", f"{tag}: {k} {r.get(k)} outside [0,1] — "
+                                   "reordering instrumentation broken")
+            for k in ("reorder_extent_mean", "reorder_extent_max",
+                      "reorder_buf_max"):
+                v = num(k)
+                if v is not None and not (math.isfinite(v) and v >= 0.0):
+                    report("FAIL", f"{tag}: {k} {r.get(k)} is not a finite "
+                                   "non-negative packet count")
             if floor is not None and r["proto"] == "aodv" and pdr is not None:
                 if pdr < floor:
                     report("FAIL", f"{tag}: anchor '{a.anchor}' floor "

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -114,6 +114,114 @@ every ns-3 release the CI matrix covers (3.36–3.48).
 - **NS-3 only.** The NS-2 adapter has no energy instrumentation; see
   [cross-validation.md](../cross-validation.md).
 
+## Packet reordering (#212, NS-3 only)
+
+Stochastic multipath forwarding delivers packets out of order **by
+construction**: AntHocNet picks the next hop per packet, pheromone-weighted,
+across several paths of differing delay, so a packet sent later on a shorter
+path can overtake one sent earlier on a longer one.
+[configuration.md](../configuration.md) already names this as the cost of a low
+`betaData` ("lower = more spread — and more reordering"); these columns measure
+it. **Read a non-zero AntHocNet figure as the mechanism working as designed, not
+as a fault.** It is a trade, not a defect: what it buys is the load spreading and
+the route redundancy that the PDR and NRL columns report. The number that
+matters is whether the reordering an application would feel is worth those
+gains — which is exactly the question [#179](https://github.com/danieljoppi/AntHocNet/issues/179) (`betaData` 2 → the thesis's 20)
+has to answer, and could not before this metric existed.
+
+`FlowMonitor` reports per-flow counts and delays, never per-packet order, so
+these come from an application-level sequence number instead: the ns-3
+`OnOffApplication` sources set `EnableSeqTsSizeHeader`, and every `PacketSink`
+reads the sequence number off each delivered datagram. **Packet size is
+unchanged** — ns-3 builds the 20-byte `SeqTsSizeHeader` *inside* the configured
+64-byte `PacketSize`, so the datagram is still 64 bytes on the wire and no
+existing PDR / delay / throughput / NRL number moves.
+
+Metrics are computed **per flow** (keyed by the source socket address, so the
+`--sink` converge mode's shared sink still separates flows) and only then
+aggregated. A single badly-spread flow is the interesting case and a pooled
+number alone would hide it, hence the worst-flow column.
+
+- **reorder_ratio** — out-of-order delivery ratio, pooled over all data flows:
+  reordered packets / received packets, in [0,1].
+- **reorder_ratio_max** — the same ratio for the **worst single flow**.
+- **reorder_extent_mean / reorder_extent_max** — reordering extent over the
+  reordered packets, in packets: mean, and the largest seen.
+- **reorder_buf_max** — the largest reorder-buffer occupancy, in packets, that a
+  receiver would need to hand the delivered packets up in sequence order.
+
+### The exact definitions used
+
+"Reordering" has several non-equivalent definitions in the literature, so the
+choice is stated here rather than left implicit. All three follow
+[RFC 4737](https://www.rfc-editor.org/rfc/rfc4737) (*Packet Reordering
+Metrics*), applied to the receive stream of one flow at the sink:
+
+1. **Reordered / out-of-order** — RFC 4737's `Type-P-Reordered` singleton.
+   Maintain `NextExp`, the largest sequence number seen so far plus one. An
+   arriving packet with sequence number `s` is **reordered iff `s < NextExp`**;
+   when it is not, `NextExp` advances to `s + 1`, and when it is, `NextExp` is
+   left alone. `NextExp` never decreases, which is what makes the criterion
+   order-preserving. Equivalently — and this is how issue #212 words it — a
+   packet counts as reordered when its sequence number is below the running
+   maximum for that flow.
+   **Loss is not reordering**: a lost packet merely makes `NextExp` jump, and
+   the packets that follow are still in order. This matters here, because the
+   harness runs at PDRs well below 100 %.
+2. **Reordering extent** — RFC 4737's `Type-P-Packet-Reordering-Extent`, the
+   position-distance form: for a reordered packet received at position `i` with
+   sequence number `s`, the extent is `i − min{ j < i : seq[j] > s }`, i.e. the
+   number of positions back, **in the received stream**, to the earliest packet
+   received that has a larger sequence number. It is ≥ 1 for every reordered
+   packet by construction. This is what distinguishes "one straggler" (a large
+   extent on a handful of packets) from "systematically interleaved" (a small
+   extent on many). RFC 4737 notes that this position-distance form *tends to
+   overestimate* the receiver storage actually needed to restore order — which
+   is precisely why the next metric is carried alongside it.
+3. **Reorder-buffer occupancy** — the high-water mark of a receiver buffer that
+   releases packets in sequence order, defined **over the packets that actually
+   arrived**. On each arrival the packet is buffered, then the longest complete
+   prefix of the flow's delivered-packet sequence is released; the metric is the
+   largest number held at once. Defining it over arrivals rather than over the
+   sent sequence is deliberate: a buffer that waits for the literal next
+   sequence number stalls forever on the first lost packet, so at this harness's
+   PDRs it would measure loss rather than reordering.
+
+Duplicates are not handled specially: `OnOffApplication` emits each sequence
+number once and IP-layer unicast forwarding does not duplicate, so a flow's
+received sequence numbers are unique.
+
+### Instrumentation self-check
+
+Two arms should read ≈ 0 and are the reason to believe the AntHocNet number:
+
+- **AODV, OLSR and DSDV** are single-path — one next hop per destination at a
+  time — so the only reordering they can produce is the incidental kind around a
+  route change. This is the control a reviewer will look for first.
+- **AntHocNet with `--ns3::anthocnet::RoutingProtocol::EnableMultipath=false`**
+  collapses to a single next hop and should likewise fall to ≈ 0. That is a free
+  validation of the instrumentation itself: if it does not, the metric is
+  measuring something other than multipath spreading.
+
+Neither is expected to be exactly zero — a route change can hand consecutive
+packets to paths of different length under any protocol — but both should be
+small next to the multipath figure.
+
+### Caveats
+
+- **The `*_max` columns are averaged over the RNG runs** like every other
+  column: they are a mean of per-run maxima, not a maximum over runs.
+- **Reordering is traffic-pattern dependent.** At the paper's 1 packet/s per
+  flow, consecutive packets are 1 s apart and only a path-delay difference of
+  that order can reorder them; a denser source reorders far more readily at the
+  same routing behaviour. Compare these columns only between arms of the same
+  scenario, never across scenarios with different `cbrBps` or `flows`.
+- **The reported figures are CSV columns; the human table prints them on a
+  `# reorder` line** rather than as table columns, because the table's field
+  positions are a parsing contract for `bench_parse.py` and the workflows'
+  `##BENCH##` re-emit.
+- **NS-3 only.** The NS-2 adapter has no equivalent instrumentation.
+
 Aggregates are means over the RNG runs; the CSV also carries per-metric sample
 stddev across runs (`pdr_sd`, `delay_sd`, `delay99_sd`, `nrl_sd`), which the
 charts render as error bars, and the human table prints as `# stddev` lines.

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -10,7 +10,11 @@
  * bytes, #132), plus radio energy (#209): total joules consumed, joules per
  * delivered packet, the residual-energy spread across nodes and the
  * first-node-death time, from a BasicEnergySource + WifiRadioEnergyModel
- * installed identically on every node for every protocol.
+ * installed identically on every node for every protocol,
+ * plus packet reordering (#212): the RFC 4737 out-of-order
+ * delivery ratio, the reordering extent (mean/max) and the reorder-buffer
+ * occupancy needed to restore order, measured per flow at the sink and then
+ * aggregated.
  * Fair comparison: the RNG run is reset before each protocol so every protocol
  * sees the identical mobility/traffic realisation, and NRL is counted uniformly
  * for every protocol from the IP layer.
@@ -37,6 +41,10 @@
 #include "ns3/ipv4-flow-classifier.h"
 #include "ns3/ipv4-l3-protocol.h"
 #include "ns3/udp-header.h"
+// #212: the application-level sequence number the reordering metrics key on.
+// Part of the applications module (already included above) since ns-3.31, so it
+// is available across the whole CI matrix (3.36-3.48).
+#include "ns3/seq-ts-size-header.h"
 
 // #209: BasicEnergySource lives in the energy module; WifiRadioEnergyModel and
 // its helper live in the wifi module (already included above) in every ns-3 the
@@ -84,6 +92,26 @@ void CountControlTx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t) {
         ++g_controlPkts;
         g_controlBytes += p->GetSize();
     }
+}
+
+// --- packet reordering (#212) ----------------------------------------------
+// Per-flow arrival-order sequence numbers, keyed by the *source* socket address
+// (source IP + ephemeral port). That key is unique per OnOff application in both
+// the default i->(n-1-i) pairing and the --sink converge mode, where several
+// flows share one PacketSink and a per-sink index would not separate them.
+// Filled for every protocol and every run — reordering is a reported metric, not
+// a --diag extra.
+//
+// The ordering key is the sequence number ns-3's OnOffApplication writes when
+// its EnableSeqTsSizeHeader attribute is set (see the SetAttribute call in
+// RunOne for why this does not change the packet size). FlowMonitor cannot
+// supply it: it reports per-flow counts and delays, never per-packet order.
+std::map<Address, std::vector<uint32_t>> g_rxSeq;
+
+void RecordRxSeq(Ptr<const Packet> p, const Address& from) {
+    SeqTsSizeHeader h;
+    p->PeekHeader(h);
+    g_rxSeq[from].push_back(h.GetSeq());
 }
 
 // --- diagnostics (--diag): ant-level introspection for AntHocNet -----------
@@ -253,6 +281,12 @@ struct Result {
     double resMeanJ = 0.0;       // sample stddev (J) — the fairness spread
     double resSdJ = 0.0;
     double firstDeathS = -1.0;   // -1 = no node died (see OnEnergyDepleted)
+    // #212 packet reordering (definitions in docs/benchmarks/metrics.md):
+    double reorderRatio = 0.0;     // RFC 4737 Type-P-Reordered fraction, [0,1]
+    double reorderRatioMax = 0.0;  // worst single flow's ratio, [0,1]
+    double reorderExtMean = 0.0;   // mean reordering extent over reordered pkts
+    double reorderExtMax = 0.0;    // max reordering extent, packets
+    double reorderBufMax = 0.0;    // max reorder-buffer occupancy, packets
 };
 
 Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
@@ -269,6 +303,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_qCount = g_qNonzero = g_qMax = 0;
     g_qSum = 0.0;
     g_firstDeathS = -1.0;
+    g_rxSeq.clear();
 
     NodeContainer nodes;
     nodes.Create(P.nNodes);
@@ -431,6 +466,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                           InetSocketAddress(ifs.GetAddress(dst), port));
         onoff.SetAttribute("DataRate", StringValue(rate.str()));
         onoff.SetAttribute("PacketSize", UintegerValue(64));
+        // #212: carry a per-flow application sequence number so reordering can
+        // be measured at the sink. This does NOT change the packet size, and so
+        // does not move a single existing PDR / delay / throughput / NRL number:
+        // ns-3 builds the 20-byte SeqTsSizeHeader *inside* the configured
+        // PacketSize (onoff-application.cc does
+        // `Create<Packet>(m_pktSize - header.GetSerializedSize())` and then
+        // `AddHeader`), so the datagram stays 64 bytes on the wire and only 44
+        // of them are now dummy payload. The attribute and that construction
+        // date from ns-3.31, i.e. they predate the whole CI matrix (3.36-3.48),
+        // which is where this is actually compiled and run.
+        onoff.SetAttribute("EnableSeqTsSizeHeader", BooleanValue(true));
         const double startS = startVar->GetValue();
         onoff.SetAttribute("StartTime", TimeValue(Seconds(startS)));
         onoff.SetAttribute("StopTime", TimeValue(Seconds(P.simTime - 1.0)));
@@ -451,6 +497,16 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         sinks.Add(sink.Install(nodes.Get(P.sink)));
     }
     sinks.Start(Seconds(0.0));
+
+    // #212: reordering is a reported metric for every protocol and every run, so
+    // this hook is unconditional — unlike the --diag hooks below. The sink's
+    // plain "Rx" trace hands over the whole datagram, header included, so the
+    // sequence number is read here rather than through PacketSink's own
+    // EnableSeqTsSizeHeader path (that one runs a TCP-oriented reassembly buffer
+    // we have no use for on UDP).
+    for (uint32_t i = 0; i < sinks.GetN(); ++i) {
+        sinks.Get(i)->TraceConnectWithoutContext("Rx", MakeCallback(&RecordRxSeq));
+    }
 
     if (g_diag) {
         // First-delivery timestamp from every data sink (all protocols), plus
@@ -610,6 +666,92 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             }
         }
         r.firstDeathS = g_firstDeathS;
+    }
+
+    // --- packet reordering (#212) --------------------------------------------
+    // Computed per flow first and only then aggregated: a single badly-spread
+    // flow is the interesting case, and a packet-weighted aggregate alone would
+    // hide it — hence reorderRatioMax (the worst flow) alongside the pooled
+    // ratio. Definitions (stated in full in docs/benchmarks/metrics.md because
+    // "reordering" has several non-equivalent definitions in the literature):
+    //
+    //  - **Out-of-order (reordered) ratio** — RFC 4737's `Type-P-Reordered`
+    //    singleton: keep NextExp = (largest sequence number seen so far) + 1;
+    //    an arriving packet with sequence number s is reordered iff s < NextExp,
+    //    and NextExp advances to s+1 only when it is not. Losses do not count as
+    //    reordering: a gap merely makes NextExp jump.
+    //  - **Reordering extent** — RFC 4737's `Type-P-Packet-Reordering-Extent`:
+    //    for a reordered packet received at position i, the number of positions
+    //    back to the *earliest* packet received with a larger sequence number,
+    //    i.e. i - min{ j < i : seq[j] > s }. RFC 4737 notes this
+    //    position-distance form tends to *overestimate* the receiver storage
+    //    actually needed, which is exactly why the buffer-occupancy figure below
+    //    is carried alongside it.
+    //  - **Reorder-buffer occupancy** — the largest number of packets a receiver
+    //    would have to hold at once to hand the *delivered* packets up in
+    //    sequence order. Defined over the packets that actually arrived, so a
+    //    lost packet does not stall the buffer forever (a naive "wait for the
+    //    next sequence number" buffer would measure loss, not reordering, at
+    //    this harness's PDRs).
+    //
+    // Prefix maxima make both the reordered test and the extent search cheap:
+    // pref[i] = max(seq[0..i]) is non-decreasing, so s is reordered iff
+    // s <= pref[i-1], and the earliest arrival with a larger sequence number is
+    // the first index at which pref exceeds s (binary search).
+    {
+        uint64_t rxSeqTotal = 0, reorderedTotal = 0;
+        uint64_t extSum = 0, extCount = 0, extMax = 0, bufMax = 0;
+        double ratioMaxFlow = 0.0;
+        for (auto& kv : g_rxSeq) {
+            const std::vector<uint32_t>& arr = kv.second;  // arrival order
+            if (arr.empty()) continue;
+            std::vector<uint32_t> pref(arr.size());
+            uint32_t m = arr[0];
+            for (std::size_t i = 0; i < arr.size(); ++i) {
+                if (arr[i] > m) m = arr[i];
+                pref[i] = m;
+            }
+            uint64_t reordered = 0;
+            for (std::size_t i = 1; i < arr.size(); ++i) {
+                if (arr[i] > pref[i - 1]) continue;  // in order (s >= NextExp)
+                ++reordered;
+                const std::size_t j = static_cast<std::size_t>(
+                    std::upper_bound(pref.begin(), pref.begin() + i, arr[i])
+                    - pref.begin());
+                const uint64_t ext = i - j;  // >= 1 for any reordered packet
+                extSum += ext;
+                ++extCount;
+                if (ext > extMax) extMax = ext;
+            }
+            // Reorder-buffer occupancy: walk the arrivals, release the prefix of
+            // the sorted (in-sequence) delivery order that has become complete,
+            // and record the high-water mark of what is still held.
+            std::vector<uint32_t> ordered(arr);
+            std::sort(ordered.begin(), ordered.end());
+            std::vector<char> arrived(ordered.size(), 0);
+            std::size_t k = 0;
+            uint64_t occ = 0, occMax = 0;
+            for (uint32_t s : arr) {
+                arrived[static_cast<std::size_t>(
+                    std::lower_bound(ordered.begin(), ordered.end(), s)
+                    - ordered.begin())] = 1;
+                ++occ;
+                while (k < ordered.size() && arrived[k]) { --occ; ++k; }
+                if (occ > occMax) occMax = occ;
+            }
+            rxSeqTotal += arr.size();
+            reorderedTotal += reordered;
+            const double ratio = static_cast<double>(reordered) / arr.size();
+            if (ratio > ratioMaxFlow) ratioMaxFlow = ratio;
+            if (occMax > bufMax) bufMax = occMax;
+        }
+        r.reorderRatio = rxSeqTotal
+            ? static_cast<double>(reorderedTotal) / rxSeqTotal : 0.0;
+        r.reorderRatioMax = ratioMaxFlow;
+        r.reorderExtMean = extCount
+            ? static_cast<double>(extSum) / extCount : 0.0;
+        r.reorderExtMax = static_cast<double>(extMax);
+        r.reorderBufMax = static_cast<double>(bufMax);
     }
 
     // Diagnostics line (prefixed "# " so CSV consumers ignore it). Shows whether
@@ -907,6 +1049,10 @@ int main(int argc, char* argv[]) {
         double resMin = 0, resMean = 0, resSd = 0;
         double firstDeath = 0;
         uint32_t deathRuns = 0;
+        // #212 reordering. The *Max fields are averaged across runs like every
+        // other column: a mean of per-run maxima, not a max over runs.
+        double reordRatio = 0, reordRatioMax = 0;
+        double reordExtMean = 0, reordExtMax = 0, reordBufMax = 0;
     };
     std::vector<Agg> agg(list.size());
     for (std::size_t i = 0; i < list.size(); ++i) {
@@ -957,6 +1103,11 @@ int main(int argc, char* argv[]) {
                 agg[i].firstDeath += r.firstDeathS;
                 ++agg[i].deathRuns;
             }
+            agg[i].reordRatio += r.reorderRatio;
+            agg[i].reordRatioMax += r.reorderRatioMax;
+            agg[i].reordExtMean += r.reorderExtMean;
+            agg[i].reordExtMax += r.reorderExtMax;
+            agg[i].reordBufMax += r.reorderBufMax;
         }
         agg[i].pdr /= runs;
         agg[i].delay /= runs;
@@ -974,6 +1125,11 @@ int main(int argc, char* argv[]) {
         agg[i].resSd /= runs;
         agg[i].firstDeath = agg[i].deathRuns
             ? agg[i].firstDeath / agg[i].deathRuns : -1.0;
+        agg[i].reordRatio /= runs;
+        agg[i].reordRatioMax /= runs;
+        agg[i].reordExtMean /= runs;
+        agg[i].reordExtMax /= runs;
+        agg[i].reordBufMax /= runs;
         if (runs > 1) {
             auto sd = [runs](double sum, double sumSq) {
                 const double mean = sum / runs;
@@ -996,13 +1152,17 @@ int main(int argc, char* argv[]) {
         // #132 nrl_bytes (control bytes / delivered data bytes), then #209
         // energy (total consumed, per delivered packet, residual spread across
         // nodes, the initial energy the run was configured with, and the
-        // first-node-death time with -1 = no node died).
+        // first-node-death time with -1 = no node died), then #212
+        // reordering (out-of-order ratio pooled over flows and for the worst
+        // single flow, reordering extent mean/max, reorder-buffer occupancy).
         std::cout << "protocol,runs,nNodes,area,speed,flows,pdr_pct,delay_ms,"
                      "throughput_kbps,delay99_ms,nrl,jitter_ms,delay_off50_ms,"
                      "delay_off90_ms,pdr_sd,delay_sd,delay99_sd,nrl_sd,"
                      "nrl_bytes,energy_j,energy_per_pkt_j,energy_res_min_j,"
                      "energy_res_mean_j,energy_res_sd_j,energy_init_j,"
-                     "first_death_s\n";
+                     "first_death_s,reorder_ratio,reorder_ratio_max,"
+                     "reorder_extent_mean,reorder_extent_max,"
+                     "reorder_buf_max\n";
         std::cout << std::fixed;
         for (std::size_t i = 0; i < list.size(); ++i) {
             std::cout << list[i] << ',' << runs << ',' << P.nNodes << ','
@@ -1027,7 +1187,12 @@ int main(int argc, char* argv[]) {
                       << std::setprecision(2) << agg[i].resMean << ','
                       << std::setprecision(3) << agg[i].resSd << ','
                       << std::setprecision(2) << P.energyJ << ','
-                      << std::setprecision(1) << agg[i].firstDeath << '\n';
+                      << std::setprecision(1) << agg[i].firstDeath << ','
+                      << std::setprecision(4) << agg[i].reordRatio << ','
+                      << std::setprecision(4) << agg[i].reordRatioMax << ','
+                      << std::setprecision(2) << agg[i].reordExtMean << ','
+                      << std::setprecision(2) << agg[i].reordExtMax << ','
+                      << std::setprecision(2) << agg[i].reordBufMax << '\n';
         }
         return 0;
     }
@@ -1095,6 +1260,22 @@ int main(int argc, char* argv[]) {
                       << " nrl=" << std::setprecision(3) << agg[i].nrlSd
                       << " nrl_bytes=" << std::setprecision(3) << agg[i].nrlBytesSd << "\n";
         }
+    }
+    // #212 packet reordering. Deliberately a '# ' line rather than five more
+    // fixed-width table columns: the table's field *positions* are a parsing
+    // contract (bench_parse.py and the workflows' ##BENCH## awk read the left
+    // columns by position), and reordering is a diagnostic of the multipath
+    // mechanism rather than a headline comparison number. The CSV carries all
+    // five columns by name. Expect ~0 for AODV/OLSR/DSDV and for AntHocNet with
+    // EnableMultipath=false; a non-zero AntHocNet figure is the stochastic
+    // multipath working as designed, not a fault (docs/benchmarks/metrics.md).
+    for (std::size_t i = 0; i < list.size(); ++i) {
+        std::cout << std::fixed << "# reorder " << list[i]
+                  << " ratio=" << std::setprecision(4) << agg[i].reordRatio
+                  << " ratioWorstFlow=" << std::setprecision(4) << agg[i].reordRatioMax
+                  << " extentMean=" << std::setprecision(2) << agg[i].reordExtMean
+                  << " extentMax=" << std::setprecision(2) << agg[i].reordExtMax
+                  << " bufMax=" << std::setprecision(2) << agg[i].reordBufMax << "\n";
     }
     return 0;
 }

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -24,7 +24,9 @@ Output CSV columns:
   kind,group,x,scenario,class,protocol,runs,nNodes,areaX,speed,pause,flows,
   pdr_pct,delay_ms,delay99_ms,throughput_kbps,nrl,...,energy_j,
   energy_per_pkt_j,energy_res_min_j,energy_res_mean_j,energy_res_sd_j,
-  energy_init_j,first_death_s   (see METRICS below for the full, append-only
+  energy_init_j,first_death_s,reorder_ratio,reorder_ratio_max,
+  reorder_extent_mean,reorder_extent_max,reorder_buf_max
+                                (see METRICS below for the full, append-only
                                  list)
 
   kind   = "discrete" (named scenario) or "sweep" (one point of a sweep)
@@ -92,13 +94,22 @@ SWEEPS = {
 # nodes at end of run, the initial per-node energy the run was configured with
 # (so residual <= initial is checkable downstream), and the first-node-death
 # time with -1 meaning no node died.
-# APPEND ONLY — sweep_summary.py and bench_parse.py read these by name.
+# The reorder_* columns are #212 (ns-3 only): the RFC 4737 out-of-order delivery
+# ratio pooled over the data flows, the same ratio for the worst single flow,
+# the reordering extent (mean/max, in packets) and the reorder-buffer occupancy
+# needed to restore order. Multipath reordering is expected AntHocNet behaviour;
+# see docs/benchmarks/metrics.md for the exact definitions.
+# APPEND ONLY — downstream consumers (make-charts.py, sweep_summary.py,
+# bench_parse.py, scenario_check.py) look these columns up by header name, so
+# appending is safe and reordering is not.
 METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
            "jitter_ms", "delay_off50_ms", "delay_off90_ms",
            "pdr_sd", "delay_sd", "delay99_sd", "nrl_sd", "nrl_bytes",
            "energy_j", "energy_per_pkt_j", "energy_res_min_j",
            "energy_res_mean_j", "energy_res_sd_j", "energy_init_j",
-           "first_death_s"]
+           "first_death_s",
+           "reorder_ratio", "reorder_ratio_max", "reorder_extent_mean",
+           "reorder_extent_max", "reorder_buf_max"]
 PARAMS = ["runs", "nNodes", "area", "speed", "flows"]
 OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + ["runs", "nNodes", "areaX", "speed", "pause", "flows", "propagation"]


### PR DESCRIPTION
Implements [#212](https://github.com/danieljoppi/AntHocNet/issues/212). `docs/configuration.md` has always stated the cost on the `betaData` row — *"lower = more spread (**and more reordering**)"* — and we have never measured it.

[#179](https://github.com/danieljoppi/AntHocNet/issues/179) proposes moving `betaData` from 2 to the thesis's 20, which is exactly the knob that controls this. Without the metric we would make that decision blind to its principal side-effect.

## New CSV columns (appended)

```
reorder_ratio, reorder_ratio_max, reorder_extent_mean, reorder_extent_max, reorder_buf_max
```

Per-flow (keyed by source socket address, so `--sink` converge mode still separates flows), then aggregated. `reorder_ratio_max` is the **worst single flow** — one badly-spread flow would otherwise be averaged away.

## Definitions — RFC 4737, stated precisely

"Reordering" has several non-equivalent definitions in the literature, so an unstated choice isn't reproducible. Implemented:

- **Out-of-order ratio** — RFC 4737's `Type-P-Reordered` singleton. `NextExp` = (max seq seen)+1; packet `s` is reordered iff `s < NextExp`. **Loss is not reordering** — a gap just advances `NextExp`, which matters at this harness's sub-100% PDRs.
- **Displacement** — `Type-P-Packet-Reordering-Extent` in position-distance form: `i − min{ j < i : seq[j] > s }`. Mean and max, in packets.
- **Reorder-buffer occupancy** — high-water mark of a buffer defined over *packets that arrived*, not over the sent sequence. A buffer waiting for the literal next seq would stall forever on the first loss and measure loss, not reordering. RFC 4737 notes extent overestimates real storage need, which is why both are carried.

## Packet size is **not** changed — verified, not assumed

This was the trap: adding a sequence header naively would change packet size and silently shift **every existing PDR/throughput number in the taxonomy**.

It doesn't. Sources set ns-3's `EnableSeqTsSizeHeader`, and ns-3 builds the 20-byte `SeqTsSizeHeader` *inside* the configured `PacketSize` — `Create<Packet>(m_pktSize - header.GetSerializedSize())` then `AddHeader`. The datagram stays **64 bytes on the wire** (44 payload + 20 header). No on-wire bytes, no RNG draws, no timing change ⇒ **no existing metric moves**. The attribute exists since ns-3.31, predating the whole CI matrix.

## Algorithm verified independently

The three loops were lifted verbatim into a standalone C++ program (`-Wall -Wextra`, C++14) and run against hand-checked sequences:

| input | expected | result |
|---|---|---|
| in-order, and lossy-but-ordered | 0 on all three metrics | ✓ |
| RFC 4737's `1,3,4,2` | extent 2, buffer 2 | ✓ |
| `1,5,2,3` | extents 1,2 with buffer 1 | ✓ (reproduces the RFC's overestimation caveat) |
| straggler vs interleave | separated by extent max | 10 vs 1 |
| empty / single-packet flows | safe | ✓ |

## Other changes

- `scenario_check.py results`: ratios ∈ [0,1], extents/occupancy finite ≥ 0 — verified to skip cleanly on both a pre-#212 CSV and a pre-#212 `##BENCH##` table.
- `docs/benchmarks/metrics.md`: definitions, the AODV/OLSR/DSDV ≈0 control and the `EnableMultipath=false` ≈0 self-check, and an explicit statement that **multipath reordering is expected protocol behaviour, not a fault**.
- The fixed-width human table is deliberately **not** widened — its field positions are a parsing contract for `bench_parse.py` and the `##BENCH##` awk, and #219 already claims the next two positional slots. Numbers go on a `# reorder` line, following the `# stddev` precedent.

## Merge order

Conflicts with [#219](https://github.com/danieljoppi/AntHocNet/pull/219) (energy) are confined to the CSV header string, the CSV row, the `Agg` struct and adjacent trailing blocks — all pure additions. **#219 should merge first and this rebase onto it.**

## Verification

`make test` 23/23 · `check_invariants.sh` clean · `python3 -m ruff check ns3/tools` clean on **ruff 0.16.0** (PATH `ruff` is 0.15.8 and shadows it) · `ast.parse` OK · `run-scenarios.py --dry-run` emits the widened header.

**Not verified here:** `anthocnet-compare` doesn't compile in this sandbox (no ns-3 tree) — the CI matrix validates it. Also `rfc-editor.org`, `ietf.org` and `nsnam.org` all 403 through the proxy, so RFC 4737's text and the ns-3 doxygen could not be re-read; the RFC is cited **by metric name rather than section number**, with the algorithm spelled out in full so the choice is reproducible either way.

**Acceptance items 1–3 of #212 remain open** — baselines ≈0, `enableMultipath=false` ≈0, and the β=2 vs β=20 A/B all need a `scenario-matrix` dispatch once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_