### PR TITLE
feat(ns3): route next hops per interface and add the isl-grid scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,21 @@ jobs:
           echo "AntHocNet PDR% = ${pdr:-<none>}"
           awk -v p="${pdr:-0}" 'BEGIN { exit (p+0 > 0) ? 0 : 1 }' \
             || { echo "FAIL: AntHocNet delivered no packets (PDR=${pdr:-<none>})"; exit 1; }
+      - name: ISL-grid delivery smoke (#214 — multi-interface satellite shape)
+        # The same loose "must deliver something" gate as above, on the topology
+        # the satellite track needs (#192): a +Grid torus of point-to-point
+        # links where every node holds 4 ISLs on 4 separate subnets. This is the
+        # shape that the #203 multi-interface fix exists for, so a regression
+        # there shows up here as zero delivery rather than only in a manual run.
+        # Kept small (4x4, 30 s) so it costs a few seconds per matrix leg.
+        run: |
+          cd /opt/ns-3
+          out=$(./ns3 run "isl-grid --csv --protocols=anthocnet --rows=4 --cols=4 --time=30 --flows=2" 2>/dev/null)
+          echo "$out"
+          pdr=$(printf '%s\n' "$out" | awk -F, '$1=="anthocnet"{print $9}')
+          echo "AntHocNet ISL-grid PDR% = ${pdr:-<none>}"
+          awk -v p="${pdr:-0}" 'BEGIN { exit (p+0 > 0) ? 0 : 1 }' \
+            || { echo "FAIL: AntHocNet delivered no packets on the ISL grid (PDR=${pdr:-<none>})"; exit 1; }
       - name: Validation-anchor gate (single-hop PDR floor, #59)
         # Blocking anchor from docs/benchmarks/methodology.md "Validation
         # anchors": on a static, in-range 2-node link the *stock* stack

--- a/ns3/README.md
+++ b/ns3/README.md
@@ -100,6 +100,34 @@ These come from the protocol's item-15 trace sources (`Tx`, `Rx`,
 `Config::Connect` to. The heavy paper-regime run is wired up as the
 manually-dispatched **Paper benchmark** GitHub Actions workflow.
 
+## Satellite / ISL topology (`isl-grid`)
+
+An inter-satellite-link mesh is conventionally abstracted as a **+Grid torus**:
+two intra-plane links (fore/aft) and two cross-plane links (port/starboard) per
+satellite. Frozen at one instant that is a static torus of point-to-point links,
+which stock ns-3 builds today — no orbital mechanics and no third-party
+satellite module:
+
+```bash
+./ns3 configure --enable-examples \
+  --enable-modules='anthocnet;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
+./ns3 build
+
+./ns3 run "isl-grid --rows=10 --cols=10 --protocols=anthocnet,aodv"
+./ns3 run "isl-grid --rows=6 --cols=6 --islDelayMs=12 --csv"   # longer ISLs
+```
+
+Every node holds 4 ISLs on 4 **separate subnets**, which is the shape the
+multi-interface routing fix ([#203](https://github.com/danieljoppi/AntHocNet/issues/203))
+exists for — a 4×4 delivery smoke runs in CI on every matrix leg. Options:
+`--rows --cols --torus --islDelayMs --islRate --time --flows --cbrBps --runs
+--protocols --csv --diag`.
+
+This is a **scenario, not a satellite module**: no orbital mobility, no link
+budget, no handover. Those belong to the satellite track
+([#192](https://github.com/danieljoppi/AntHocNet/issues/192)) and its substrate
+decision ([#193](https://github.com/danieljoppi/AntHocNet/issues/193)).
+
 ## Uninstall
 
 ```bash
@@ -134,6 +162,7 @@ ns3/
   helper/anthocnet-helper.{h,cc}       Ipv4RoutingHelper
   examples/anthocnet-example.cc        minimal wifi adhoc demo
   examples/anthocnet-compare.cc        vs AODV/OLSR/DSDV (FlowMonitor metrics)
+  examples/isl-grid.cc                 +Grid torus of point-to-point ISLs (#214)
   test/anthocnet-test-suite.cc         header round-trip + multi-hop delivery
   CMakeLists.txt                       ns-3.36+ build
   wscript                              ns-3 < 3.36 build

--- a/ns3/examples/CMakeLists.txt
+++ b/ns3/examples/CMakeLists.txt
@@ -38,6 +38,25 @@ build_lib_example(
     ${libdsdv}
 )
 
+# ISL-grid scenario (#214): a static +Grid torus of point-to-point links — the
+# LEO inter-satellite-link abstraction — with no mobility and no wifi. Needs
+# point-to-point in addition to the comparison example's dependencies.
+build_lib_example(
+  NAME isl-grid
+  SOURCE_FILES isl-grid.cc
+  LIBRARIES_TO_LINK
+    ${libanthocnet}
+    ${libcore}
+    ${libnetwork}
+    ${libinternet}
+    ${libapplications}
+    ${libpoint-to-point}
+    ${libflow-monitor}
+    ${libaodv}
+    ${libolsr}
+    ${libdsdv}
+)
+
 # #24 control: STOCK baselines only (AODV/OLSR/DSDV) on the identical scenario,
 # deliberately NOT linking ${libanthocnet}/${libcore} so no AntHocNet code is in
 # the binary — isolates "is the scenario hard" from "does our module break the

--- a/ns3/examples/isl-grid.cc
+++ b/ns3/examples/isl-grid.cc
@@ -1,0 +1,434 @@
+/*
+ * ISL-grid scenario (issue #214, satellite track #192).
+ *
+ * A LEO inter-satellite-link mesh is conventionally abstracted as a **+Grid
+ * torus**: each satellite holds two intra-plane links (fore/aft, near-constant
+ * length) and two cross-plane links (port/starboard, length varying with
+ * latitude). Frozen at one instant that is simply a static torus of
+ * point-to-point links, which stock ns-3 can build today — no orbital
+ * mechanics, no third-party satellite module, and therefore no dependency on
+ * the substrate decision in #193.
+ *
+ * That is deliberately enough to answer the questions the satellite track is
+ * actually blocked on:
+ *   - does AntHocNet route a 4-degree, high-diameter, non-random topology?
+ *   - does the #203 multi-interface fix hold on a node with exactly the 4 ISLs
+ *     it was written for (each on its own subnet)?
+ *   - how does control-plane cost scale with n (#207)?
+ *
+ * This is a *scenario*, not a module. It adds no net devices and no mobility;
+ * if it ever grows either, it belongs in #195 instead.
+ *
+ * Metrics mirror anthocnet-compare's definitions (PDR, mean and 99th-pct delay,
+ * throughput, NRL as routing-control packets over delivered data packets, plus
+ * #132 byte-NRL and #57 jitter) so numbers are comparable across the two
+ * harnesses. The offered-load percentiles (dOff50/dOff90) are NOT computed
+ * here: they exist to expose survivorship bias under mobility-driven route
+ * loss, which this static topology does not have. They are omitted rather than
+ * emitted as a placeholder so nothing downstream mistakes a filler for a
+ * measurement.
+ *
+ * Requires the aodv, olsr, dsdv, point-to-point and flow-monitor modules:
+ *   ./ns3 run "isl-grid --rows=10 --cols=10 --protocols=anthocnet,aodv"
+ */
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+#include "ns3/internet-module.h"
+#include "ns3/applications-module.h"
+#include "ns3/point-to-point-module.h"
+#include "ns3/flow-monitor-module.h"
+#include "ns3/ipv4-flow-classifier.h"
+#include "ns3/ipv4-l3-protocol.h"
+#include "ns3/udp-header.h"
+
+#include "ns3/aodv-module.h"
+#include "ns3/olsr-module.h"
+#include "ns3/dsdv-module.h"
+#include "ns3/anthocnet-helper.h"
+
+#include <cstdint>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <vector>
+
+using namespace ns3;
+
+namespace {
+
+// Same counting point and convention as anthocnet-compare: data traffic uses
+// this UDP port, every other UDP packet seen at the IP layer is routing control.
+constexpr uint16_t kDataPort = 9;
+
+uint64_t g_controlPkts = 0;
+uint64_t g_controlBytes = 0;
+bool     g_diag = false;
+std::map<uint8_t, uint64_t> g_antTx;
+std::map<uint8_t, uint64_t> g_antRx;
+
+void CountControlTx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t) {
+    Ptr<Packet> c = p->Copy();
+    Ipv4Header ip;
+    if (c->RemoveHeader(ip) == 0) return;
+    if (ip.GetProtocol() != 17) return;  // not UDP; routing control here is UDP
+    UdpHeader udp;
+    if (c->PeekHeader(udp) == 0) return;
+    if (udp.GetDestinationPort() != kDataPort) {
+        ++g_controlPkts;
+        g_controlBytes += p->GetSize();
+    }
+}
+
+void DiagAntTx(uint8_t type, uint8_t /*dir*/, bool /*broadcast*/) {
+    if (g_diag) g_antTx[type] += 1;
+}
+void DiagAntRx(uint8_t type, uint8_t /*dir*/) {
+    if (g_diag) g_antRx[type] += 1;
+}
+
+struct Params {
+    uint32_t rows;
+    uint32_t cols;
+    double   simTime;
+    double   islDelayMs;
+    std::string islRate;
+    uint32_t nFlows;
+    double   cbrBps;
+    bool     torus;
+};
+
+struct Result {
+    std::string proto;
+    uint64_t txPackets = 0;
+    uint64_t rxPackets = 0;
+    uint32_t links = 0;
+    double pdr = 0.0;
+    double meanDelayMs = 0.0;
+    double delay99Ms = 0.0;
+    double throughputKbps = 0.0;
+    double nrl = 0.0;
+    double nrlBytes = 0.0;
+    double jitterMs = 0.0;
+};
+
+/// Grid index -> node index. Row = orbital plane, column = position in plane.
+inline uint32_t Idx(uint32_t r, uint32_t c, const Params& P) { return r * P.cols + c; }
+
+/// Link (r,c) to its +1 neighbour in each dimension, wrapping when torus is on.
+/// Only the two "forward" directions are walked, so every link is created once
+/// and each node ends up with degree 4 on a full torus. A dimension of size 2
+/// is not wrapped even in torus mode: the forward and wrapped links would be
+/// the same pair of nodes, and a duplicate parallel link is not a torus.
+std::vector<std::pair<uint32_t, uint32_t>> GridLinks(const Params& P) {
+    std::vector<std::pair<uint32_t, uint32_t>> links;
+    for (uint32_t r = 0; r < P.rows; ++r) {
+        for (uint32_t c = 0; c < P.cols; ++c) {
+            // Intra-plane (along a row): the c -> c+1 link, or the wrap-around
+            // that closes the ring at the last column when the torus is on.
+            if (c + 1 < P.cols) {
+                links.emplace_back(Idx(r, c, P), Idx(r, c + 1, P));
+            } else if (P.torus && P.cols > 2) {
+                links.emplace_back(Idx(r, c, P), Idx(r, 0, P));
+            }
+            // Cross-plane (along a column): same construction.
+            if (r + 1 < P.rows) {
+                links.emplace_back(Idx(r, c, P), Idx(r + 1, c, P));
+            } else if (P.torus && P.rows > 2) {
+                links.emplace_back(Idx(r, c, P), Idx(0, c, P));
+            }
+        }
+    }
+    return links;
+}
+
+Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
+    RngSeedManager::SetSeed(1);
+    RngSeedManager::SetRun(seed);
+    g_controlPkts = 0;
+    g_controlBytes = 0;
+    g_antTx.clear();
+    g_antRx.clear();
+
+    const uint32_t nNodes = P.rows * P.cols;
+    NodeContainer nodes;
+    nodes.Create(nNodes);
+
+    InternetStackHelper internet;
+    if (proto == "anthocnet") {
+        AntHocNetHelper h;
+        internet.SetRoutingHelper(h);
+    } else if (proto == "aodv") {
+        AodvHelper h;
+        internet.SetRoutingHelper(h);
+    } else if (proto == "olsr") {
+        OlsrHelper h;
+        internet.SetRoutingHelper(h);
+    } else if (proto == "dsdv") {
+        DsdvHelper h;
+        internet.SetRoutingHelper(h);
+    }
+    internet.Install(nodes);
+
+    // One point-to-point link per ISL, each on its own /30 — the addressing a
+    // real ISL mesh has, and the shape that exercises #203.
+    PointToPointHelper p2p;
+    p2p.SetDeviceAttribute("DataRate", StringValue(P.islRate));
+    // Seconds(), not MilliSeconds(): the latter takes an integer count, so a
+    // fractional ISL delay would be silently truncated.
+    p2p.SetChannelAttribute("Delay", TimeValue(Seconds(P.islDelayMs / 1000.0)));
+
+    Ipv4AddressHelper address;
+    address.SetBase("10.1.0.0", "255.255.255.252");
+    const std::vector<std::pair<uint32_t, uint32_t>> links = GridLinks(P);
+    std::vector<Ipv4InterfaceContainer> ifs;
+    ifs.reserve(links.size());
+    for (const auto& l : links) {
+        NetDeviceContainer devs =
+            p2p.Install(NodeContainer(nodes.Get(l.first), nodes.Get(l.second)));
+        ifs.push_back(address.Assign(devs));
+        address.NewNetwork();
+    }
+
+    // Routing overhead, counted at the IP layer exactly as anthocnet-compare
+    // does, so NRL means the same thing in both harnesses.
+    for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+        Ptr<Ipv4L3Protocol> l3 = nodes.Get(i)->GetObject<Ipv4L3Protocol>();
+        if (l3) l3->TraceConnectWithoutContext("Tx", MakeCallback(&CountControlTx));
+    }
+
+    // Flows span the grid (i -> n-1-i), the pairing anthocnet-compare uses; on a
+    // torus that is a genuinely multi-hop path rather than a neighbour exchange.
+    // Every node's FIRST interface address is its canonical identity to the core
+    // (see #218), so addressing the destination by ifs[0] of its first link is
+    // what a real deployment would do — and is what forced the #203 fix.
+    std::vector<Ipv4Address> nodeAddr(nNodes);
+    std::vector<bool> haveAddr(nNodes, false);
+    for (std::size_t k = 0; k < links.size(); ++k) {
+        if (!haveAddr[links[k].first]) {
+            nodeAddr[links[k].first] = ifs[k].GetAddress(0);
+            haveAddr[links[k].first] = true;
+        }
+        if (!haveAddr[links[k].second]) {
+            nodeAddr[links[k].second] = ifs[k].GetAddress(1);
+            haveAddr[links[k].second] = true;
+        }
+    }
+
+    std::ostringstream rate;
+    rate << static_cast<uint64_t>(P.cbrBps) << "bps";
+    Ptr<UniformRandomVariable> startVar = CreateObject<UniformRandomVariable>();
+    startVar->SetAttribute("Min", DoubleValue(1.0));
+    startVar->SetAttribute("Max", DoubleValue(11.0));
+
+    ApplicationContainer apps, sinks;
+    for (uint32_t i = 0; i < P.nFlows && i < nNodes; ++i) {
+        const uint32_t src = i;
+        const uint32_t dst = nNodes - 1 - i;
+        if (src == dst) continue;
+        OnOffHelper onoff("ns3::UdpSocketFactory",
+                          InetSocketAddress(nodeAddr[dst], kDataPort));
+        onoff.SetAttribute("DataRate", StringValue(rate.str()));
+        onoff.SetAttribute("PacketSize", UintegerValue(64));
+        onoff.SetAttribute("StartTime", TimeValue(Seconds(startVar->GetValue())));
+        onoff.SetAttribute("StopTime", TimeValue(Seconds(P.simTime - 1.0)));
+        apps.Add(onoff.Install(nodes.Get(src)));
+
+        PacketSinkHelper sink("ns3::UdpSocketFactory",
+                              InetSocketAddress(Ipv4Address::GetAny(), kDataPort));
+        sinks.Add(sink.Install(nodes.Get(dst)));
+    }
+    sinks.Start(Seconds(0.0));
+
+    if (g_diag && proto == "anthocnet") {
+        for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+            Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
+            if (!ip) continue;
+            Ptr<Ipv4RoutingProtocol> rp = ip->GetRoutingProtocol();
+            if (!rp) continue;
+            rp->TraceConnectWithoutContext("Tx", MakeCallback(&DiagAntTx));
+            rp->TraceConnectWithoutContext("Rx", MakeCallback(&DiagAntRx));
+        }
+    }
+
+    FlowMonitorHelper fmHelper;
+    Ptr<FlowMonitor> monitor = fmHelper.InstallAll();
+
+    Simulator::Stop(Seconds(P.simTime));
+    Simulator::Run();
+
+    monitor->CheckForLostPackets();
+    Result r;
+    r.proto = proto;
+    r.links = static_cast<uint32_t>(links.size());
+    double totalDelay = 0.0, totalRxBytes = 0.0, totalJitter = 0.0, binWidth = 0.0;
+    uint64_t rxForDelay = 0, jitterSamples = 0;
+    std::map<uint32_t, uint64_t> delayBins;
+    Ptr<Ipv4FlowClassifier> classifier =
+        DynamicCast<Ipv4FlowClassifier>(fmHelper.GetClassifier());
+    for (auto& kv : monitor->GetFlowStats()) {
+        Ipv4FlowClassifier::FiveTuple t = classifier->FindFlow(kv.first);
+        if (t.destinationPort != kDataPort) continue;  // data flows only
+        r.txPackets += kv.second.txPackets;
+        r.rxPackets += kv.second.rxPackets;
+        totalDelay += kv.second.delaySum.GetSeconds();
+        rxForDelay += kv.second.rxPackets;
+        totalRxBytes += kv.second.rxBytes;
+        totalJitter += kv.second.jitterSum.GetSeconds();
+        if (kv.second.rxPackets > 0) jitterSamples += kv.second.rxPackets - 1;
+        // Copy: Histogram's accessors are non-const in older ns-3 (<=3.36).
+        Histogram h = kv.second.delayHistogram;
+        for (uint32_t b = 0; b < h.GetNBins(); ++b) {
+            if (binWidth == 0.0) binWidth = h.GetBinWidth(b);
+            delayBins[b] += h.GetBinCount(b);
+        }
+    }
+    r.pdr = r.txPackets ? 100.0 * r.rxPackets / r.txPackets : 0.0;
+    r.meanDelayMs = rxForDelay ? 1000.0 * totalDelay / rxForDelay : 0.0;
+    r.throughputKbps = (totalRxBytes * 8.0 / 1000.0) / P.simTime;
+    r.nrl = r.rxPackets ? static_cast<double>(g_controlPkts) / r.rxPackets : 0.0;
+    r.nrlBytes = totalRxBytes > 0.0
+        ? static_cast<double>(g_controlBytes) / totalRxBytes : 0.0;
+    r.jitterMs = jitterSamples ? 1000.0 * totalJitter / jitterSamples : 0.0;
+    if (rxForDelay && binWidth > 0.0) {
+        const uint64_t target = static_cast<uint64_t>(0.99 * rxForDelay);
+        uint64_t cum = 0;
+        for (const auto& b : delayBins) {
+            cum += b.second;
+            if (cum >= target) {
+                r.delay99Ms = 1000.0 * (b.first + 1) * binWidth;
+                break;
+            }
+        }
+    }
+
+    Simulator::Destroy();
+    return r;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    uint32_t rows = 6, cols = 6, nFlows = 4, runs = 1;
+    double simTime = 60.0, islDelayMs = 5.0, cbrBps = 4096;
+    bool torus = true, csv = false;
+    std::string islRate = "10Mbps";
+    std::string protocols = "anthocnet";
+
+    CommandLine cmd(__FILE__);
+    cmd.AddValue("rows", "Orbital planes (grid rows)", rows);
+    cmd.AddValue("cols", "Satellites per plane (grid columns)", cols);
+    cmd.AddValue("torus", "Wrap the grid edges (+Grid torus); false = open grid", torus);
+    cmd.AddValue("islDelayMs", "One-way ISL propagation delay (ms). LEO ISLs are "
+                               "3-18 ms depending on separation", islDelayMs);
+    cmd.AddValue("islRate", "ISL data rate", islRate);
+    cmd.AddValue("time", "Simulation time (s)", simTime);
+    cmd.AddValue("flows", "Number of CBR flows", nFlows);
+    cmd.AddValue("cbrBps", "Per-flow CBR rate (bits/s)", cbrBps);
+    cmd.AddValue("runs", "Number of RNG runs to average (seeds 1..runs)", runs);
+    cmd.AddValue("protocols", "Comma-separated list", protocols);
+    cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
+    cmd.AddValue("diag", "Emit per-run '# diag' lines (ant tallies)", g_diag);
+    cmd.Parse(argc, argv);
+
+    // Same 1 ms delay bin as anthocnet-compare, so delay99 is comparable.
+    Config::SetDefault("ns3::FlowMonitor::DelayBinWidth", DoubleValue(0.001));
+
+    Params P;
+    P.rows = rows;
+    P.cols = cols;
+    P.simTime = simTime;
+    P.islDelayMs = islDelayMs;
+    P.islRate = islRate;
+    P.nFlows = nFlows;
+    P.cbrBps = cbrBps;
+    P.torus = torus;
+
+    std::vector<std::string> list;
+    std::stringstream ss(protocols);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        if (!item.empty()) list.push_back(item);
+    }
+    NS_ABORT_MSG_IF(list.empty(), "--protocols selected nothing");
+
+    std::vector<Result> agg(list.size());
+    for (std::size_t i = 0; i < list.size(); ++i) {
+        agg[i].proto = list[i];
+        for (uint32_t s = 1; s <= runs; ++s) {
+            Result r = RunOne(list[i], P, s);
+            agg[i].links = r.links;
+            agg[i].pdr += r.pdr;
+            agg[i].meanDelayMs += r.meanDelayMs;
+            agg[i].delay99Ms += r.delay99Ms;
+            agg[i].throughputKbps += r.throughputKbps;
+            agg[i].nrl += r.nrl;
+            agg[i].nrlBytes += r.nrlBytes;
+            agg[i].jitterMs += r.jitterMs;
+            std::cout << std::fixed << std::setprecision(2)
+                      << "##RUN## " << s << ' ' << list[i]
+                      << ' ' << r.pdr << ' ' << r.meanDelayMs
+                      << ' ' << r.delay99Ms << ' ' << r.throughputKbps
+                      << ' ' << r.nrl << ' ' << r.nrlBytes
+                      << ' ' << r.jitterMs << std::endl;
+            if (g_diag && list[i] == "anthocnet") {
+                std::cout << "# diag " << list[i] << " seed=" << s << " ctrlTx="
+                          << g_controlPkts << " antTx[";
+                for (const auto& kv : g_antTx) {
+                    std::cout << static_cast<int>(kv.first) << '=' << kv.second << ',';
+                }
+                std::cout << "] antRx[";
+                for (const auto& kv : g_antRx) {
+                    std::cout << static_cast<int>(kv.first) << '=' << kv.second << ',';
+                }
+                std::cout << ']' << std::endl;
+            }
+        }
+        agg[i].pdr /= runs;
+        agg[i].meanDelayMs /= runs;
+        agg[i].delay99Ms /= runs;
+        agg[i].throughputKbps /= runs;
+        agg[i].nrl /= runs;
+        agg[i].nrlBytes /= runs;
+        agg[i].jitterMs /= runs;
+    }
+
+    const uint32_t nNodes = rows * cols;
+    if (csv) {
+        std::cout << "protocol,runs,rows,cols,nodes,links,isl_delay_ms,flows,"
+                     "pdr_pct,delay_ms,delay99_ms,throughput_kbps,nrl,nrl_bytes,"
+                     "jitter_ms\n";
+        for (const auto& a : agg) {
+            std::cout << std::fixed << a.proto << ',' << runs << ',' << rows << ','
+                      << cols << ',' << nNodes << ',' << a.links << ','
+                      << std::setprecision(1) << islDelayMs << ',' << nFlows << ','
+                      << std::setprecision(1) << a.pdr << ','
+                      << a.meanDelayMs << ',' << a.delay99Ms << ','
+                      << std::setprecision(2) << a.throughputKbps << ','
+                      << std::setprecision(3) << a.nrl << ',' << a.nrlBytes << ','
+                      << std::setprecision(2) << a.jitterMs << '\n';
+        }
+        return 0;
+    }
+
+    std::cout << "+Grid " << (torus ? "torus" : "open") << ' ' << rows << 'x' << cols
+              << " = " << nNodes << " satellites, " << agg.front().links
+              << " ISLs @ " << islDelayMs << " ms " << islRate << ", " << nFlows
+              << " flows, " << simTime << " s, mean of " << runs << " run(s)\n\n";
+    std::cout << std::setw(14) << std::left << "protocol" << std::right
+              << std::setw(8) << "PDR%" << std::setw(11) << "delay(ms)"
+              << std::setw(13) << "delay99(ms)" << std::setw(14) << "thrput(kbps)"
+              << std::setw(8) << "NRL" << std::setw(11) << "NRLbytes"
+              << std::setw(12) << "jitter(ms)" << '\n';
+    std::cout << std::string(91, '-') << '\n';
+    for (const auto& a : agg) {
+        std::cout << std::fixed << std::setw(14) << std::left << a.proto << std::right
+                  << std::setw(8) << std::setprecision(1) << a.pdr
+                  << std::setw(11) << a.meanDelayMs
+                  << std::setw(13) << a.delay99Ms
+                  << std::setw(14) << std::setprecision(2) << a.throughputKbps
+                  << std::setw(8) << std::setprecision(2) << a.nrl
+                  << std::setw(11) << a.nrlBytes
+                  << std::setw(12) << a.jitterMs << '\n';
+    }
+    return 0;
+}

--- a/ns3/examples/wscript
+++ b/ns3/examples/wscript
@@ -15,3 +15,10 @@ def build(bld):
                                       'wifi', 'mobility', 'applications',
                                       'aodv', 'olsr', 'dsdv', 'flow-monitor'])
         cmp.source = 'anthocnet-compare.cc'
+
+        # ISL-grid scenario (#214): static +Grid torus of point-to-point links.
+        isl = bld.create_ns3_program('isl-grid',
+                                     ['anthocnet', 'core', 'network', 'internet',
+                                      'applications', 'point-to-point',
+                                      'aodv', 'olsr', 'dsdv', 'flow-monitor'])
+        isl.source = 'isl-grid.cc'

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -519,6 +519,44 @@ void RoutingProtocol::NotifyRemoveAddress(uint32_t, Ipv4InterfaceAddress) {}
 
 // --- routing ----------------------------------------------------------------
 
+void RoutingProtocol::ResolveNextHop(NodeAddress next, Ipv4Address& gateway,
+                                     Ptr<NetDevice>& dev, uint32_t& iface) const {
+    const Ipv4Address nextIp = ToIpv4(next);
+
+    // 1. Directly attached: the next hop is on one of our own subnets. Every
+    //    single-interface topology takes this path, so the common case keeps
+    //    exactly its pre-#203 gateway/device.
+    for (const auto& kv : m_socketAddresses) {
+        const Ipv4InterfaceAddress& addr = kv.second;
+        if (addr.GetLocal().CombineMask(addr.GetMask()) ==
+            nextIp.CombineMask(addr.GetMask())) {
+            const int32_t i = m_ipv4->GetInterfaceForAddress(addr.GetLocal());
+            if (i < 0) continue;
+            gateway = nextIp;
+            iface   = static_cast<uint32_t>(i);
+            dev     = m_ipv4->GetNetDevice(iface);
+            return;
+        }
+    }
+
+    // 2. Multi-interface peer: the core named it by its canonical address,
+    //    which sits on a subnet we are not attached to. Its hello told us which
+    //    of our links actually reaches it, and at what address.
+    std::map<Ipv4Address, PeerRoute>::const_iterator it = m_peerRoutes.find(nextIp);
+    if (it != m_peerRoutes.end() && it->second.iface < m_ipv4->GetNInterfaces()) {
+        gateway = it->second.linkLocal;
+        iface   = it->second.iface;
+        dev     = m_ipv4->GetNetDevice(iface);
+        return;
+    }
+
+    // 3. Unknown next hop: degrade to the first interface exactly as before.
+    gateway = nextIp;
+    iface   = static_cast<uint32_t>(
+        m_ipv4->GetInterfaceForAddress(m_socketAddresses.begin()->second.GetLocal()));
+    dev = m_ipv4->GetNetDevice(iface);
+}
+
 Ptr<Ipv4Route> RoutingProtocol::LoopbackRoute(const Ipv4Header& header, Ptr<NetDevice> oif) const {
     Ptr<Ipv4Route> route = Create<Ipv4Route>();
     route->SetDestination(header.GetDestination());
@@ -556,14 +594,15 @@ Ptr<Ipv4Route> RoutingProtocol::RouteOutput(Ptr<Packet> p, const Ipv4Header& hea
     NodeAddress next = m_logic->nextHopForData(ToCore(dst));
     if (next != kInvalidAddress) {
         m_everRouted.insert(ToCore(dst));  // #21: this dest has been routed
+        Ipv4Address gateway;
+        Ptr<NetDevice> dev;
+        uint32_t ifIdx;
+        ResolveNextHop(next, gateway, dev, ifIdx);  // #203
         Ptr<Ipv4Route> route = Create<Ipv4Route>();
         route->SetDestination(dst);
-        route->SetGateway(ToIpv4(next));
-        Ipv4InterfaceAddress ifaceAddr = m_socketAddresses.begin()->second;
-        route->SetSource(m_ipv4->SourceAddressSelection(
-            m_ipv4->GetInterfaceForAddress(ifaceAddr.GetLocal()), dst));
-        route->SetOutputDevice(m_ipv4->GetNetDevice(
-            m_ipv4->GetInterfaceForAddress(ifaceAddr.GetLocal())));
+        route->SetGateway(gateway);
+        route->SetSource(m_ipv4->SourceAddressSelection(ifIdx, dst));
+        route->SetOutputDevice(dev);
         return route;
     }
 
@@ -607,12 +646,15 @@ bool RoutingProtocol::RouteInput(Ptr<const Packet> p, const Ipv4Header& header,
     NodeAddress next = m_logic->nextHopForData(ToCore(dst));
     if (next != kInvalidAddress) {
         m_everRouted.insert(ToCore(dst));  // #21: this dest has been routed
+        Ipv4Address gateway;
+        Ptr<NetDevice> dev;
+        uint32_t ifIdx;
+        ResolveNextHop(next, gateway, dev, ifIdx);  // #203
         Ptr<Ipv4Route> route = Create<Ipv4Route>();
         route->SetDestination(dst);
-        route->SetGateway(ToIpv4(next));
+        route->SetGateway(gateway);
         route->SetSource(header.GetSource());
-        route->SetOutputDevice(m_ipv4->GetNetDevice(
-            m_ipv4->GetInterfaceForAddress(m_socketAddresses.begin()->second.GetLocal())));
+        route->SetOutputDevice(dev);
         ucb(route, p, header);
         return true;
     }
@@ -649,18 +691,31 @@ void RoutingProtocol::SendAnt(const AntMessage& msg, Ipv4Address dest) {
     AntHeader header(msg);
     packet->AddHeader(header);
 
-    for (auto& kv : m_socketAddresses) {
-        Ptr<Socket> socket = kv.first;
-        Ipv4Address iface = kv.second.GetLocal();
-        Ipv4Address destination =
-            (dest == Ipv4Address("255.255.255.255"))
-                ? kv.second.GetBroadcast()
-                : dest;
-        socket->SendTo(packet->Copy(), 0, InetSocketAddress(destination, ANT_PORT));
-        // For unicast we only need to send out once.
-        if (dest != Ipv4Address("255.255.255.255")) break;
-        (void) iface;
+    if (dest == Ipv4Address("255.255.255.255")) {
+        for (auto& kv : m_socketAddresses) {
+            kv.first->SendTo(packet->Copy(), 0,
+                             InetSocketAddress(kv.second.GetBroadcast(), ANT_PORT));
+        }
+        return;
     }
+
+    // Unicast: out of the interface that actually reaches this next hop, and
+    // addressed to where it is reachable on that link (#203). A backward ant
+    // retraces a path made of canonical addresses, so on a multi-interface node
+    // the ant's next hop is routinely NOT on the subnet it must be sent over.
+    Ipv4Address gateway;
+    Ptr<NetDevice> dev;
+    uint32_t ifIdx;
+    ResolveNextHop(ToCore(dest), gateway, dev, ifIdx);
+    for (auto& kv : m_socketAddresses) {
+        if (m_ipv4->GetInterfaceForAddress(kv.second.GetLocal()) ==
+            static_cast<int32_t>(ifIdx)) {
+            kv.first->SendTo(packet->Copy(), 0, InetSocketAddress(gateway, ANT_PORT));
+            return;
+        }
+    }
+    m_socketAddresses.begin()->first->SendTo(packet->Copy(), 0,
+                                             InetSocketAddress(gateway, ANT_PORT));
 }
 
 void RoutingProtocol::ExecuteDecisions(const std::vector<RouteDecision>& decisions,
@@ -698,6 +753,40 @@ void RoutingProtocol::RecvAnt(Ptr<Socket> socket) {
     packet->RemoveHeader(header);
     AntMessage incoming = header.Message();
 
+    // #203: a hello carries both of the sender's names — `src` is how the core
+    // will name it in pheromone tables and retraced ant paths, `sender` is where
+    // it actually is on this link. They differ only when the peer is
+    // multi-interface and reached us over something other than its first
+    // interface, which is precisely the case ResolveNextHop needs help with.
+    if (incoming.type == AntType::Hello && incoming.src != kInvalidAddress) {
+        const Ipv4Address canonical = ToIpv4(incoming.src);
+        if (canonical != sender) {
+            // A hello arrives on the subnet-broadcast socket; check the unicast
+            // map too so the mapping is still learned if that ever changes.
+            bool known = false;
+            Ipv4InterfaceAddress ifaceAddr;
+            auto bit = m_socketSubnetBroadcast.find(socket);
+            if (bit != m_socketSubnetBroadcast.end()) {
+                ifaceAddr = bit->second;
+                known = true;
+            } else {
+                auto uit = m_socketAddresses.find(socket);
+                if (uit != m_socketAddresses.end()) {
+                    ifaceAddr = uit->second;
+                    known = true;
+                }
+            }
+            const int32_t i =
+                known ? m_ipv4->GetInterfaceForAddress(ifaceAddr.GetLocal()) : -1;
+            if (i >= 0) {
+                PeerRoute pr;
+                pr.iface = static_cast<uint32_t>(i);
+                pr.linkLocal = sender;
+                m_peerRoutes[canonical] = pr;
+            }
+        }
+    }
+
     NodeAddress prevHop = ToCore(sender);
     std::vector<RouteDecision> decisions = m_logic->onReceiveAnt(incoming, prevHop);
 
@@ -734,12 +823,15 @@ void RoutingProtocol::FlushQueue(NodeAddress coreDest) {
             m_queue.Enqueue(e);
             continue;
         }
+        Ipv4Address gateway;
+        Ptr<NetDevice> dev;
+        uint32_t ifIdx;
+        ResolveNextHop(next, gateway, dev, ifIdx);  // #203
         Ptr<Ipv4Route> route = Create<Ipv4Route>();
         route->SetDestination(dst);
-        route->SetGateway(ToIpv4(next));
+        route->SetGateway(gateway);
         route->SetSource(e.header.GetSource());
-        route->SetOutputDevice(m_ipv4->GetNetDevice(
-            m_ipv4->GetInterfaceForAddress(m_socketAddresses.begin()->second.GetLocal())));
+        route->SetOutputDevice(dev);
         if (!e.ucb.IsNull()) {
             m_everRouted.insert(coreDest);      // #21: this dest has been routed
             m_queue.NoteDelivered(e);           // #21: attribute this packet's hold

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -194,6 +194,21 @@ private:
     bool MapMacToCore(const Mac48Address& mac,
                       ::anthocnet::core::NodeAddress& out) const;
 
+    /// Issue #203: resolve a core next-hop name to the concrete way of reaching
+    /// it — the gateway address to send to, the device to send it out of, and
+    /// that device's interface index.
+    ///
+    /// Necessary because the core names a node by ONE address (the first
+    /// interface's, fixed when the logic is constructed in NotifyInterfaceUp)
+    /// while a multi-interface node is reachable on a different subnet per
+    /// link. On single-interface topologies the two coincide and this resolves
+    /// to exactly the pre-#203 values.
+    ///
+    /// Never fails: an unresolvable hop falls back to the first interface, the
+    /// old behaviour, rather than dropping the packet.
+    void ResolveNextHop(::anthocnet::core::NodeAddress next, Ipv4Address& gateway,
+                        Ptr<NetDevice>& dev, uint32_t& iface) const;
+
     // state
     Ptr<Ipv4> m_ipv4;
     // Per-interface sockets: one bound to the unicast address (receives
@@ -202,6 +217,20 @@ private:
     // address does NOT receive broadcasts, so both are required.
     std::map<Ptr<Socket>, Ipv4InterfaceAddress> m_socketAddresses;
     std::map<Ptr<Socket>, Ipv4InterfaceAddress> m_socketSubnetBroadcast;
+
+    /// Issue #203: where a peer the core named actually is. `iface` is the ns-3
+    /// interface index whose device shares a link with it; `linkLocal` is the
+    /// address to send to on that link.
+    struct PeerRoute {
+        uint32_t    iface = 0;
+        Ipv4Address linkLocal;
+    };
+    /// Peer canonical address (how the core names it, i.e. how it appears in
+    /// pheromone tables and ant paths) -> how to reach it. Learned from hello
+    /// ants, the one message carrying both of a peer's names: `msg.src` is the
+    /// canonical one, the IP source is the link-local one. Only populated when
+    /// the two differ, so it stays empty on every single-interface topology.
+    std::map<Ipv4Address, PeerRoute> m_peerRoutes;
 
     ::anthocnet::core::Config m_config;
     Ns3Clock m_clock;

--- a/ns3/test/anthocnet-test-suite.cc
+++ b/ns3/test/anthocnet-test-suite.cc
@@ -151,6 +151,82 @@ private:
     uint32_t m_rxBytes;
 };
 
+// Issue #203 — delivery across a node with MORE THAN ONE interface.
+//
+// Same 3-node line as above, but built from two separate channels on two
+// separate subnets, so the middle node has two interfaces:
+//
+//     0 (10.1.1.1) --- (10.1.1.2) 1 (10.1.2.1) --- (10.1.2.2) 2
+//
+// This is the satellite/ISL shape (#192, #194) and it fails before #203: the
+// data path derived its output device from m_socketAddresses.begin(), so node 1
+// forwarded packets for 10.1.2.2 back out of its 10.1.1.0/24 device, and
+// backward ants unicast to a canonical address that is not on the link they
+// were sent over.
+class MultiInterfaceDeliveryTestCase : public TestCase
+{
+public:
+    MultiInterfaceDeliveryTestCase()
+        : TestCase("Multi-hop delivery through a multi-interface node (#203)"), m_rxBytes(0) {}
+
+    void DoRun() override {
+        RngSeedManager::SetSeed(1);
+        RngSeedManager::SetRun(1);
+
+        NodeContainer nodes;
+        nodes.Create(3);
+
+        // Two point-to-point-style links, each its own channel: 0<->1 and 1<->2.
+        // Node 1 therefore holds one device (and one subnet) per link, and 0 and
+        // 2 share no medium at all.
+        NodeContainer leftPair(nodes.Get(0), nodes.Get(1));
+        NodeContainer rightPair(nodes.Get(1), nodes.Get(2));
+        SimpleNetDeviceHelper devHelper;
+        NetDeviceContainer leftDevs = devHelper.Install(leftPair, CreateObject<SimpleChannel>());
+        NetDeviceContainer rightDevs = devHelper.Install(rightPair, CreateObject<SimpleChannel>());
+
+        AntHocNetHelper anthocnet;
+        InternetStackHelper internet;
+        internet.SetRoutingHelper(anthocnet);
+        internet.Install(nodes);
+
+        Ipv4AddressHelper address;
+        address.SetBase("10.1.1.0", "255.255.255.0");
+        Ipv4InterfaceContainer leftIfs = address.Assign(leftDevs);
+        address.SetBase("10.1.2.0", "255.255.255.0");
+        Ipv4InterfaceContainer rightIfs = address.Assign(rightDevs);
+
+        const uint16_t port = 9;
+
+        Ptr<Socket> rx = Socket::CreateSocket(nodes.Get(2), UdpSocketFactory::GetTypeId());
+        rx->Bind(InetSocketAddress(Ipv4Address::GetAny(), port));
+        rx->SetRecvCallback(MakeCallback(&MultiInterfaceDeliveryTestCase::Receive, this));
+
+        // Node 0 -> node 2's address, which lives on the far subnet and is only
+        // reachable through node 1's second interface.
+        Ptr<Socket> tx = Socket::CreateSocket(nodes.Get(0), UdpSocketFactory::GetTypeId());
+        tx->Connect(InetSocketAddress(rightIfs.GetAddress(1), port));
+        for (double t = 10.0; t < 18.0; t += 0.5) {
+            Simulator::Schedule(Seconds(t), &MultiInterfaceDeliveryTestCase::Send, this, tx);
+        }
+
+        Simulator::Stop(Seconds(20.0));
+        Simulator::Run();
+        Simulator::Destroy();
+
+        NS_TEST_ASSERT_MSG_GT(m_rxBytes, 0u,
+                              "node 2 received no data across the multi-interface relay");
+    }
+
+private:
+    void Send(Ptr<Socket> s) { s->Send(Create<Packet>(64)); }
+    void Receive(Ptr<Socket> s) {
+        Ptr<Packet> p;
+        while ((p = s->Recv())) m_rxBytes += p->GetSize();
+    }
+    uint32_t m_rxBytes;
+};
+
 // B3 — address mapping never aliases the core's kInvalidAddress sentinel.
 class AddressMappingTestCase : public TestCase
 {
@@ -296,6 +372,7 @@ public:
         AddTestCase(new AntHeaderRoundTripTestCase(), AHN_TEST_QUICK);
         AddTestCase(new AddressMappingTestCase(), AHN_TEST_QUICK);
         AddTestCase(new AntHocNetDeliveryTestCase(), AHN_TEST_QUICK);
+        AddTestCase(new MultiInterfaceDeliveryTestCase(), AHN_TEST_QUICK);
         AddTestCase(new RepairAntOnLinkBreakTestCase(), AHN_TEST_QUICK);
     }
 };


### PR DESCRIPTION
Opens the satellite-networking track (#192) with the two pieces that do not depend on the substrate decision still open in #193: a genuine multi-interface routing defect, and the topology that exercises it.

> **Scope note.** This PR carries **two** changes — a `fix` (#203) and a `feat` (#214) — because both were developed on the same branch. Squash-merging collapses them into the single `feat:` commit above, so #203 gets no separate changelog line. A `feat` bumps the minor, which subsumes the patch bump, so versioning is not *wrong* — only the changelog is coarser than ideal. The title was originally auto-set to `fix(ns3): …` from the first commit; left that way, a feature would have shipped under a patch bump.

## 1. `fix` — data path always used the first interface's output device (#203)

The NS-3 data path derived its output device from `m_socketAddresses.begin()` — an arbitrary entry in a `std::map` keyed by `Ptr<Socket>` — rather than the interface owning the chosen next hop. On a single-interface node that is trivially correct, which is why **no benchmarked regime here was affected and no published number changes**. On a multi-interface node it is wrong for every next hop not on the first interface's subnet. A satellite carries ~4 ISLs on 4 subnets, so three quarters of next-hop choices went out the wrong link.

**Four** sites were affected, one more than the issue originally recorded:

| Site | Path |
|---|---|
| `RouteOutput` | locally-originated data |
| `RouteInput` | in-transit forwarding |
| `FlushQueue` | pending packets released after discovery |
| **`SendAnt`** | **ant *unicast* — sent on the first socket and `break`'d** |

The `SendAnt` site matters most: it is how backward ants retrace, so the control plane was broken on multi-interface nodes too, not just the data plane.

### Why correct device selection alone is insufficient

The core names a node by **one** address. `AntRouterLogic` is constructed in `NotifyInterfaceUp` keyed by the *first* interface's address, and that canonical name is what every node stamps onto an ant's visited stack (`core/src/ant_router_logic.cpp:421`) and therefore what ends up as the next hop in pheromone tables. Meanwhile the adapter learns neighbours from the **IP source** of received ants — the *link-local* address of the interface the ant arrived over. On single-interface nodes the two coincide; on multi-interface nodes they diverge, so a next hop can name a subnet we are not attached to, and subnet matching alone falls through.

Hello ants are the one message carrying **both** names (`msg.src` canonical, IP source link-local), so `RecvAnt` records the mapping and `ResolveNextHop` uses it:

1. **directly attached** — next hop on one of our own subnets. Every single-interface topology takes this path and keeps byte-identical gateway/device/source values.
2. **multi-interface peer** — via the hello-learned mapping, rewriting the gateway to where the peer actually is.
3. **otherwise** — fall back to the first interface, i.e. the old behaviour, rather than dropping the packet.

The map is populated only when the two names differ, so it stays **empty in every existing regime**. This is adapter translation, not routing logic (golden rule 2): the core still chooses the next hop, the adapter works out how to reach it. **No core change, no wire change.**

The residual naming divergence is worked around here, not resolved — filed as #218, since resolving it properly touches ADR-0011 and possibly the wire format.

## 2. `feat` — ISL-grid scenario (#214)

`ns3/examples/isl-grid.cc`: an R×C **+Grid torus** of point-to-point links, each ISL on its own `/30`, so every node holds 4 interfaces on 4 subnets. This is the conventional LEO inter-satellite-link abstraction frozen at one instant — no orbital mechanics, no third-party satellite module, hence no dependency on #193.

Metrics mirror `anthocnet-compare`'s definitions exactly (PDR, mean/99th delay, throughput, NRL as control-packets-over-delivered, #132 byte-NRL, #57 jitter), at the same IP-layer counting point and 1 ms delay bin, so numbers are comparable across harnesses. `dOff50`/`dOff90` are deliberately **not** computed: they expose survivorship bias under mobility-driven route loss, which a static topology does not have, and a placeholder would be mistaken for a measurement.

Deliberately a **scenario, not a module** — no mobility, no link budget, no handover. The README states the boundary so it does not erode into #195 territory.

## Verification

**Both directions measured, not reasoned.** An NS-3 build needs a simulator tree this repo does not vendor and no container runtime was available, so every claim below comes from CI.

| Run | Content | Result |
|---|---|---|
| [30190452648](https://github.com/danieljoppi/AntHocNet/actions/runs/30190452648) | this branch | **13/13 green** |
| [30187578151](https://github.com/danieljoppi/AntHocNet/actions/runs/30187578151) | #203 fix alone | ✅ suite passes |
| [30187834337](https://github.com/danieljoppi/AntHocNet/actions/runs/30187834337) | fix reverted, test kept | ❌ `FAIL: TestSuite anthocnet` |

The third run is the one that matters: it proves the new test **catches** the bug rather than passing either way. The build linked 96/96 targets before failing, so it is the test failing, not a compile error. That temporary commit was reset away; the branch tip is the fix.

ISL-grid result (4×4 torus, 3.42 leg):

```
anthocnet,1,4,4,16,32,5.0,2,100.0,10.4,11.0,4.10,12.180,19.480,0.00
AntHocNet ISL-grid PDR% = 100.0
```

Two independent sanity checks that this measures what it claims:

- **16 nodes, 32 links** — exactly 2 per node, i.e. degree 4, which a +Grid torus must produce. A construction bug would show here.
- **Delay matches the analytic value.** Both flows are 2 hops (the wrap makes opposite corners near neighbours), so 5 ms/ISL predicts 10 ms; measured **10.39 ms**, remainder serialisation. Jitter 0.00, as a static contention-free topology should give.

Also green: the 3.42 **determinism gate** (same seed twice, byte-identical rows — the evidence that touching all four send paths did not perturb single-interface behaviour), the **validation-anchor gate**, ns-2.34/2.35 including valgrind, core 23/23, core ASan/UBSan, codec fuzz.

## Tests

- `MultiInterfaceDeliveryTestCase` (NS-3 suite): 3-node line built from two channels on two subnets so the middle node holds two interfaces; asserts end-to-end delivery. Fails without the fix.
- ISL-grid CI smoke (4×4, 30 s): the same loose "must deliver something" gate as the existing e2e check, at the real 4-ISL shape. Runs on **every** matrix leg — including ns-3.36, where the unit-test step is skipped, so it also closes that coverage gap.
- No core test: no core logic changed (golden rule 7 applies to `core/` changes). Invariant checker reports no rule-1/4/7 findings.

## Known gaps

- **Baseline row on the ISL grid not run.** AODV/OLSR/DSDV are wired up but only AntHocNet is exercised in the smoke, to keep per-leg CI cost down. Belongs with the control row in #216.
- **`ResolveNextHop` case 3** (unresolvable next hop → legacy fallback) is not directly covered by a test.
- **The peer map depends on hello.** #204 proposes suppressing hello on ISLs, which would silently disable the mapping and regress this to the fallback path. That interaction needs a pinning test when #204 is implemented.
- **NRL 12.18** on a churn-free topology is the hello cost #204 predicts and the first datapoint for #207 — but it is a 30 s low-load run, so the small data denominator flatters it. Not a constellation-scale figure.

Closes #203
Closes #214
Refs #192, #194, #196, #207, #218, #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1
