### PR TITLE
feat(bench): break down packet drops by cause, and fix a silent queue eviction found doing it

### DIFF
--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -160,6 +160,11 @@ whenever PDR is, residual energy within [0, initial]; all skipped for inputs
 predating energy instrumentation), the #212 reordering bounds (out-of-order
 ratios in [0,1]; extents and reorder-buffer occupancies finite and
 non-negative — all skipped for inputs predating reordering instrumentation),
-and — with `--anchor` — the AODV floors read from
+the #215 drop-cause identity (PDR plus the
+five protocol-agnostic causes must account for ~100% of offered packets: WARN
+past 1 pp, FAIL past 5 pp — the tolerance is the data still queued when the run
+stops; also FAILs a negative cause share, which means two causes count the same
+packet; skipped for inputs predating drop instrumentation), and — with
+`--anchor` — the AODV floors read from
 `ns3/tools/anchors.yml` (never duplicated). A `results` FAIL is a #51-class
 harness regression: fix the harness before trusting any number from that run.

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -114,6 +114,14 @@ def parse_results(path):
     rules below are skipped. They are CSV-only by design — anthocnet-compare
     prints them on a '# reorder' line rather than widening the fixed-width
     results table, and ROW does not match a '# ' line.
+
+    Drop-cause fields (#215) are likewise CSV-only and post-instrumentation:
+    anthocnet-compare prints them on a '# drops' line rather than widening the
+    fixed-width table, so a results table yields None for all of them and the
+    drop rules below skip. The three AntHocNet-only causes are deliberately
+    **blank** for the other protocols (the cause does not exist there, as
+    opposed to existing and measuring zero); a blank parses to None and is
+    skipped, exactly like an absent column.
     """
     with open(path) as fh:
         text = fh.read()
@@ -134,7 +142,15 @@ def parse_results(path):
                    "reorder_ratio_max": r.get("reorder_ratio_max"),
                    "reorder_extent_mean": r.get("reorder_extent_mean"),
                    "reorder_extent_max": r.get("reorder_extent_max"),
-                   "reorder_buf_max": r.get("reorder_buf_max")}
+                   "reorder_buf_max": r.get("reorder_buf_max"),
+                   "drop_route": r.get("drop_route_pct"),
+                   "drop_queue": r.get("drop_queue_pct"),
+                   "drop_mac": r.get("drop_mac_pct"),
+                   "drop_chan": r.get("drop_chan_pct"),
+                   "drop_ttl": r.get("drop_ttl_pct"),
+                   "drop_setup": r.get("drop_setup_pct"),
+                   "drop_reconv": r.get("drop_reconv_pct"),
+                   "drop_repair": r.get("drop_repair_pct")}
         return
     for line in text.splitlines():
         m = ROW.match(line)
@@ -230,6 +246,66 @@ def cmd_results(a):
                 if v is not None and not (math.isfinite(v) and v >= 0.0):
                     report("FAIL", f"{tag}: {k} {r.get(k)} is not a finite "
                                    "non-negative packet count")
+            # #215 drop-cause breakdown. The five protocol-agnostic causes are
+            # measured from three independent books — FlowMonitor's per-flow
+            # drop reasons, the Ipv4L3Protocol Tx/Rx hop tallies and the WifiMac
+            # retry-limit verdicts — so nothing forces them to add up. They must
+            # account, together with the delivered packets, for every offered
+            # packet:
+            #
+            #     pdr + route + queue + mac + chan + ttl  ==  100
+            #
+            # TOLERANCE. The one legitimate shortfall is data still sitting in a
+            # routing protocol's pending queue when the run stops; a packet can
+            # wait there at most QueueTimeout (3 s), so the residual is bounded
+            # by 3 s of offered traffic — 0.3 % of a 900 s paper run, ~2.5 % of
+            # the 120 s --quick preset. Hence WARN past 1 pp and FAIL past 5 pp,
+            # which still leaves the check able to see a #173-scale
+            # misattribution (tens of pp) without firing on run length.
+            #
+            # A FAIL here is a finding in its own right, not a formality: it
+            # means one of the three books is wrong (a drop path that fires no
+            # error callback, a trace hook not connected, a cause counted
+            # twice), and every conclusion drawn from the breakdown is unsafe
+            # until it is fixed.
+            causes = {k: num(f"drop_{k}")
+                      for k in ("route", "queue", "mac", "chan", "ttl")}
+            for k, v in causes.items():
+                if v is None:
+                    continue
+                if not math.isfinite(v) or not (0.0 <= v <= 100.0):
+                    report("FAIL", f"{tag}: drop_{k}_pct {r.get('drop_' + k)} "
+                                   "outside [0,100] — drop attribution broken "
+                                   "(a negative share means causes overlap)")
+            if pdr is not None and all(v is not None for v in causes.values()):
+                total = pdr + sum(causes.values())
+                gap = total - 100.0
+                detail = (f"pdr {pdr:.1f} + " +
+                          " + ".join(f"{k} {causes[k]:.2f}"
+                                     for k in ("route", "queue", "mac",
+                                               "chan", "ttl")) +
+                          f" = {total:.2f}")
+                if abs(gap) > 5.0:
+                    report("FAIL", f"{tag}: drop causes do not account for the "
+                                   f"offered packets ({detail}, off by "
+                                   f"{gap:+.2f} pp) — attribution is wrong, do "
+                                   "not read the breakdown")
+                elif abs(gap) > 1.0:
+                    report("WARN", f"{tag}: drop causes off by {gap:+.2f} pp "
+                                   f"({detail}) — expected only from packets "
+                                   "still queued at end of run")
+            # The AntHocNet-only causes are a *sub-breakdown* of drop_route_pct
+            # (all three end in the same L3 error callback), never causes on top
+            # of it. A mismatch means one pending-queue exit path is unaccounted
+            # for; WARN rather than FAIL, since the identity above is the rule
+            # that decides whether the numbers are usable.
+            sub = [num(f"drop_{k}") for k in ("setup", "reconv", "repair")]
+            route = causes["route"]
+            if (route is not None and all(v is not None for v in sub)
+                    and abs(sum(sub) - route) > 1.0):
+                report("WARN", f"{tag}: setup+reconv+repair {sum(sub):.2f} != "
+                               f"drop_route_pct {route:.2f} — a pending-queue "
+                               "exit path is not attributed")
             if floor is not None and r["proto"] == "aodv" and pdr is not None:
                 if pdr < floor:
                     report("FAIL", f"{tag}: anchor '{a.anchor}' floor "

--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -64,6 +64,13 @@ public:
     /// Per-destination advertisements dropped by the origin cooldown
     /// (config.linkfailNotifyInterval, issue #20).
     std::uint64_t linkfailOriginsSuppressed() const { return linkfailOriginsSuppressed_; }
+    /// Local repairs that expired without a backward ant and therefore released
+    /// the data buffered for their destination — the number of DiscardPending
+    /// decisions this node has emitted ([1] §3.5, D6; drop-cause breakdown,
+    /// issue #215). This is the *event* count: the adapter owns the pending
+    /// queue, so only it knows how many packets each discard released. Counted
+    /// here so the cause stays simulator-agnostic and both adapters get it.
+    std::uint64_t repairDiscards() const { return repairDiscards_; }
 
     // --- neighbour learning ----------------------------------------------
     /// Record that `neighbor` is reachable (link-layer detection / hello),
@@ -204,6 +211,7 @@ private:
     std::uint64_t linkfailPropagations_ = 0;        ///< re-broadcast LinkFails (issue #20)
     std::uint64_t linkfailBudgetDrops_  = 0;        ///< budget-suppressed propagations (issue #20)
     std::uint64_t linkfailOriginsSuppressed_ = 0;   ///< cooldown-suppressed advertisements (issue #20)
+    std::uint64_t repairDiscards_ = 0;              ///< expired local repairs that discarded pending data (#215)
     std::map<NodeAddress, double> lastLinkfailNotify_;  ///< dest -> last originated LinkFail time
 };
 

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -75,6 +75,7 @@ std::vector<RouteDecision> AntRouterLogic::onMaintenanceTick() {
         if (table_.bestRegular(dest) > config_.minPheromone) continue;
 
         out.push_back({RouteAction::DiscardPending, dest, false, {}});
+        ++repairDiscards_;  // #215 drop cause "repair discard" (event count)
 
         // Same origin cooldown as reportNeighborLoss (issue #20): the break
         // that armed this repair usually already advertised dest's loss.

--- a/core/tests/test_link_failure.cpp
+++ b/core/tests/test_link_failure.cpp
@@ -272,12 +272,14 @@ int main() {
 
         router.reportTxFailure(/*next*/ 5, /*dataDest*/ 9);  // launches the repair
         CHECK_EQ(router.antsSent(AntType::Repair), static_cast<std::uint64_t>(1));
+        CHECK_EQ(router.repairDiscards(), static_cast<std::uint64_t>(0));
 
         // Before the deadline (5 × 1/0.8 = 6.25 s) nothing fires.
         clock.advance(1.0);
         for (const RouteDecision& d : router.onMaintenanceTick()) {
             CHECK(d.action != RouteAction::DiscardPending);
         }
+        CHECK_EQ(router.repairDiscards(), static_cast<std::uint64_t>(0));
 
         // Past the deadline, still no route: discard + notify.
         clock.advance(cfg1.repairWaitFactor / 0.8);
@@ -295,12 +297,17 @@ int main() {
         }
         CHECK(discard);
         CHECK(notified);
+        // #215: the discard is counted in the core, so the drop cause "repair
+        // discard" is available to both adapters without either of them
+        // re-deriving it from the decision stream.
+        CHECK_EQ(router.repairDiscards(), static_cast<std::uint64_t>(1));
 
         // The deadline is one-shot: a later tick does not re-fire it.
         clock.advance(1.0);
         for (const RouteDecision& d : router.onMaintenanceTick()) {
             CHECK(d.action != RouteAction::DiscardPending);
         }
+        CHECK_EQ(router.repairDiscards(), static_cast<std::uint64_t>(1));  // #215: not re-counted
     }
 
     // 12. A backward ant from the destination within the window cancels the
@@ -330,6 +337,8 @@ int main() {
         for (const RouteDecision& d : router.onMaintenanceTick()) {
             CHECK(d.action != RouteAction::DiscardPending);
         }
+        // #215: a repair that succeeded is not a drop cause.
+        CHECK_EQ(router.repairDiscards(), static_cast<std::uint64_t>(0));
     }
 
     // 13. A route restored by other means (reactive ant, diffusion) also

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -32,6 +32,122 @@ same realisations. Metrics come from an NS-3 `FlowMonitor`:
   `maxPathLength` addresses) while an AODV RREQ is small and fixed. The measured
   packet-vs-byte comparison run is tracked in #132.
 
+## Drop causes (#215, NS-3 only)
+
+PDR says how many packets went missing. These columns say **why**, as a
+percentage of *offered* (sent) packets, so that
+
+```
+pdr_pct + drop_route_pct + drop_queue_pct + drop_mac_pct
+        + drop_chan_pct  + drop_ttl_pct   ≈ 100
+```
+
+Every offered packet is accounted for exactly once: it was delivered, or it
+died of one of five causes. That identity is what makes the breakdown readable
+— a cause is a *share of the loss*, not a free-floating counter — and
+`scenario_check.py results` enforces it (see *Why the identity must close*).
+
+The five causes are measured **identically for all four protocols**, so a
+column means the same thing in the AntHocNet arm and in the AODV arm:
+
+- **drop_route_pct** — the routing layer gave up: no route was ever found, or
+  the route it was waiting on did not come back in time. Measured from
+  FlowMonitor's per-flow drop reasons (`DROP_NO_ROUTE` + `DROP_ROUTE_ERROR`),
+  i.e. from the protocol's own error callback, whichever protocol raised it.
+- **drop_queue_pct** — the packet was overtaken by congestion at the
+  *interface*: the device transmit queue or the traffic-control queue disc was
+  full (`DROP_QUEUE` + `DROP_QUEUE_DISC`). This is the "network is drowning in
+  its own traffic" signal, not a routing failure.
+- **drop_mac_pct** — the link broke under the packet: 802.11 exhausted its
+  retry limit on the unicast (`WIFI_MAC_DROP_REACHED_RETRY_LIMIT` on the
+  `WifiMac` `DroppedMpdu` trace — the same signal AntHocNet's ADR-0008 detector
+  D uses). **Terminal failures only**: AntHocNet re-injects a MAC-dropped data
+  packet into its pending queue (#46), and a re-injected packet is not lost —
+  its real fate is counted wherever it finally ends up — so re-injections are
+  subtracted here rather than counted twice.
+- **drop_chan_pct** — sent and never received. Counted as the difference
+  between data IP packets handed to a real interface and data IP packets that
+  arrived at the next hop's IP layer (the `Ipv4L3Protocol` `Tx`/`Rx` traces,
+  the same counting point as NRL), minus the MAC and interface-queue drops
+  already attributed above. What remains is genuine on-air loss: collisions,
+  capture, a next hop that moved out of range mid-frame, ARP failures. **This
+  one can only come from the simulator** — it is the gap between "we sent it"
+  and "it arrived", which `core/` by construction cannot see (golden rule 1).
+- **drop_ttl_pct** — the IP TTL reached zero (`DROP_TTL_EXPIRE`): the packet
+  was forwarded in a loop or along a path longer than the TTL allows. Note this
+  is the *IP* TTL on data packets; `Config::maxPathLength` is the analogous
+  ceiling on *ants* and does not appear here (ants are control traffic, counted
+  by NRL).
+
+Three further columns split `drop_route_pct` for AntHocNet. They are a
+**sub-breakdown of that column, not extra causes** — adding them into the
+identity would double-count — and they are **blank, never `0`, for the other
+protocols**, because the mechanisms simply do not exist there. Blank means "not
+applicable"; `0` would mean "applicable and never fired", and the two must stay
+distinguishable:
+
+- **drop_setup_pct** — held in the pending queue for a destination this node
+  had **never** routed to, and aged out at `QueueTimeout` (or was evicted when
+  the queue filled). This is the true *no route* case: discovery never
+  succeeded.
+- **drop_reconv_pct** — same exit, but for a destination this node **had**
+  routed to: a route existed, was lost, and did not return within
+  `QueueTimeout`. Reconvergence loss, not discovery failure. Packets
+  re-injected after a MAC failure and then aged out land here too — they were
+  also waiting for a route that had existed.
+- **drop_repair_pct** — released by `DiscardPending` after a **local repair
+  timed out** (the paper's §3.5, decision D6). The core counts the repair events
+  (`AntRouterLogic::repairDiscards()`); the NS-3 adapter owns the queue and so
+  counts the packets.
+
+### Which causes are protocol behaviour, not faults
+
+This is the part that matters when reading a table. Not every drop is a bug.
+
+| Cause | Reading |
+|-------|---------|
+| **drop_repair_pct** | **Expected, deliberate behaviour.** The AntHocNet paper (§3.4 link failures / §3.5 local repair) chooses to discard the packets buffered behind a failed local repair rather than hold them indefinitely: it trades a slice of PDR for a **bounded delay tail**. A non-zero repair-discard share is the protocol working as specified, and #21's `RepairHoldCap`/`ReconvHoldCap` levers move packets *deliberately* between this column and the delay tail. Read it against `delay99_ms`/`jitter_ms`, never on its own. |
+| **drop_reconv_pct** | **Expected under mobility**, in proportion to how fast links break. It is the direct cost of reactive re-discovery; a *rising* share as `pause` falls is the protocol responding to mobility, not degrading. It becomes a finding only when it dominates on a **static** field. |
+| **drop_setup_pct** | Expected during the start-up transient and for genuinely unreachable destinations (a partitioned field — `scenario_check.py preflight` warns about those before the run). A large steady-state share means discovery is failing: that is #169's signature. |
+| **drop_chan_pct** | **PHY/scenario property, not a protocol property**, up to the control traffic the protocol puts on the air. All four arms share a channel, so compare the column *across* arms: the protocol with the higher share is the one filling the medium. A collapse dominated by this column is [#173](https://github.com/danieljoppi/AntHocNet/issues/173)'s exact signature — and having it as a column is why #215 exists at all, since #173 cost a benchmark campaign, a testbench reproduction and a code audit to reach that same conclusion. |
+| **drop_queue_pct** | Congestion, same reading as `drop_chan_pct`: offered load (or control overhead) exceeding what the interface can drain. Cross-check against `--qdiag` and `preflight`'s offered-load fraction. |
+| **drop_mac_pct** | Link breakage. Expected under mobility; a high share at low speed points at the PHY setup (`--rateManager`, #51) rather than at routing. |
+| **drop_ttl_pct** | **Always a fault signal.** Data should not loop. Anything materially above zero means forwarding loops — read it with `EnableMultipath` and the A1 loop-suppression caveat in the NS-3 adapter. |
+
+### Why the identity must close
+
+The five protocol-agnostic causes come from **three independent books**:
+FlowMonitor's per-flow drop reasons, the `Ipv4L3Protocol` `Tx`/`Rx` hop
+tallies, and the `WifiMac` retry-limit verdicts. Nothing forces them to agree,
+which is what makes their sum a real check rather than an accounting tautology.
+`scenario_check.py results` therefore treats a mismatch as a harness
+regression, in the same class as the #51 anchor floors:
+
+- **WARN** past 1 percentage point, **FAIL** past 5.
+- The tolerance exists for one legitimate residual: data still sitting in a
+  routing protocol's pending queue when the run stops. A packet waits there at
+  most `QueueTimeout` (3 s), so the residual is bounded by 3 s of offered
+  traffic — ≈0.3 % of a 900 s paper run, ≈2.5 % of the 120 s `--quick` preset.
+  5 pp leaves plenty of room for that while still catching a #173-scale
+  misattribution (tens of pp).
+- A negative share in any cause also FAILs: it means two causes are counting
+  the same packet.
+
+If the check fails, **do not read the breakdown** — one of the three books is
+wrong (a drop path that fires no error callback, a trace hook that did not
+connect on this ns-3 release, a cause counted twice) and every per-cause
+conclusion is unsafe until it is fixed.
+
+### Caveats
+
+- **NS-3 only.** The NS-2 adapter has no equivalent instrumentation; see
+  [cross-validation.md](../cross-validation.md).
+- The human table prints these on a `# drops` line (like `# energy`) rather
+  than widening the fixed-width table; the CSV carries all eight columns.
+- `# drops` also prints `other=`, the L3 drops in none of the five buckets
+  (bad checksum, interface down, fragment timeout — structurally zero in this
+  harness). If it is ever non-zero it is the reason the identity misses.
+
 ## Energy (#209, NS-3 only)
 
 Radio energy comes from an ns-3 `BasicEnergySource` on every node plus a

--- a/docs/cross-validation.md
+++ b/docs/cross-validation.md
@@ -74,6 +74,18 @@ NS-3 PHY/device model, not of the shared `core/` algorithm:
   every other PHY-dependent divergence noted above. Do not attempt to
   cross-validate energy; cross-validate the routing behaviour, and read the
   energy caveats in [benchmarks/metrics.md](benchmarks/metrics.md).
+- **Drop-cause breakdown** (`drop_route_pct`, `drop_queue_pct`,
+  `drop_mac_pct`, `drop_chan_pct`, `drop_ttl_pct`, and AntHocNet's
+  `drop_setup_pct` / `drop_reconv_pct` / `drop_repair_pct`; #215). Channel loss
+  is by definition the gap between what a node put on the medium and what the
+  next hop received — a property of the NS-3 PHY/channel model, not of the
+  shared algorithm — and the interface-queue and MAC-retry causes are read from
+  NS-3's `FlowMonitor` and `WifiMac` traces. NS-2's counterparts are a
+  different PHY and a different set of hooks, so the *shares* would not be
+  comparable even if wired up. What **is** cross-validatable is the
+  AntHocNet-specific behaviour behind two of the columns: the core counts
+  repair discards (`AntRouterLogic::repairDiscards()`) simulator-agnostically,
+  so both adapters see the same events for the same run.
 
 ## What "agreement" means
 

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -14,7 +14,12 @@
  * plus packet reordering (#212): the RFC 4737 out-of-order
  * delivery ratio, the reordering extent (mean/max) and the reorder-buffer
  * occupancy needed to restore order, measured per flow at the sink and then
- * aggregated.
+ * aggregated,
+ * and a per-cause drop
+ * breakdown (#215): why the packets PDR is missing went missing — L3 route
+ * failure, interface-queue overflow, MAC retry exhaustion, channel loss and TTL
+ * expiry, measured identically for all four protocols and summing with PDR to
+ * ~100% of offered packets.
  * Fair comparison: the RNG run is reset before each protocol so every protocol
  * sees the identical mobility/traffic realisation, and NRL is counted uniformly
  * for every protocol from the IP layer.
@@ -45,6 +50,10 @@
 // Part of the applications module (already included above) since ns-3.31, so it
 // is available across the whole CI matrix (3.36-3.48).
 #include "ns3/seq-ts-size-header.h"
+// #215 drop causes: Ipv4FlowProbe::DropReason indexes FlowStats::packetsDropped;
+// LlcSnapHeader is what a wifi MPDU carries above the MAC header.
+#include "ns3/ipv4-flow-probe.h"
+#include "ns3/llc-snap-header.h"
 
 // #209: BasicEnergySource lives in the energy module; WifiRadioEnergyModel and
 // its helper live in the wifi module (already included above) in every ns-3 the
@@ -112,6 +121,64 @@ void RecordRxSeq(Ptr<const Packet> p, const Address& from) {
     SeqTsSizeHeader h;
     p->PeekHeader(h);
     g_rxSeq[from].push_back(h.GetSeq());
+}
+
+// --- drop-cause breakdown (#215) --------------------------------------------
+// A lost packet used to be anonymous: PDR said how many went missing, nothing
+// said why. #173 needed a whole campaign to establish that its collapse was
+// channel loss rather than route failure; in a breakdown that is one column.
+//
+// The protocol-agnostic causes are measured here, in the simulator, for all
+// four protocols. Two of them are per-hop tallies at the IP layer — the same
+// counting point NRL uses:
+//   g_dataHopTx  data IP packets handed to a real interface for transmission
+//   g_dataHopRx  data IP packets that arrived at the next hop's IP layer
+// Their difference is every data packet that entered the medium and did not
+// come out of it. That pool is then carved up: the MAC reports the frames it
+// gave up on after exhausting retries (g_macDataDrops), FlowMonitor reports the
+// interface/qdisc queue overflows, and whatever remains is genuine channel loss
+// — collisions, capture, out-of-range, ARP failures. Only the simulator can see
+// that difference, which is exactly why it cannot come from core/ (issue #215).
+//
+// Interface 0 is the loopback device. AntHocNet (like AODV) bounces a routeless
+// packet through it to reach RouteInput, so it must be excluded from BOTH
+// tallies or the bounce reads as a hop that was sent and never received.
+uint64_t g_dataHopTx = 0;
+uint64_t g_dataHopRx = 0;
+uint64_t g_macDataDrops = 0;  // data frames dropped at the MAC retry limit
+
+// Is this a CBR *data* IP packet (as opposed to routing control)? Same test as
+// CountControlTx, from the other side.
+bool IsDataIp(Ptr<const Packet> p) {
+    Ptr<Packet> c = p->Copy();
+    Ipv4Header ip;
+    if (c->RemoveHeader(ip) == 0) return false;
+    if (ip.GetProtocol() != 17) return false;  // not UDP
+    UdpHeader udp;
+    if (c->PeekHeader(udp) == 0) return false;
+    return udp.GetDestinationPort() == kDataPort;
+}
+
+void CountDataHopTx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t iface) {
+    if (iface != 0 && IsDataIp(p)) ++g_dataHopTx;
+}
+void CountDataHopRx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t iface) {
+    if (iface != 0 && IsDataIp(p)) ++g_dataHopRx;
+}
+
+// WifiMac "DroppedMpdu": a retry-limit drop is the MAC giving up on a unicast,
+// i.e. the link broke under the packet. Counted for every protocol from the
+// same trace the AntHocNet adapter uses for ADR-0008 detector D, so the column
+// means the same thing in all four arms. Other drop reasons (queue full,
+// lifetime expiry) are congestion and are counted by FlowMonitor instead.
+void CountMacDataDrop(WifiMacDropReason reason, Ptr<const AHN_WIFI_MPDU> mpdu) {
+    if (reason != WIFI_MAC_DROP_REACHED_RETRY_LIMIT || !mpdu) return;
+    Ptr<Packet> pkt = mpdu->GetPacket()->Copy();
+    LlcSnapHeader llc;
+    if (pkt->GetSize() < llc.GetSerializedSize()) return;
+    pkt->RemoveHeader(llc);
+    if (llc.GetType() != 0x0800) return;  // not IPv4
+    if (IsDataIp(pkt)) ++g_macDataDrops;
 }
 
 // --- diagnostics (--diag): ant-level introspection for AntHocNet -----------
@@ -287,6 +354,20 @@ struct Result {
     double reorderExtMean = 0.0;   // mean reordering extent over reordered pkts
     double reorderExtMax = 0.0;    // max reordering extent, packets
     double reorderBufMax = 0.0;    // max reorder-buffer occupancy, packets
+    // #215 drop causes, each as a % of *offered* (txPackets), so that
+    // pdr + the five protocol-agnostic causes ≈ 100. Sentinel **-1 = not
+    // applicable to this protocol** (emitted as a blank field, never a 0, so
+    // "this protocol has no such cause" stays distinguishable from "measured
+    // zero"); the three AntHocNet-only causes use it for every other arm.
+    double dropRoutePct = 0.0;   // L3 route failure (no route / route error)
+    double dropQueuePct = 0.0;   // interface or qdisc queue overflow
+    double dropMacPct   = 0.0;   // MAC retry limit, terminal (not re-injected)
+    double dropChanPct  = 0.0;   // sent on the medium, never received
+    double dropTtlPct   = 0.0;   // IP TTL exhausted
+    double dropSetupPct  = -1.0; // AntHocNet: pending-queue loss, never routed
+    double dropReconvPct = -1.0; // AntHocNet: pending-queue loss, route lost
+    double dropRepairPct = -1.0; // AntHocNet: DiscardPending after a failed repair
+    double dropOtherPct  = 0.0;  // L3 drops in none of the buckets above (diag)
 };
 
 Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
@@ -304,6 +385,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_qSum = 0.0;
     g_firstDeathS = -1.0;
     g_rxSeq.clear();
+    g_dataHopTx = g_dataHopRx = g_macDataDrops = 0;  // #215
 
     NodeContainer nodes;
     nodes.Create(P.nNodes);
@@ -437,6 +519,24 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     for (uint32_t i = 0; i < nodes.GetN(); ++i) {
         Ptr<Ipv4L3Protocol> l3 = nodes.Get(i)->GetObject<Ipv4L3Protocol>();
         if (l3) l3->TraceConnectWithoutContext("Tx", MakeCallback(&CountControlTx));
+        // #215: the same IP-layer hook, counting *data* hops in and out, plus
+        // the MAC's own retry-limit verdict. Connected per protocol arm, so the
+        // causes are measured identically for anthocnet, aodv, olsr and dsdv.
+        if (l3) {
+            l3->TraceConnectWithoutContext("Tx", MakeCallback(&CountDataHopTx));
+            l3->TraceConnectWithoutContext("Rx", MakeCallback(&CountDataHopRx));
+        }
+    }
+    for (uint32_t i = 0; i < devices.GetN(); ++i) {
+        Ptr<WifiNetDevice> w = devices.Get(i)->GetObject<WifiNetDevice>();
+        Ptr<WifiMac> wmac = w ? w->GetMac() : nullptr;  // `mac` above is the helper
+        // TraceConnect returns false if the source is absent on this ns-3
+        // release; tolerated, exactly as the adapter's detector D does — the
+        // MAC column then reads 0 and its share lands in channel loss.
+        if (wmac) {
+            wmac->TraceConnectWithoutContext("DroppedMpdu",
+                                             MakeCallback(&CountMacDataDrop));
+        }
     }
 
     Ipv4AddressHelper address;
@@ -558,6 +658,11 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     uint64_t jitterSamples = 0;  // each flow contributes rx-1 jitter samples
     std::map<uint32_t, uint64_t> delayBins;  // aggregated delay histogram
     double binWidth = 0.0;
+    // #215: IP-layer drop attribution, restricted to the data flows exactly the
+    // way PDR is. FlowMonitor indexes FlowStats::packetsDropped by
+    // Ipv4FlowProbe::DropReason and grows the vector lazily, so every read is
+    // bounds-checked.
+    uint64_t dropRoute = 0, dropTtl = 0, dropQueue = 0, dropL3Total = 0;
     // Restrict the delivery/delay/throughput metrics to the CBR *data* flows
     // (dest port kDataPort). FlowMonitor also classifies the routing-control
     // flows, which must not count toward PDR.
@@ -579,6 +684,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             if (binWidth == 0.0) binWidth = h.GetBinWidth(b);
             delayBins[b] += h.GetBinCount(b);
         }
+        // #215 drop attribution for this data flow.
+        const std::vector<uint32_t>& pd = kv.second.packetsDropped;
+        auto reason = [&pd](std::size_t i) -> uint64_t {
+            return i < pd.size() ? pd[i] : 0u;
+        };
+        dropRoute += reason(Ipv4FlowProbe::DROP_NO_ROUTE)
+                   + reason(Ipv4FlowProbe::DROP_ROUTE_ERROR);
+        dropTtl += reason(Ipv4FlowProbe::DROP_TTL_EXPIRE);
+        dropQueue += reason(Ipv4FlowProbe::DROP_QUEUE)
+                   + reason(Ipv4FlowProbe::DROP_QUEUE_DISC);
+        for (uint32_t v : pd) dropL3Total += v;
     }
     r.pdr = r.txPackets ? 100.0 * r.rxPackets / r.txPackets : 0.0;
     r.meanDelayMs = rxForDelay ? 1000.0 * totalDelay / rxForDelay : 0.0;
@@ -754,6 +870,76 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         r.reorderBufMax = static_cast<double>(bufMax);
     }
 
+    // #215 drop-cause breakdown, as a fraction of offered packets.
+    //
+    // The identity this is built to satisfy, and which scenario_check.py
+    // enforces, follows from packet conservation at the IP layer. Over all
+    // nodes and all data packets:
+    //
+    //   offered + hopRx + reinjected = hopTx + delivered + L3drops + stillQueued
+    //
+    // (a node's data packets come in from the app or from a device — or back
+    // from the MAC-failure re-injection path — and leave to a device, to the
+    // local transport, or into a drop). With
+    //   hopTx - hopRx = macDrops + queueDrops + channel      [definition of channel]
+    //   macTerminal   = macDrops - reinjected                [the rest came back]
+    // it rearranges to
+    //   offered - delivered = L3drops + macTerminal + queueDrops + channel + stillQueued
+    // i.e. pdr + route + ttl + queue + mac + channel = 100, up to the packets
+    // still sitting in a pending queue when the run stops. Nothing here is
+    // forced to add up: the L3 causes come from FlowMonitor, the hop tallies
+    // from the Ipv4L3Protocol traces and the MAC verdicts from the WifiMac
+    // trace, so a shortfall means one of those three books is wrong — which is
+    // precisely the harness regression the check is there to catch.
+    if (r.txPackets) {
+        const double tx = static_cast<double>(r.txPackets);
+        // AntHocNet-only causes: the pending queue and the local-repair discard
+        // exist in no other arm, so they stay at the -1 "not applicable"
+        // sentinel there rather than reporting a misleading 0.
+        uint64_t reinjected = 0;
+        if (proto == "anthocnet") {
+            uint64_t holdSetup = 0, holdReconv = 0, repairPkts = 0;
+            for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+                Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
+                if (!ip) continue;
+                Ptr<ns3::anthocnet::RoutingProtocol> ahn =
+                    DynamicCast<ns3::anthocnet::RoutingProtocol>(ip->GetRoutingProtocol());
+                if (!ahn) continue;
+                const ns3::anthocnet::HoldStats& s = ahn->HoldTimeStats();
+                holdSetup += s.droppedCount[ns3::anthocnet::HOLD_SETUP];
+                // A packet re-injected after a MAC failure (#46) and then aged
+                // out was still waiting for a route that had existed and did
+                // not come back — the reconvergence cause, not a separate one.
+                holdReconv += s.droppedCount[ns3::anthocnet::HOLD_RECONV]
+                            + s.droppedCount[ns3::anthocnet::HOLD_REPAIR];
+                repairPkts += ahn->RepairDiscardedPackets();
+                reinjected += ahn->MacReinjectedPackets();
+            }
+            r.dropSetupPct  = 100.0 * holdSetup / tx;
+            r.dropReconvPct = 100.0 * holdReconv / tx;
+            r.dropRepairPct = 100.0 * repairPkts / tx;
+        }
+        // Every one of these three ends in an error callback, so together they
+        // are a *sub-breakdown* of dropRoutePct, not extra causes on top of it;
+        // adding them to the identity would double-count.
+        const uint64_t macTerminal =
+            g_macDataDrops > reinjected ? g_macDataDrops - reinjected : 0;
+        const double hopLoss = static_cast<double>(g_dataHopTx)
+                             - static_cast<double>(g_dataHopRx);
+        r.dropRoutePct = 100.0 * dropRoute / tx;
+        r.dropTtlPct   = 100.0 * dropTtl / tx;
+        r.dropQueuePct = 100.0 * dropQueue / tx;
+        r.dropMacPct   = 100.0 * macTerminal / tx;
+        r.dropChanPct  = 100.0 * (hopLoss - static_cast<double>(g_macDataDrops)
+                                          - static_cast<double>(dropQueue)) / tx;
+        // L3 drops in none of the buckets above (bad checksum, interface down,
+        // fragment timeout — all structurally zero in this harness). Diagnostic
+        // only: if it is ever non-zero it is the reason the identity misses.
+        const uint64_t other = dropL3Total > dropRoute + dropTtl + dropQueue
+            ? dropL3Total - dropRoute - dropTtl - dropQueue : 0;
+        r.dropOtherPct = 100.0 * other / tx;
+    }
+
     // Diagnostics line (prefixed "# " so CSV consumers ignore it). Shows whether
     // routes form (reactive ants sent vs received elsewhere; back-ant arrivals)
     // and when the first packet is delivered.
@@ -846,12 +1032,19 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             // drops) across the setup / reconvergence / repair hold paths so
             // the dominant one can be attacked. Summed across nodes.
             ns3::anthocnet::HoldStats hs;
+            // #215: the repair-discard cause from both sides — the core's
+            // simulator-agnostic event count (how many local repairs expired)
+            // and the adapter's packet count (how much data each released).
+            uint64_t repairEvents = 0, repairPkts = 0, macReinjected = 0;
             for (uint32_t i = 0; i < nodes.GetN(); ++i) {
                 Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
                 if (!ip) continue;
                 Ptr<ns3::anthocnet::RoutingProtocol> ahn =
                     DynamicCast<ns3::anthocnet::RoutingProtocol>(ip->GetRoutingProtocol());
                 if (!ahn) continue;
+                repairEvents += ahn->RepairDiscards();
+                repairPkts += ahn->RepairDiscardedPackets();
+                macReinjected += ahn->MacReinjectedPackets();
                 const ns3::anthocnet::HoldStats& s = ahn->HoldTimeStats();
                 for (uint8_t r = 0; r < ns3::anthocnet::kHoldReasons; ++r) {
                     hs.deliveredCount[r] += s.deliveredCount[r];
@@ -877,7 +1070,9 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                 std::cout << (r ? " " : "") << kReasonName[r] << "="
                           << hs.droppedCount[r];
             }
-            std::cout << "]";
+            std::cout << "]"
+                      << " repairDiscard=" << repairEvents << "ev/" << repairPkts
+                      << "pkt macReinject=" << macReinjected;
         }
         std::cout << "\n";
     }
@@ -1053,6 +1248,12 @@ int main(int argc, char* argv[]) {
         // other column: a mean of per-run maxima, not a max over runs.
         double reordRatio = 0, reordRatioMax = 0;
         double reordExtMean = 0, reordExtMax = 0, reordBufMax = 0;
+        // #215: drop-cause means across runs. dropNa latches when a cause does
+        // not apply to this protocol, so the mean stays the -1 "not applicable"
+        // sentinel and is emitted blank rather than as a measured 0.
+        double dropRoute = 0, dropQueue = 0, dropMac = 0, dropChan = 0, dropTtl = 0;
+        double dropSetup = 0, dropReconv = 0, dropRepair = 0, dropOther = 0;
+        bool dropNa = false;
     };
     std::vector<Agg> agg(list.size());
     for (std::size_t i = 0; i < list.size(); ++i) {
@@ -1108,6 +1309,19 @@ int main(int argc, char* argv[]) {
             agg[i].reordExtMean += r.reorderExtMean;
             agg[i].reordExtMax += r.reorderExtMax;
             agg[i].reordBufMax += r.reorderBufMax;
+            agg[i].dropRoute += r.dropRoutePct;
+            agg[i].dropQueue += r.dropQueuePct;
+            agg[i].dropMac += r.dropMacPct;
+            agg[i].dropChan += r.dropChanPct;
+            agg[i].dropTtl += r.dropTtlPct;
+            agg[i].dropOther += r.dropOtherPct;
+            if (r.dropSetupPct < 0.0) {
+                agg[i].dropNa = true;  // #215: cause not applicable to this arm
+            } else {
+                agg[i].dropSetup += r.dropSetupPct;
+                agg[i].dropReconv += r.dropReconvPct;
+                agg[i].dropRepair += r.dropRepairPct;
+            }
         }
         agg[i].pdr /= runs;
         agg[i].delay /= runs;
@@ -1130,6 +1344,19 @@ int main(int argc, char* argv[]) {
         agg[i].reordExtMean /= runs;
         agg[i].reordExtMax /= runs;
         agg[i].reordBufMax /= runs;
+        agg[i].dropRoute /= runs;
+        agg[i].dropQueue /= runs;
+        agg[i].dropMac /= runs;
+        agg[i].dropChan /= runs;
+        agg[i].dropTtl /= runs;
+        agg[i].dropOther /= runs;
+        if (agg[i].dropNa) {
+            agg[i].dropSetup = agg[i].dropReconv = agg[i].dropRepair = -1.0;
+        } else {
+            agg[i].dropSetup /= runs;
+            agg[i].dropReconv /= runs;
+            agg[i].dropRepair /= runs;
+        }
         if (runs > 1) {
             auto sd = [runs](double sum, double sumSq) {
                 const double mean = sum / runs;
@@ -1154,7 +1381,12 @@ int main(int argc, char* argv[]) {
         // nodes, the initial energy the run was configured with, and the
         // first-node-death time with -1 = no node died), then #212
         // reordering (out-of-order ratio pooled over flows and for the worst
-        // single flow, reordering extent mean/max, reorder-buffer occupancy).
+        // single flow, reordering extent mean/max, reorder-buffer occupancy),
+        // then #215's drop-cause breakdown: the five protocol-agnostic
+        // causes (which sum with pdr_pct to ~100), then the three AntHocNet-only
+        // ones, which are a sub-breakdown of drop_route_pct and are **blank**
+        // for the other protocols (blank = the cause does not exist there;
+        // 0 would mean it exists and never fired).
         std::cout << "protocol,runs,nNodes,area,speed,flows,pdr_pct,delay_ms,"
                      "throughput_kbps,delay99_ms,nrl,jitter_ms,delay_off50_ms,"
                      "delay_off90_ms,pdr_sd,delay_sd,delay99_sd,nrl_sd,"
@@ -1162,8 +1394,17 @@ int main(int argc, char* argv[]) {
                      "energy_res_mean_j,energy_res_sd_j,energy_init_j,"
                      "first_death_s,reorder_ratio,reorder_ratio_max,"
                      "reorder_extent_mean,reorder_extent_max,"
-                     "reorder_buf_max\n";
+                     "reorder_buf_max,drop_route_pct,drop_queue_pct,"
+                     "drop_mac_pct,"
+                     "drop_chan_pct,drop_ttl_pct,drop_setup_pct,"
+                     "drop_reconv_pct,drop_repair_pct\n";
         std::cout << std::fixed;
+        // Blank, not zero, when a cause does not apply to this protocol (#215).
+        auto optPct = [](double v) {
+            std::ostringstream o;
+            if (v >= 0.0) o << std::fixed << std::setprecision(3) << v;
+            return o.str();
+        };
         for (std::size_t i = 0; i < list.size(); ++i) {
             std::cout << list[i] << ',' << runs << ',' << P.nNodes << ','
                       << std::setprecision(0) << P.areaX << ','
@@ -1192,7 +1433,15 @@ int main(int argc, char* argv[]) {
                       << std::setprecision(4) << agg[i].reordRatioMax << ','
                       << std::setprecision(2) << agg[i].reordExtMean << ','
                       << std::setprecision(2) << agg[i].reordExtMax << ','
-                      << std::setprecision(2) << agg[i].reordBufMax << '\n';
+                      << std::setprecision(2) << agg[i].reordBufMax << ','
+                      << std::setprecision(3) << agg[i].dropRoute << ','
+                      << std::setprecision(3) << agg[i].dropQueue << ','
+                      << std::setprecision(3) << agg[i].dropMac << ','
+                      << std::setprecision(3) << agg[i].dropChan << ','
+                      << std::setprecision(3) << agg[i].dropTtl << ','
+                      << optPct(agg[i].dropSetup) << ','
+                      << optPct(agg[i].dropReconv) << ','
+                      << optPct(agg[i].dropRepair) << '\n';
         }
         return 0;
     }
@@ -1249,6 +1498,35 @@ int main(int argc, char* argv[]) {
                   << " resSdJ=" << std::setprecision(3) << agg[i].resSd
                   << " firstDeathS=" << std::setprecision(1) << agg[i].firstDeath
                   << "\n";
+    }
+    // #215 drop causes: why the packets PDR is missing went missing, as a % of
+    // offered. `sum` is pdr + the five protocol-agnostic causes and should read
+    // ~100; `other` and the gap between `sum` and 100 are the diagnostic
+    // handles when it does not (unbucketed L3 drop reasons, and packets still
+    // held in a pending queue when the run stopped). setup/reconv/repair are
+    // AntHocNet's sub-breakdown of `route` and print as "-" elsewhere. '# '
+    // prefix keeps the line off the CSV/##BENCH## paths, like '# energy'.
+    auto opt = [](double v) {
+        std::ostringstream o;
+        if (v < 0.0) o << "-";
+        else o << std::fixed << std::setprecision(2) << v;
+        return o.str();
+    };
+    for (std::size_t i = 0; i < list.size(); ++i) {
+        const double sum = agg[i].pdr + agg[i].dropRoute + agg[i].dropQueue
+                         + agg[i].dropMac + agg[i].dropChan + agg[i].dropTtl;
+        std::cout << std::fixed << std::setprecision(2) << "# drops " << list[i]
+                  << " pdr=" << agg[i].pdr
+                  << " route=" << agg[i].dropRoute
+                  << " queue=" << agg[i].dropQueue
+                  << " mac=" << agg[i].dropMac
+                  << " chan=" << agg[i].dropChan
+                  << " ttl=" << agg[i].dropTtl
+                  << " sum=" << sum
+                  << " other=" << agg[i].dropOther
+                  << " [route: setup=" << opt(agg[i].dropSetup)
+                  << " reconv=" << opt(agg[i].dropReconv)
+                  << " repair=" << opt(agg[i].dropRepair) << "]\n";
     }
     // #28 dispersion: '# ' prefix keeps these out of the CSV/##BENCH## paths.
     if (runs > 1) {

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -751,6 +751,10 @@ void RoutingProtocol::FlushQueue(NodeAddress coreDest) {
 void RoutingProtocol::DiscardQueue(NodeAddress coreDest) {
     std::vector<QueueEntry> pending;
     m_queue.DequeueAll(ToIpv4(coreDest), pending);
+    // #215: count the packets, not just the event — the core counts the events
+    // (repairDiscards()), but only the adapter owns the queue and so knows how
+    // many packets each expired repair released.
+    m_repairDiscardedPackets += pending.size();
     for (QueueEntry& e : pending) {
         if (!e.ecb.IsNull()) e.ecb(e.packet, e.header, Socket::ERROR_NOROUTETOHOST);
     }
@@ -888,6 +892,7 @@ void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI
         entry.ucb = m_cachedUcb;
         entry.ecb = m_cachedEcb;
         entry.holdReason = HOLD_REPAIR;  // #21: held during local repair (#46)
+        ++m_macReinjectedPackets;        // #215: this MAC failure was not terminal
         m_queue.Enqueue(entry);
         FlushQueue(dataDest);
     }

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -131,6 +131,26 @@ public:
     /// hold path.
     const HoldStats& HoldTimeStats() const { return m_queue.Stats(); }
 
+    /// Issue #215 drop-cause breakdown, the AntHocNet-specific causes. The
+    /// generic ones (channel, MAC, TTL, interface queue) are measured
+    /// simulator-side by the comparison harness for every protocol; these three
+    /// exist only here because only this protocol has a pending queue and a
+    /// local-repair discard.
+    ///
+    /// Data packets released by a failed local repair ([1] §3.5, D6) — the
+    /// *packet* count behind the core's DiscardPending events. This is expected
+    /// protocol behaviour, not a fault: the paper trades these packets for a
+    /// bounded delay tail.
+    uint64_t RepairDiscardedPackets() const { return m_repairDiscardedPackets; }
+    /// Expired local repairs (the core's event count; several packets may be
+    /// released per event).
+    uint64_t RepairDiscards() const { return m_logic ? m_logic->repairDiscards() : 0; }
+    /// Data packets a MAC retry-limit drop put *back* into the pending queue
+    /// (#46 re-injection). Such a packet is not lost yet — its terminal fate is
+    /// counted wherever it finally ends up — so the harness subtracts these from
+    /// the raw MAC-failure tally to avoid double-counting them (#215).
+    uint64_t MacReinjectedPackets() const { return m_macReinjectedPackets; }
+
 protected:
     void DoInitialize() override;
     void DoDispose() override;
@@ -263,6 +283,10 @@ private:
     // reconvergence wait (route was known and lost) when a data packet is
     // deferred, so the hold-time attribution can tell the two apart.
     std::set<::anthocnet::core::NodeAddress> m_everRouted;
+
+    // Issue #215 drop-cause counters (see the accessors above).
+    uint64_t m_repairDiscardedPackets = 0;
+    uint64_t m_macReinjectedPackets = 0;
 
     // trace sources (item 15): ant sent/received and route add/remove.
     TracedCallback<uint8_t, uint8_t, bool> m_txAntTrace;

--- a/ns3/model/anthocnet-rqueue.cc
+++ b/ns3/model/anthocnet-rqueue.cc
@@ -27,8 +27,20 @@ bool RequestQueue::Enqueue(QueueEntry& entry) {
     }
     entry.expire = expire;
     if (m_queue.size() >= m_maxLen) {
-        // Drop the oldest to make room.
+        // Drop the oldest to make room. Accounted and error-callback'd exactly
+        // like an aged-out entry (#215): it is the same loss for the same
+        // reason — the route did not arrive in time — and leaving it silent
+        // made the packet vanish from every downstream tally, so the drop-cause
+        // breakdown could not add up. Matches aodv-rqueue, which also drops the
+        // most-aged packet through its error callback.
+        const QueueEntry old = m_queue.front();  // copy: the ecb runs after the erase
         m_queue.erase(m_queue.begin());
+        const uint8_t r = old.holdReason < kHoldReasons ? old.holdReason : HOLD_SETUP;
+        m_stats.droppedCount[r] += 1;
+        m_stats.droppedSumS[r] += (Simulator::Now() - old.enqueueFirst).GetSeconds();
+        if (!old.ecb.IsNull()) {
+            old.ecb(old.packet, old.header, Socket::ERROR_NOROUTETOHOST);
+        }
     }
     m_queue.push_back(entry);
     return true;

--- a/ns3/model/anthocnet-rqueue.h
+++ b/ns3/model/anthocnet-rqueue.h
@@ -29,8 +29,12 @@ constexpr uint8_t kHoldReasons = 3;
 /// The #88 sweep showed the median offered packet delivers in ~3 ms (dOff50):
 /// the mean/jitter gap vs AODV is carried entirely by queue-held packets, so
 /// which reason accumulates the most *delivered* hold time is the dominant
-/// cause of the tail. `dropped*` counts packets that aged out at QueueTimeout
-/// (a PDR loss rather than a delay, but the same hold mechanic).
+/// cause of the tail. `dropped*` counts packets that left the queue without
+/// being forwarded — aged out at QueueTimeout, or evicted as the oldest entry
+/// when the queue was full (#215) — a PDR loss rather than a delay, but the
+/// same hold mechanic. It does NOT count packets released by a failed local
+/// repair (`DiscardPending`); those are a distinct drop cause and are counted
+/// by RoutingProtocol::RepairDiscardedPackets().
 struct HoldStats
 {
     uint64_t deliveredCount[kHoldReasons] = {0, 0, 0};

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -25,7 +25,9 @@ Output CSV columns:
   pdr_pct,delay_ms,delay99_ms,throughput_kbps,nrl,...,energy_j,
   energy_per_pkt_j,energy_res_min_j,energy_res_mean_j,energy_res_sd_j,
   energy_init_j,first_death_s,reorder_ratio,reorder_ratio_max,
-  reorder_extent_mean,reorder_extent_max,reorder_buf_max
+  reorder_extent_mean,reorder_extent_max,reorder_buf_max,
+  drop_route_pct,drop_queue_pct,drop_mac_pct,
+  drop_chan_pct,drop_ttl_pct,drop_setup_pct,drop_reconv_pct,drop_repair_pct
                                 (see METRICS below for the full, append-only
                                  list)
 
@@ -99,6 +101,14 @@ SWEEPS = {
 # the reordering extent (mean/max, in packets) and the reorder-buffer occupancy
 # needed to restore order. Multipath reordering is expected AntHocNet behaviour;
 # see docs/benchmarks/metrics.md for the exact definitions.
+# The drop_*_pct columns are #215 (ns-3 only): why the packets PDR is missing
+# went missing, each as a percentage of *offered* packets. The five
+# protocol-agnostic causes (route / queue / mac / chan / ttl) are measured
+# identically for all four protocols and sum with pdr_pct to ~100 — a
+# discrepancy is a harness finding, and scenario_check.py results fails on it.
+# The three AntHocNet-only causes (setup / reconv / repair) are a sub-breakdown
+# of drop_route_pct and are deliberately **blank**, not 0, for protocols that
+# have no such cause.
 # APPEND ONLY — downstream consumers (make-charts.py, sweep_summary.py,
 # bench_parse.py, scenario_check.py) look these columns up by header name, so
 # appending is safe and reordering is not.
@@ -109,7 +119,10 @@ METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
            "energy_res_mean_j", "energy_res_sd_j", "energy_init_j",
            "first_death_s",
            "reorder_ratio", "reorder_ratio_max", "reorder_extent_mean",
-           "reorder_extent_max", "reorder_buf_max"]
+           "reorder_extent_max", "reorder_buf_max",
+           "drop_route_pct", "drop_queue_pct", "drop_mac_pct", "drop_chan_pct",
+           "drop_ttl_pct", "drop_setup_pct", "drop_reconv_pct",
+           "drop_repair_pct"]
 PARAMS = ["runs", "nNodes", "area", "speed", "flows"]
 OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + ["runs", "nNodes", "areaX", "speed", "pause", "flows", "propagation"]


### PR DESCRIPTION
Implements [#215](https://github.com/danieljoppi/AntHocNet/issues/215). Today a lost packet is anonymous — we report PDR and nothing about *why*. [#173](https://github.com/danieljoppi/AntHocNet/issues/173) cost a benchmark campaign, a testbench reproduction and a code audit to diagnose; its signature here (collapse dominated by *channel loss*, not *no route*) would have been obvious in one run.

## The bug this found

Building the accounting surfaced a latent defect, and the identity **could not close until it was fixed**:

> `RequestQueue::Enqueue`'s full-queue eviction dropped the oldest packet **silently, with no error callback.**

Packets were vanishing unaccounted for. It now accounts the eviction and fires the ecb, matching `aodv-rqueue`'s behaviour. That is the whole argument for a conservation check rather than a set of independent counters: a counter you forgot to increment reads as zero, but a *sum that must reach 100%* cannot hide one.

## Columns (appended after `first_death_s`)

`drop_route_pct`, `drop_queue_pct`, `drop_mac_pct`, `drop_chan_pct`, `drop_ttl_pct`, `drop_setup_pct`, `drop_reconv_pct`, `drop_repair_pct` — all as % of **offered** packets.

| Cause | Source | Applies to |
|---|---|---|
| `drop_route` | FlowMonitor `DROP_NO_ROUTE + DROP_ROUTE_ERROR` | all four |
| `drop_queue` | FlowMonitor `DROP_QUEUE + DROP_QUEUE_DISC` | all four |
| `drop_mac` | `WifiMac` `DroppedMpdu` / retry-limit, minus #46 re-injections | all four |
| `drop_chan` | `Ipv4L3Protocol` Tx/Rx hop tallies, minus mac + queue | all four |
| `drop_ttl` | FlowMonitor `DROP_TTL_EXPIRE` | all four |
| `drop_setup` / `drop_reconv` | adapter `HoldStats.droppedCount[]` (reused from #21) | anthocnet — **blank** elsewhere |
| `drop_repair` | **core** `repairDiscards()` (new) + adapter packet count | anthocnet — **blank** elsewhere |

Blank rather than zero where a cause doesn't apply, so "not applicable" and "measured zero" stay distinguishable.

## Core change is minimal and stays behind the boundary

One addition: `AntRouterLogic::repairDiscards()`, incremented at the single `DiscardPending` site, with four new assertions on the existing D6 cases in `core/tests/test_link_failure.cpp` (golden rule 7). **No new port and no new `IRouterObserver` method** — `DiscardPending` already crosses the boundary as a `RouteDecision`, so the adapter never reaches into core internals (golden rules 1–2).

## Does the identity close?

**By derivation, yes; empirically, unverified** — it can't be run here. Node-level packet conservation at the IP layer gives:

```
pdr + route + queue + mac + chan + ttl = 100 − stillQueued
```

with `chan ≡ (hopTx − hopRx) − macDrops − queueDrops` and `macTerminal ≡ macDrops − reinjected`. Full algebra is in a comment block in `RunOne()`. The three inputs are **independent books** (FlowMonitor / L3 traces / WifiMac), so the sum is a genuine cross-check rather than a tautology.

Tolerance: **WARN > 1 pp, FAIL > 5 pp**. The only legitimate residual is data still queued at stop, bounded by `QueueTimeout` (3 s) of offered traffic — ≈0.3% of a 900 s run, ≈2.5% of the 120 s `--quick` preset.

## Verification

`make test` 23/23 · `check_invariants.sh` clean (including "core change has an accompanying core test") · `python3 -m ruff check ns3/tools` clean on **ruff 0.16.0** (PATH `ruff` is 0.15.8 and shadows it) · `ast.parse` + `--help` + no duplicate `METRICS`/`OUT_COLUMNS`.

`scenario_check.py results` exercised against five inputs: synthetic good (OK), WARN-band −2 pp (WARN, exit 0), FAIL −22 pp *and* a negative `drop_chan` (2 FAIL, exit 1), a results table with `# drops` lines (rules skip correctly), and the **real** pre-#215 `30031902395-area-disk.csv` (OK, 20 rows — old CSVs still validate).

## Not verified, and two risks to watch on the first real run

`anthocnet-compare` doesn't compile here — no ns-3 tree; the CI matrix validates it. Two names aren't already proven in-repo: `Ipv4FlowProbe::DropReason` members, and `FlowMonitor::FlowStats::packetsDropped` (read bounds-checked, since FlowMonitor grows that vector lazily).

Known risks, both of which would surface as a WARN/FAIL from the new rule rather than silently — **which is the point**:
1. AODV/DSDV internal packet buffers must fire their error callbacks for `drop_route_pct` to capture them. AODV's does; DSDV's is believed to.
2. `DROP_QUEUE_DISC` only populates if `Ipv4FlowProbe`'s traffic-control hook connects on that release; otherwise that share silently lands in `drop_chan_pct`.

## Merge order

Conflicts with [#221](https://github.com/danieljoppi/AntHocNet/pull/221) (reordering) are pure appends — tail of `METRICS`, the CSV header string, the CSV row, and new blocks in `scenario_check.py`/`metrics.md`. No reordering, no shared line rewritten. Either order works; whichever merges second rebases trivially.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_