### PR TITLE
feat(bench): measure path diversity, path length and flow fairness

### DIFF
--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -164,7 +164,12 @@ the #215 drop-cause identity (PDR plus the
 five protocol-agnostic causes must account for ~100% of offered packets: WARN
 past 1 pp, FAIL past 5 pp — the tolerance is the data still queued when the run
 stops; also FAILs a negative cause share, which means two causes count the same
-packet; skipped for inputs predating drop instrumentation), and — with
-`--anchor` — the AODV floors read from
+packet; skipped for inputs predating drop instrumentation),
+the #217 route-quality invariants (mean path
+length ≥ 1 hop and ≤ `maxPathLength`, max ≥ mean; used-path diversity ≥ 1 and
+≤ its own maximum; path entropy in [0, log2(max diversity)]; Jain's fairness
+index ∈ [0,1] — each of them non-zero whenever PDR is, so a trace that silently
+failed to connect reads as a FAIL rather than as "no multipath"; all skipped for
+inputs predating route-quality instrumentation), and — with `--anchor` — the AODV floors read from
 `ns3/tools/anchors.yml` (never duplicated). A `results` FAIL is a #51-class
 harness regression: fix the harness before trusting any number from that run.

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -36,6 +36,11 @@ ANCHORS_YML = os.path.normpath(
 ANCHOR_KEY = {"single-hop": "single_hop_pdr_min",
               "broch-low-mobility": "broch_low_mobility_aodv_pdr_min"}
 
+# #217: core Config::maxPathLength — the cap on the visited path an ant carries
+# and therefore on any path the protocol can lay. A delivered data packet
+# reported above it is an instrumentation error, not a long route.
+MAX_PATH_LENGTH = 100
+
 ROW = re.compile(r"^\s*(?:##BENCH##\s+)?([a-z][\w-]*)((?:\s+[-\d.]+|\s+inf)+)\s*$")
 
 issues = []
@@ -122,6 +127,11 @@ def parse_results(path):
     **blank** for the other protocols (the cause does not exist there, as
     opposed to existing and measuring zero); a blank parses to None and is
     skipped, exactly like an absent column.
+
+    Route-quality fields (#217) are likewise post-instrumentation and skipped
+    when absent. The results table carries the two headline columns (hops,
+    jain) at positions 12/13; used-path diversity and its entropy live in the
+    CSV only (the human output puts them on a '# paths' line).
     """
     with open(path) as fh:
         text = fh.read()
@@ -150,7 +160,13 @@ def parse_results(path):
                    "drop_ttl": r.get("drop_ttl_pct"),
                    "drop_setup": r.get("drop_setup_pct"),
                    "drop_reconv": r.get("drop_reconv_pct"),
-                   "drop_repair": r.get("drop_repair_pct")}
+                   "drop_repair": r.get("drop_repair_pct"),
+                   "hops": r.get("path_hops_mean"),
+                   "hops_max": r.get("path_hops_max"),
+                   "div": r.get("path_div_used"),
+                   "div_max": r.get("path_div_max"),
+                   "entropy": r.get("path_entropy_bits"),
+                   "jain": r.get("jain_pkts")}
         return
     for line in text.splitlines():
         m = ROW.match(line)
@@ -167,6 +183,9 @@ def parse_results(path):
         if len(nums) >= 11:  # #209: ... nrlBytes, energy(J), J/pkt
             row["energy"] = nums[9]
             row["energy_per_pkt"] = nums[10]
+        if len(nums) >= 13:  # #217: ... J/pkt, hops, jain
+            row["hops"] = nums[11]
+            row["jain"] = nums[12]
         yield row
 
 
@@ -306,6 +325,62 @@ def cmd_results(a):
                 report("WARN", f"{tag}: setup+reconv+repair {sum(sub):.2f} != "
                                f"drop_route_pct {route:.2f} — a pending-queue "
                                "exit path is not attributed")
+            # #217 route-quality plausibility. Absent columns (inputs predating
+            # the instrumentation) simply skip, as the energy rules do. A 0 is
+            # the "empty denominator" convention shared with nrl/J-per-packet:
+            # legitimate only when nothing was delivered, and a harness failure
+            # (trace not connected on this ns-3 release, hook never fired)
+            # whenever PDR is non-zero.
+            hops, hops_max = num("hops"), num("hops_max")
+            div, div_max = num("div"), num("div_max")
+            entropy, jain = num("entropy"), num("jain")
+            if hops is not None:
+                if hops < 0.0:
+                    report("FAIL", f"{tag}: negative path length ({hops})")
+                elif hops == 0.0 and pdr:
+                    report("FAIL", f"{tag}: mean path length 0 with PDR {pdr} — "
+                                   "packets delivered but no hop count "
+                                   "recorded")
+                elif hops > 0.0 and hops < 1.0:
+                    report("FAIL", f"{tag}: mean path length {hops} < 1 hop — "
+                                   "a delivered packet traverses at least one "
+                                   "transmission")
+                elif hops > MAX_PATH_LENGTH:
+                    report("FAIL", f"{tag}: mean path length {hops} exceeds "
+                                   f"maxPathLength ({MAX_PATH_LENGTH})")
+            if hops_max is not None:
+                if hops_max > MAX_PATH_LENGTH:
+                    report("FAIL", f"{tag}: max path length {hops_max} exceeds "
+                                   f"maxPathLength ({MAX_PATH_LENGTH})")
+                if hops is not None and hops_max and hops_max < hops:
+                    report("FAIL", f"{tag}: max path length {hops_max} < mean "
+                                   f"path length {hops}")
+            if div is not None:
+                if div == 0.0 and pdr:
+                    report("FAIL", f"{tag}: path diversity 0 with PDR {pdr} — "
+                                   "data was carried but no next hop was "
+                                   "attributed (MAC trace not connected?)")
+                elif div < 0.0 or (0.0 < div < 1.0):
+                    report("FAIL", f"{tag}: path diversity {div} < 1 — a "
+                                   "carried destination uses at least one "
+                                   "next hop")
+            if div_max is not None and div is not None and div_max and div_max < div:
+                report("FAIL", f"{tag}: max path diversity {div_max} < mean "
+                               f"path diversity {div}")
+            if entropy is not None:
+                if entropy < 0.0:
+                    report("FAIL", f"{tag}: negative path entropy ({entropy})")
+                elif div_max and div_max >= 1.0 and entropy > math.log2(div_max) + 0.01:
+                    report("FAIL", f"{tag}: path entropy {entropy} bits exceeds "
+                                   f"log2(max diversity {div_max})")
+            if jain is not None:
+                if not (0.0 <= jain <= 1.0 + 1e-9):
+                    report("FAIL", f"{tag}: Jain's fairness index {jain} "
+                                   "outside [0,1]")
+                elif jain == 0.0 and pdr:
+                    report("FAIL", f"{tag}: Jain's fairness index 0 with PDR "
+                                   f"{pdr} — packets delivered but no per-flow "
+                                   "counts")
             if floor is not None and r["proto"] == "aodv" and pdr is not None:
                 if pdr < floor:
                     report("FAIL", f"{tag}: anchor '{a.anchor}' floor "

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -148,6 +148,122 @@ conclusion is unsafe until it is fixed.
   (bad checksum, interface down, fragment timeout — structurally zero in this
   harness). If it is ever non-zero it is the reason the identity misses.
 
+## Route quality: path length, path diversity, fairness (#217, NS-3 only)
+
+AntHocNet's defining property is that it lays and maintains **multiple paths**,
+and until #217 the harness measured nothing about paths. These columns are
+produced protocol-agnostically from NS-3's own traces for **all four
+protocols** — the single-path baselines are the instrumentation's self-check,
+not a blank column.
+
+- **path_hops_mean / path_hops_max** — mean and maximum hop count *actually
+  traversed by delivered data packets*, where one hop is one transmission (a
+  packet delivered to a neighbour is 1 hop). This is what settles whether
+  AntHocNet's delay advantage comes from **shorter** paths or from better path
+  **selection**: compare `path_hops_mean` alongside `delay_ms`. 0 when nothing
+  was delivered (the `nrl` convention).
+
+  *Definition and source.* Taken from the IP TTL observed at the destination's
+  `Ipv4L3Protocol` `LocalDeliver` trace — one call per packet handed to the
+  local transport, i.e. exactly the packets PDR counts — as
+  `hops = (initial TTL − TTL at delivery) + 1`. The initial TTL is NS-3's
+  `Ipv4L3Protocol::DefaultTtl` default of 64 (unchanged across the 3.36–3.48 CI
+  matrix; nothing in the harness sets a `SocketIpTtlTag`). Every real forwarding
+  hop passes through `Ipv4L3Protocol::IpForward`, which decrements the TTL
+  exactly once. This is numerically the same quantity as FlowMonitor's
+  `FlowStats::timesForwarded + 1` — which accumulates only over delivered
+  packets — but observed per packet rather than per flow, which is what makes
+  the **maximum** available at all: FlowMonitor exposes only the sum.
+
+- **path_div_used** — **used** path diversity: the mean number of *distinct next
+  hops that actually carried a data packet* for a destination, per (node,
+  destination) pair, within one `path_div_window_s` window, averaged over the
+  cells that carried data. **path_div_max** is the largest such count seen in
+  any one cell.
+
+  *Used, not available — and the distinction is the point.* Pheromone entries
+  above `minPheromone` are the paths the table makes **available**; a table full
+  of pheromone that data never uses would read as diversity that does not
+  exist. What is reported here is **usage**: a next hop counts only when a data
+  frame it carried was acknowledged.
+
+  *Why a window.* Diversity is *concurrency*. Over a whole run a single-path
+  protocol also touches several next hops for one destination — sequentially, as
+  routes break and are rediscovered — so a whole-run distinct count would credit
+  AODV with multipath it does not have. Counting per window separates
+  concurrent spreading from sequential replacement. **Expect the baselines
+  (AODV/OLSR/DSDV) to read ≈1**; the residual excess above 1 is route churn
+  inside one window, not spreading, and it grows with mobility. A baseline
+  reading well above 1, or AntHocNet reading exactly 1, is an instrumentation
+  or protocol regression.
+
+  *Source.* The `WifiMac` `AckedMpdu` trace: it fires at the transmitter for
+  every unicast MPDU the next hop acknowledged, and the 802.11 header's `Addr1`
+  **is** the next hop. It is the only address-bearing transmit hook NS-3 offers
+  uniformly to all four protocols (the `Ipv4L3Protocol` traces do not carry the
+  gateway), and "acknowledged" makes "carried" literal — a frame the next hop
+  never received is not a path that was used. The AntHocNet adapter already
+  depends on this trace across the whole CI matrix (#68).
+
+- **path_entropy_bits** — mean Shannon entropy (bits) of the per-next-hop packet
+  split within a cell, averaged over the same cells as `path_div_used`. **0 =
+  single path**; 1 bit = an even two-way split; it is bounded above by
+  log2(`path_div_max`). Reported because the count alone cannot distinguish a
+  genuine 50/50 split from 999 packets down one next hop and 1 down another.
+
+- **path_div_window_s** — the window (s) the diversity columns are counted over
+  (`--pathWindowS`, default **10 s**), carried in the CSV because it *defines*
+  what the diversity number means. Provenance: a repo choice, not a paper value.
+  It must be long enough to hold several packets of a flow (the paper base
+  scenario offers 1 packet/s per flow, so 10 s ≈ 10 packets) and short enough
+  that a single-path protocol rarely replaces a route inside it. Comparisons
+  across different window settings are meaningless — check the column matches
+  before differencing two runs.
+
+- **jain_pkts** — **Jain's fairness index** over the per-flow delivered-packet
+  counts, `J = (Σxᵢ)² / (n·Σxᵢ²)`. `J = 1` when every flow is served equally,
+  `J = 1/n` at maximum unfairness (one flow gets everything). `heavy-load` runs
+  40 flows and the rest of the table reports only aggregates, so without this
+  one starved flow is invisible. This is where stochastic spreading should beat
+  single-path protocols.
+
+  *Population.* `n` is the number of source applications actually installed, so
+  a flow so starved that not one of its packets ever reached the IP layer — its
+  socket send failed for want of a route, which FlowMonitor never records —
+  still counts as a **zero** rather than vanishing from the index. (That is a
+  deliberate divergence from PDR's denominator, which counts only packets
+  FlowMonitor saw offered.)
+
+  *One index, two readings.* Computed over delivered **packet counts**; because
+  every flow in this harness sends the same 64-byte payload, the per-flow
+  throughput vector is a scalar multiple of the packet-count vector and Jain's
+  index is scale-invariant, so the same number is also the throughput-based
+  index. If the harness ever gains per-flow packet sizes, the two separate and
+  a second column is needed.
+
+### Caveats (route quality)
+
+- **Reactive protocols read one hop high on route-discovery packets.** A
+  protocol with no route yet bounces the packet through the loopback device to
+  reach `RouteInput` (AODV and this adapter both do); the packet then leaves via
+  `IpForward`, costing one TTL decrement that no radio carried. Those packets
+  report one hop too many, so `path_hops_mean` for `anthocnet`/`aodv` is a
+  slight over-estimate, bounded by (route discoveries)/(delivered packets) — a
+  fraction of a percent in the paper scenario, larger where routes break often.
+  FlowMonitor's `timesForwarded` counts the same bounce, so this is a property
+  of the loopback idiom, not of the TTL route to the number.
+- **Diversity is measured on acknowledged unicasts only.** Broadcast frames are
+  never acknowledged; that is correct here (routing control must not count as a
+  used data path) but it also means a protocol that delivered data over
+  broadcast would read 0. None of the four does.
+- **Diversity aggregates over every relay, not just sources.** A cell is a
+  (node, destination, window) triple, so a node forwarding for one destination
+  in a window contributes a 1 whatever the source is doing. That is the
+  intended reading — AntHocNet spreads at every hop — but it means the mean is
+  diluted by relays that saw only one packet in a window.
+- **NS-3 only.** The NS-2 adapter has no equivalent instrumentation; see
+  [cross-validation.md](../cross-validation.md).
+
 ## Energy (#209, NS-3 only)
 
 Radio energy comes from an ns-3 `BasicEnergySource` on every node plus a

--- a/docs/cross-validation.md
+++ b/docs/cross-validation.md
@@ -86,6 +86,15 @@ NS-3 PHY/device model, not of the shared `core/` algorithm:
   AntHocNet-specific behaviour behind two of the columns: the core counts
   repair discards (`AntRouterLogic::repairDiscards()`) simulator-agnostically,
   so both adapters see the same events for the same run.
+- **Route quality** (`path_hops_mean`, `path_hops_max`, `path_div_used`,
+  `path_div_max`, `path_entropy_bits`, `jain_pkts`; #217). Path length comes
+  from the IP TTL at NS-3's `Ipv4L3Protocol` `LocalDeliver` trace and used-path
+  diversity from the `WifiMac` `AckedMpdu` trace — NS-3 device/PHY hooks with no
+  NS-2 counterpart, and diversity in particular depends on 802.11
+  acknowledgement, which the two simulators model differently. Jain's fairness
+  index is computable in principle from an NS-2 trace file, but the harness that
+  would produce it does not exist on the NS-2 side. As with energy, do not block
+  cross-validation on these columns.
 
 ## What "agreement" means
 

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -19,7 +19,11 @@
  * breakdown (#215): why the packets PDR is missing went missing — L3 route
  * failure, interface-queue overflow, MAC retry exhaustion, channel loss and TTL
  * expiry, measured identically for all four protocols and summing with PDR to
- * ~100% of offered packets.
+ * ~100% of offered packets,
+ * and route quality
+ * (#217): the hop count actually traversed by delivered packets, the number of
+ * distinct next hops that actually *carried* data per destination (the direct
+ * measurement of multipath), and Jain's fairness index across the flows.
  * Fair comparison: the RNG run is reset before each protocol so every protocol
  * sees the identical mobility/traffic realisation, and NRL is counted uniformly
  * for every protocol from the IP layer.
@@ -53,6 +57,9 @@
 // #215 drop causes: Ipv4FlowProbe::DropReason indexes FlowStats::packetsDropped;
 // LlcSnapHeader is what a wifi MPDU carries above the MAC header.
 #include "ns3/ipv4-flow-probe.h"
+// #217 path diversity: the WifiMac "AckedMpdu" trace carries the MPDU whose
+// 802.11 header names the next hop; above that MAC header a wifi frame carries
+// an LLC/SNAP header before the IP header.
 #include "ns3/llc-snap-header.h"
 
 // #209: BasicEnergySource lives in the energy module; WifiRadioEnergyModel and
@@ -71,6 +78,7 @@
 #include <cstdint>
 #include <iomanip>
 #include <map>
+#include <utility>
 #include <vector>
 
 using namespace ns3;
@@ -294,6 +302,139 @@ constexpr double kDefaultVoltageV = 3.0;
 // longer runs; lower it deliberately to provoke node deaths.
 constexpr double kDefaultEnergyJ = 5000.0;
 
+// --- route quality: path length, path diversity, fairness (#217) ------------
+// AntHocNet's defining property is that it lays and maintains *multiple* paths,
+// and until now the harness measured nothing about paths at all: `a2 = 2.0`
+// (antAcceptanceFactorNewHop) exists in the 2007 thesis specifically to buy
+// disjoint paths and shipped in v1.1.0 evaluated on PDR/delay/NRL alone.
+// Everything below is measured protocol-agnostically, from ns-3's own traces,
+// for all four arms — the single-path baselines are the instrumentation's
+// self-check, not a blank column.
+
+// PATH LENGTH — hop count actually traversed by *delivered* data packets.
+// Taken from the IP TTL seen at the destination's Ipv4L3Protocol "LocalDeliver"
+// hook: every real forwarding hop runs through Ipv4L3Protocol::IpForward, which
+// decrements the TTL exactly once, so
+//     hops = (initial TTL - TTL at delivery) + 1
+// counts transmissions, i.e. a neighbour delivery is 1 hop. Equivalent to
+// FlowMonitor's FlowStats::timesForwarded + 1 (which accumulates only for
+// delivered packets), but per packet rather than per flow — which is what makes
+// the *maximum* available, and FlowMonitor exposes only the sum.
+//
+// The initial TTL is ns-3's Ipv4L3Protocol "DefaultTtl" attribute default, 64,
+// unchanged across the 3.36-3.48 CI matrix; nothing here sets a SocketIpTtlTag,
+// so every data packet starts there. CAVEAT (documented in
+// docs/benchmarks/metrics.md): a reactive protocol that has no route yet bounces
+// the packet through the loopback device to reach RouteInput (AODV and this
+// adapter both do), and the resolved packet then leaves via IpForward — one
+// extra TTL decrement that no radio ever carried. Those packets therefore read
+// one hop high, so for anthocnet/aodv the mean is a slight over-estimate,
+// bounded by (route discoveries)/(delivered packets). FlowMonitor's
+// timesForwarded counts that same bounce, so this is not a defect of the TTL
+// route specifically.
+constexpr uint8_t kIpDefaultTtl = 64;
+uint64_t g_hopSum = 0;    // sum of hop counts over delivered data packets
+uint64_t g_hopCount = 0;  // delivered data packets seen at LocalDeliver
+uint32_t g_hopMax = 0;
+
+// PATH DIVERSITY (used, not available). The issue is explicit about the
+// definition and it matters: pheromone entries above `minPheromone` are
+// *available* paths, and a table full of pheromone that data never uses would
+// read as diversity that does not exist. What is counted here is the number of
+// distinct next hops that actually **carried a data packet**, per (node,
+// destination) pair, within a time window.
+//
+// The window is load-bearing. Over a whole run a single-path protocol also
+// touches several next hops for one destination — sequentially, as routes break
+// and are rediscovered — so a whole-run count would credit AODV with
+// "multipath" it does not have. Diversity is *concurrency*, so it is measured
+// per (node, destination, window) cell and averaged over the cells that carried
+// data. At the default 10 s window the baselines read ~1 (the residual excess
+// above 1 is sequential route replacement inside one window, which is route
+// churn, not spreading), while AntHocNet's stochastic spreading shows up
+// immediately.
+//
+// Source: the WifiMac "AckedMpdu" trace. It fires at the transmitter for each
+// unicast MPDU the next hop acknowledged, and its 802.11 header's Addr1 *is*
+// the next hop — the only address-bearing transmit hook ns-3 offers uniformly
+// to all four protocols (the Ipv4L3Protocol traces do not carry the gateway).
+// "Acked" also makes "carried" literal: a frame the next hop never received is
+// not a path that was used. The AntHocNet adapter already relies on this same
+// trace across the whole CI matrix (#68), so its availability is established.
+constexpr double kDefaultPathWindowS = 10.0;
+double   g_pathWindowS = kDefaultPathWindowS;
+uint64_t g_divWindow = 0;  // index of the window g_divCur is accumulating
+// (node index, destination IPv4) -> next-hop MAC (packed) -> data packets.
+// Holds the current window only and is flushed into the accumulators when time
+// crosses into the next one, so memory stays bounded however long the run is.
+std::map<std::pair<uint32_t, uint32_t>, std::map<uint64_t, uint32_t>> g_divCur;
+uint64_t g_divCells = 0;   // (node, dest, window) cells that carried data
+double   g_divSum = 0.0;   // sum over cells of distinct used next hops
+double   g_divEntSum = 0.0;  // sum over cells of the split's Shannon entropy
+uint32_t g_divMax = 0;     // most distinct next hops seen in any one cell
+
+void FlushDiversityWindow() {
+    for (const auto& cell : g_divCur) {
+        uint64_t total = 0;
+        for (const auto& kv : cell.second) total += kv.second;
+        if (total == 0) continue;
+        double entropy = 0.0;
+        for (const auto& kv : cell.second) {
+            const double p = static_cast<double>(kv.second) / total;
+            if (p > 0.0) entropy -= p * std::log(p) / std::log(2.0);
+        }
+        const uint32_t k = static_cast<uint32_t>(cell.second.size());
+        ++g_divCells;
+        g_divSum += k;
+        g_divEntSum += entropy;
+        if (k > g_divMax) g_divMax = k;
+    }
+    g_divCur.clear();
+}
+
+void CountAckedDataHop(uint32_t node, Ptr<const AHN_WIFI_MPDU> mpdu) {
+    if (!mpdu) return;
+    Ptr<Packet> pkt = mpdu->GetPacket()->Copy();
+    LlcSnapHeader llc;
+    if (pkt->GetSize() < llc.GetSerializedSize()) return;
+    pkt->RemoveHeader(llc);
+    if (llc.GetType() != 0x0800) return;  // not IPv4
+    Ipv4Header ip;
+    if (pkt->RemoveHeader(ip) == 0) return;
+    if (ip.GetProtocol() != 17) return;  // not UDP; routing control here is UDP
+    UdpHeader udp;
+    if (pkt->PeekHeader(udp) == 0) return;
+    // Data only: routing control is exactly what must NOT count as a used path.
+    if (udp.GetDestinationPort() != kDataPort) return;
+    const uint64_t window =
+        static_cast<uint64_t>(Simulator::Now().GetSeconds() / g_pathWindowS);
+    if (window != g_divWindow) {
+        FlushDiversityWindow();
+        g_divWindow = window;
+    }
+    uint8_t mac[6] = {0, 0, 0, 0, 0, 0};
+    mpdu->GetHeader().GetAddr1().CopyTo(mac);
+    uint64_t nextHop = 0;
+    for (int i = 0; i < 6; ++i) nextHop = (nextHop << 8) | mac[i];
+    g_divCur[std::make_pair(node, ip.GetDestination().Get())][nextHop] += 1;
+}
+
+// Ipv4L3Protocol "LocalDeliver": one call per packet handed to the local
+// transport, i.e. exactly the delivered packets PDR counts. The header arrives
+// with the TTL the packet carried on the wire.
+void CountDeliveredHops(const Ipv4Header& ip, Ptr<const Packet> p, uint32_t) {
+    if (ip.GetProtocol() != 17) return;
+    UdpHeader udp;
+    if (p->PeekHeader(udp) == 0) return;
+    if (udp.GetDestinationPort() != kDataPort) return;
+    const uint8_t ttl = ip.GetTtl();
+    const uint32_t hops =
+        ttl < kIpDefaultTtl ? static_cast<uint32_t>(kIpDefaultTtl - ttl) + 1u : 1u;
+    g_hopSum += hops;
+    ++g_hopCount;
+    if (hops > g_hopMax) g_hopMax = hops;
+}
+
 void SampleQueues(NodeContainer nodes, double period, double until) {
     for (uint32_t i = 0; i < nodes.GetN(); ++i) {
         const uint32_t q = NodeMacBacklog(nodes.Get(i));
@@ -325,6 +466,9 @@ struct Params {
     double   energyJ;         // initial energy per node (J)
     double   voltageV;        // supply voltage (V)
     double   txCurrentA, rxCurrentA, idleCurrentA;
+    // #217: window over which "distinct next hops used for a destination" is
+    // counted (s). See the path-diversity block above main().
+    double   pathWindowS;
 };
 
 struct Result {
@@ -368,6 +512,15 @@ struct Result {
     double dropReconvPct = -1.0; // AntHocNet: pending-queue loss, route lost
     double dropRepairPct = -1.0; // AntHocNet: DiscardPending after a failed repair
     double dropOtherPct  = 0.0;  // L3 drops in none of the buckets above (diag)
+    // #217 route quality. hops* are 0 when nothing was delivered and div*/
+    // entropy are 0 when no data hop was ever acked, matching the `nrl` and
+    // `energy_per_pkt_j` convention for an empty denominator.
+    double hopsMean = 0.0;       // mean hop count over delivered data packets
+    double hopsMax = 0.0;        // max hop count over delivered data packets
+    double divUsed = 0.0;        // mean distinct *used* next hops per cell
+    double divMax = 0.0;         // max distinct used next hops in any one cell
+    double divEntropyBits = 0.0; // mean Shannon entropy (bits) of the split
+    double jain = 0.0;           // Jain's index over per-flow delivered packets
 };
 
 Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
@@ -386,6 +539,15 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_firstDeathS = -1.0;
     g_rxSeq.clear();
     g_dataHopTx = g_dataHopRx = g_macDataDrops = 0;  // #215
+    // #217
+    g_hopSum = g_hopCount = 0;
+    g_hopMax = 0;
+    g_pathWindowS = P.pathWindowS;
+    g_divWindow = 0;
+    g_divCur.clear();
+    g_divCells = 0;
+    g_divSum = g_divEntSum = 0.0;
+    g_divMax = 0;
 
     NodeContainer nodes;
     nodes.Create(P.nNodes);
@@ -525,6 +687,9 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         if (l3) {
             l3->TraceConnectWithoutContext("Tx", MakeCallback(&CountDataHopTx));
             l3->TraceConnectWithoutContext("Rx", MakeCallback(&CountDataHopRx));
+            // #217 path length: TTL of every locally delivered data packet.
+            l3->TraceConnectWithoutContext("LocalDeliver",
+                                           MakeCallback(&CountDeliveredHops));
         }
     }
     for (uint32_t i = 0; i < devices.GetN(); ++i) {
@@ -533,9 +698,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         // TraceConnect returns false if the source is absent on this ns-3
         // release; tolerated, exactly as the adapter's detector D does — the
         // MAC column then reads 0 and its share lands in channel loss.
+        // #217 path diversity: the next hop of every data frame the MAC got an
+        // ack for, bound to the transmitting node. `devices` is index-aligned
+        // with `nodes` (one wifi device per node), so `i` names the transmitter.
+        // The same tolerance applies — the diversity columns then read 0, which
+        // scenario_check.py FAILs whenever PDR is non-zero rather than letting a
+        // silently-missing trace pass as "no multipath".
         if (wmac) {
             wmac->TraceConnectWithoutContext("DroppedMpdu",
                                              MakeCallback(&CountMacDataDrop));
+            wmac->TraceConnectWithoutContext(
+                "AckedMpdu", MakeBoundCallback(&CountAckedDataHop, i));
         }
     }
 
@@ -649,6 +822,9 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     Simulator::Run();
 
     monitor->CheckForLostPackets();
+    // #217: fold the window still open at Simulator::Stop() into the diversity
+    // accumulators, or the last (up to) --pathWindowS seconds are dropped.
+    FlushDiversityWindow();
     Result r;
     r.proto = proto;
     double totalDelay = 0.0;
@@ -663,6 +839,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     // Ipv4FlowProbe::DropReason and grows the vector lazily, so every read is
     // bounds-checked.
     uint64_t dropRoute = 0, dropTtl = 0, dropQueue = 0, dropL3Total = 0;
+    // #217: per-flow delivered-packet counts, for Jain's fairness index.
+    std::vector<double> flowRx;
     // Restrict the delivery/delay/throughput metrics to the CBR *data* flows
     // (dest port kDataPort). FlowMonitor also classifies the routing-control
     // flows, which must not count toward PDR.
@@ -678,6 +856,10 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         totalRxBytes += kv.second.rxBytes;
         totalJitter += kv.second.jitterSum.GetSeconds();
         if (kv.second.rxPackets > 0) jitterSamples += kv.second.rxPackets - 1;
+        // #217: one entry per data flow that offered at least one packet.
+        if (kv.second.txPackets > 0) {
+            flowRx.push_back(static_cast<double>(kv.second.rxPackets));
+        }
         // Copy: Histogram's accessors are non-const in older ns-3 (<=3.36).
         Histogram h = kv.second.delayHistogram;
         for (uint32_t b = 0; b < h.GetNBins(); ++b) {
@@ -940,6 +1122,37 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         r.dropOtherPct = 100.0 * other / tx;
     }
 
+    // #217 route quality.
+    r.hopsMean = g_hopCount
+        ? static_cast<double>(g_hopSum) / static_cast<double>(g_hopCount) : 0.0;
+    r.hopsMax = static_cast<double>(g_hopMax);
+    r.divUsed = g_divCells ? g_divSum / static_cast<double>(g_divCells) : 0.0;
+    r.divEntropyBits =
+        g_divCells ? g_divEntSum / static_cast<double>(g_divCells) : 0.0;
+    r.divMax = static_cast<double>(g_divMax);
+    // Jain's fairness index over per-flow delivered-packet counts:
+    //     J = (sum x_i)^2 / (n * sum x_i^2),  J in (0, 1], J = 1/n at maximum
+    // unfairness (one flow gets everything), J = 1 when every flow gets the
+    // same. n is the number of source applications actually installed, so a
+    // flow so starved that not one of its packets ever reached the IP layer
+    // (its socket send failed for want of a route, which FlowMonitor never
+    // sees) still counts as a zero rather than vanishing from the index — that
+    // starved flow is the whole point of the metric. Equivalently computed over
+    // per-flow throughput: every flow here sends the same 64-byte payload, so
+    // the throughput vector is a scalar multiple of the packet-count vector and
+    // Jain is scale-invariant. One column, both readings.
+    {
+        std::vector<double> x = flowRx;
+        while (x.size() < apps.GetN()) x.push_back(0.0);
+        double sum = 0.0, sumSq = 0.0;
+        for (double v : x) {
+            sum += v;
+            sumSq += v * v;
+        }
+        r.jain = (!x.empty() && sumSq > 0.0)
+            ? (sum * sum) / (static_cast<double>(x.size()) * sumSq) : 0.0;
+    }
+
     // Diagnostics line (prefixed "# " so CSV consumers ignore it). Shows whether
     // routes form (reactive ants sent vs received elsewhere; back-ant arrivals)
     // and when the first packet is delivered.
@@ -1153,6 +1366,13 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("rxCurrentA", "Radio receive current (A)", rxCurrentA);
     cmd.AddValue("idleCurrentA", "Radio idle current (A); also applied to the "
                                  "CCA-busy and switching states", idleCurrentA);
+    // #217: the window over which concurrently-used next hops are counted.
+    // Carried into the CSV (path_div_window_s) because it defines what the
+    // diversity number means — see the path-diversity block above main().
+    double pathWindowS = kDefaultPathWindowS;
+    cmd.AddValue("pathWindowS", "Window (s) over which distinct next hops used "
+                                "for a destination are counted as concurrent "
+                                "paths (#217); default 10", pathWindowS);
     cmd.Parse(argc, argv);
 
     // 'paper' = the Broch/CMU MobiCom'98 field (the literature *calibration*
@@ -1215,6 +1435,7 @@ int main(int argc, char* argv[]) {
     P.txCurrentA = txCurrentA;
     P.rxCurrentA = rxCurrentA;
     P.idleCurrentA = idleCurrentA;
+    P.pathWindowS = pathWindowS > 0.0 ? pathWindowS : kDefaultPathWindowS;
 
     // 1 ms delay bins for the 99th-percentile computation.
     Config::SetDefault("ns3::FlowMonitor::DelayBinWidth", DoubleValue(0.001));
@@ -1254,6 +1475,11 @@ int main(int argc, char* argv[]) {
         double dropRoute = 0, dropQueue = 0, dropMac = 0, dropChan = 0, dropTtl = 0;
         double dropSetup = 0, dropReconv = 0, dropRepair = 0, dropOther = 0;
         bool dropNa = false;
+        // #217: route-quality means across runs. hopsMax/divMax are averaged
+        // like every other column rather than maxed, so they stay comparable
+        // with the per-run rows and with the mean columns beside them.
+        double hopsMean = 0, hopsMax = 0;
+        double divUsed = 0, divMax = 0, divEntropy = 0, jain = 0;
     };
     std::vector<Agg> agg(list.size());
     for (std::size_t i = 0; i < list.size(); ++i) {
@@ -1322,6 +1548,12 @@ int main(int argc, char* argv[]) {
                 agg[i].dropReconv += r.dropReconvPct;
                 agg[i].dropRepair += r.dropRepairPct;
             }
+            agg[i].hopsMean += r.hopsMean;
+            agg[i].hopsMax += r.hopsMax;
+            agg[i].divUsed += r.divUsed;
+            agg[i].divMax += r.divMax;
+            agg[i].divEntropy += r.divEntropyBits;
+            agg[i].jain += r.jain;
         }
         agg[i].pdr /= runs;
         agg[i].delay /= runs;
@@ -1357,6 +1589,12 @@ int main(int argc, char* argv[]) {
             agg[i].dropReconv /= runs;
             agg[i].dropRepair /= runs;
         }
+        agg[i].hopsMean /= runs;
+        agg[i].hopsMax /= runs;
+        agg[i].divUsed /= runs;
+        agg[i].divMax /= runs;
+        agg[i].divEntropy /= runs;
+        agg[i].jain /= runs;
         if (runs > 1) {
             auto sd = [runs](double sum, double sumSq) {
                 const double mean = sum / runs;
@@ -1386,7 +1624,10 @@ int main(int argc, char* argv[]) {
         // causes (which sum with pdr_pct to ~100), then the three AntHocNet-only
         // ones, which are a sub-breakdown of drop_route_pct and are **blank**
         // for the other protocols (blank = the cause does not exist there;
-        // 0 would mean it exists and never fired).
+        // 0 would mean it exists and never fired), then #217 route
+        // quality (hop count of delivered packets, *used* next-hop diversity
+        // and the entropy of that split, the window those are counted over,
+        // and Jain's fairness index across flows).
         std::cout << "protocol,runs,nNodes,area,speed,flows,pdr_pct,delay_ms,"
                      "throughput_kbps,delay99_ms,nrl,jitter_ms,delay_off50_ms,"
                      "delay_off90_ms,pdr_sd,delay_sd,delay99_sd,nrl_sd,"
@@ -1397,7 +1638,10 @@ int main(int argc, char* argv[]) {
                      "reorder_buf_max,drop_route_pct,drop_queue_pct,"
                      "drop_mac_pct,"
                      "drop_chan_pct,drop_ttl_pct,drop_setup_pct,"
-                     "drop_reconv_pct,drop_repair_pct\n";
+                     "drop_reconv_pct,drop_repair_pct,"
+                     "path_hops_mean,path_hops_max,"
+                     "path_div_used,path_div_max,path_entropy_bits,"
+                     "path_div_window_s,jain_pkts\n";
         std::cout << std::fixed;
         // Blank, not zero, when a cause does not apply to this protocol (#215).
         auto optPct = [](double v) {
@@ -1441,7 +1685,14 @@ int main(int argc, char* argv[]) {
                       << std::setprecision(3) << agg[i].dropTtl << ','
                       << optPct(agg[i].dropSetup) << ','
                       << optPct(agg[i].dropReconv) << ','
-                      << optPct(agg[i].dropRepair) << '\n';
+                      << optPct(agg[i].dropRepair) << ','
+                      << std::setprecision(2) << agg[i].hopsMean << ','
+                      << std::setprecision(1) << agg[i].hopsMax << ','
+                      << std::setprecision(3) << agg[i].divUsed << ','
+                      << std::setprecision(1) << agg[i].divMax << ','
+                      << std::setprecision(3) << agg[i].divEntropy << ','
+                      << std::setprecision(1) << P.pathWindowS << ','
+                      << std::setprecision(4) << agg[i].jain << '\n';
         }
         return 0;
     }
@@ -1460,14 +1711,17 @@ int main(int argc, char* argv[]) {
     // appending here cannot disturb it. The remaining #209 numbers (residual
     // spread, first death) go on the '# energy' lines below, the way #28's
     // dispersion does, rather than widening the fixed-width table further.
+    // #217 appends two more headline columns (mean hop count, Jain's fairness);
+    // used-next-hop diversity and its entropy go on the '# paths' lines.
     std::cout << std::left << std::setw(12) << "protocol"
               << std::right << std::setw(8) << "PDR%" << std::setw(11) << "delay(ms)"
               << std::setw(13) << "delay99(ms)" << std::setw(13) << "thrput(kbps)"
               << std::setw(8) << "NRL"
               << std::setw(12) << "jitter(ms)" << std::setw(12) << "dOff50(ms)"
               << std::setw(12) << "dOff90(ms)" << std::setw(12) << "nrlBytes"
-              << std::setw(12) << "energy(J)" << std::setw(12) << "J/pkt" << "\n";
-    std::cout << std::string(137, '-') << "\n";
+              << std::setw(12) << "energy(J)" << std::setw(12) << "J/pkt"
+              << std::setw(12) << "hops" << std::setw(12) << "jain" << "\n";
+    std::cout << std::string(161, '-') << "\n";
     for (std::size_t i = 0; i < list.size(); ++i) {
         std::cout << std::left << std::setw(12) << list[i] << std::right << std::fixed
                   << std::setw(8) << std::setprecision(1) << agg[i].pdr
@@ -1483,6 +1737,23 @@ int main(int argc, char* argv[]) {
         std::cout << std::setw(12) << std::setprecision(3) << agg[i].nrlBytes
                   << std::setw(12) << std::setprecision(1) << agg[i].energy
                   << std::setw(12) << std::setprecision(4) << agg[i].energyPerPkt
+                  << std::setw(12) << std::setprecision(2) << agg[i].hopsMean
+                  << std::setw(12) << std::setprecision(4) << agg[i].jain
+                  << "\n";
+    }
+    // #217 path detail: used-path diversity (distinct next hops that actually
+    // carried data for a destination, within a --pathWindowS window), the
+    // entropy of that split, and the longest delivered path. divUsed ~1 with
+    // entropy ~0 is a single-path protocol — the expected reading for aodv,
+    // olsr and dsdv, and the instrumentation's self-check.
+    for (std::size_t i = 0; i < list.size(); ++i) {
+        std::cout << std::fixed << "# paths " << list[i]
+                  << " divUsed=" << std::setprecision(3) << agg[i].divUsed
+                  << " divMax=" << std::setprecision(1) << agg[i].divMax
+                  << " entropyBits=" << std::setprecision(3) << agg[i].divEntropy
+                  << " windowS=" << std::setprecision(1) << P.pathWindowS
+                  << " hopsMean=" << std::setprecision(2) << agg[i].hopsMean
+                  << " hopsMax=" << std::setprecision(1) << agg[i].hopsMax
                   << "\n";
     }
     // #209 energy detail: residual-energy spread across nodes (the fairness

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -27,7 +27,9 @@ Output CSV columns:
   energy_init_j,first_death_s,reorder_ratio,reorder_ratio_max,
   reorder_extent_mean,reorder_extent_max,reorder_buf_max,
   drop_route_pct,drop_queue_pct,drop_mac_pct,
-  drop_chan_pct,drop_ttl_pct,drop_setup_pct,drop_reconv_pct,drop_repair_pct
+  drop_chan_pct,drop_ttl_pct,drop_setup_pct,drop_reconv_pct,drop_repair_pct,
+  path_hops_mean,path_hops_max,path_div_used,
+  path_div_max,path_entropy_bits,path_div_window_s,jain_pkts
                                 (see METRICS below for the full, append-only
                                  list)
 
@@ -109,6 +111,14 @@ SWEEPS = {
 # The three AntHocNet-only causes (setup / reconv / repair) are a sub-breakdown
 # of drop_route_pct and are deliberately **blank**, not 0, for protocols that
 # have no such cause.
+# The path_*/jain_* columns are #217 route quality (ns-3 only, all four
+# protocols): mean and max hop count actually traversed by delivered packets;
+# path_div_used = the mean number of distinct next hops that actually *carried*
+# a data packet for a destination within one path_div_window_s window (used
+# paths, not pheromone-available ones), path_div_max its maximum and
+# path_entropy_bits the Shannon entropy of that split; jain_pkts = Jain's
+# fairness index over per-flow delivered-packet counts. Baselines are expected
+# to read path_div_used ~1 — that is the instrumentation's self-check.
 # APPEND ONLY — downstream consumers (make-charts.py, sweep_summary.py,
 # bench_parse.py, scenario_check.py) look these columns up by header name, so
 # appending is safe and reordering is not.
@@ -122,7 +132,9 @@ METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
            "reorder_extent_max", "reorder_buf_max",
            "drop_route_pct", "drop_queue_pct", "drop_mac_pct", "drop_chan_pct",
            "drop_ttl_pct", "drop_setup_pct", "drop_reconv_pct",
-           "drop_repair_pct"]
+           "drop_repair_pct",
+           "path_hops_mean", "path_hops_max", "path_div_used", "path_div_max",
+           "path_entropy_bits", "path_div_window_s", "jain_pkts"]
 PARAMS = ["runs", "nNodes", "area", "speed", "flows"]
 OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + ["runs", "nNodes", "areaX", "speed", "pause", "flows", "propagation"]


### PR DESCRIPTION
Implements items 1 and 2 of [#217](https://github.com/danieljoppi/AntHocNet/issues/217). AntHocNet's defining property is that it lays and maintains **multiple paths**, and the harness measured nothing about paths — including when v1.1.0 shipped `antAcceptanceFactorNewHop = 2.0`, a factor whose stated purpose in the thesis is buying **disjoint** paths, on PDR/delay/NRL evidence alone.

Items 3–4 (discovery latency, convergence time) deliberately deferred — see below.

## Columns (appended)

`path_hops_mean`, `path_hops_max`, `path_div_used`, `path_div_max`, `path_entropy_bits`, `path_div_window_s`, `jain_pkts`

## Diversity is **used**, not available — and windowed

A next hop counts only when a data frame it carried was **acknowledged**. Per `(node, destination)`, within one `path_div_window_s` window (default 10 s, `--pathWindowS`), averaged over cells that carried data. `path_entropy_bits` is the Shannon entropy of the per-next-hop packet split (0 = single path).

**The window is the load-bearing judgement call.** Over a whole run a single-path protocol also touches several next hops for one destination *sequentially* — route breaks then rediscovery — which would credit AODV with multipath and destroy the baseline check entirely. Diversity is **concurrency**, so it has to be windowed. The window is carried in the CSV because it defines what the number means: runs with different windows must not be differenced.

Source is the `WifiMac` `AckedMpdu` trace, bound per transmitting node — the 802.11 header's `Addr1` *is* the next hop. It's the only address-bearing transmit hook ns-3 offers uniformly to all four protocols (the `Ipv4L3Protocol` traces carry the interface, never the gateway). The adapter already depends on this trace across the CI matrix (#68), and the MPDU is unwrapped exactly as ADR-0008 detector D does, consistent with #222 rather than parallel to it.

**Path length** comes from the IP TTL at `LocalDeliver`: `hops = (64 − ttl) + 1`. Chosen over FlowMonitor's `timesForwarded` because the latter is a per-flow *sum* and cannot yield a maximum, which the issue asks for; otherwise numerically identical.

**Jain** is over per-flow delivered-packet counts with `n` = source apps **installed**, so a flow whose sends all failed for want of a route — invisible to FlowMonitor — counts as a zero rather than vanishing. One index only: all flows send 64 bytes, so the throughput-based index is the identical number, documented rather than duplicated.

## Baselines: ≈1, not exactly 1 — and that's stated honestly

All four protocols are measured; `aodv`/`olsr`/`dsdv` should read `path_div_used` ≈ 1 with entropy ≈ 0, which is the instrumentation's self-check.

Residual excess above 1 is sequential route replacement *inside* one window — route churn, growing with mobility. The plausibility rule is therefore `≥ 1`, **not `== 1`**: claiming exact degeneracy would be asserting something the measurement cannot deliver.

## No `core/` change, deliberately

A core used-next-hop counter behind `IRouterObserver` was considered and rejected: it could only cover AntHocNet, but #217 requires the baselines measured — that *is* the self-check — which forces a protocol-agnostic ns-3-side measurement. A core counter would then be a **second, divergent book for the same quantity**. Golden rules 1/2 hold trivially, rule 7 isn't engaged, `make test` stays 23/23 unchanged. Same shape as #209.

## Verification

`make test` 23/23 unchanged · `check_invariants.sh` PASS · `python3 -m ruff check ns3/tools` clean on **ruff 0.16.0** (PATH `ruff` is 0.15.8; confirmed `scenario_check.py`'s 2 findings are pre-existing on `main` by stashing) · `ast.parse` OK.

`scenario_check.py results` exercised: **all 11 new rules fire** on synthetic bad CSVs; a good CSV passes including an all-zero DSDV arm (zeros tolerated only when PDR is 0); a 13-column results table parses and FAILs when corrupted; an 11-field pre-#217 `##BENCH##` cell still passes; the real pre-#217 `30031902395-area-disk.csv` returns **OK, 20 rows, 0 fail**.

## Not verified

`anthocnet-compare` doesn't compile here — no ns-3 tree; the matrix validates it. API kept conservative (`LocalDeliver`, `AckedMpdu`, `GetAddr1()`, `LlcSnapHeader`, existing `AHN_WIFI_MPDU`) — no new version macros.

**No measured numbers.** Whether AntHocNet's diversity actually exceeds 1, and by how much, is unverified until a campaign. If `AckedMpdu` were silently absent on some release, diversity reads 0 — deliberately a `scenario_check` **FAIL** whenever PDR is non-zero, so it cannot pass as "no multipath".

One known bias, reasoned from ns-3 source rather than measured: reactive protocols bounce routeless packets through loopback, costing a TTL decrement no radio carried, so `path_hops` is biased high by (route discoveries)/(delivered packets). Documented in `metrics.md`; FlowMonitor's `timesForwarded` carries the identical bias.

## Merge coordination

Conflicts with #221/#222 are append-style except **one real point**: #222 and this branch both add table columns, so `scenario_check.py`'s results-table positional indices (`nums[11]`, `nums[12]` here) need re-numbering by whoever merges second.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ)_