### PR TITLE
docs: record what the ducatelle thesis answered, and one estimator mismatch it exposed

### DIFF
--- a/docs/publications/thesis/README.md
+++ b/docs/publications/thesis/README.md
@@ -1,23 +1,86 @@
-# Thesis — pending
+# Thesis — supplied, partially digested
 
-Target document: F. Ducatelle, *Adaptive Routing in Ad Hoc Wireless Multi-hop
-Networks*, PhD thesis, Università della Svizzera Italiana / IDSIA, 2007. The
-maintainer decision of record (#58/#70, 2026-07-19) designates it the
-**primary source** for parameter verification; the 2004 PPSN paper
+Source document: F. Ducatelle, *Adaptive Routing in Ad Hoc Wireless Multi-hop
+Networks*, PhD thesis, Università della Svizzera Italiana / IDSIA, **May 2007**
+(218 pp). The maintainer decision of record (#58/#70, 2026-07-19) designates it
+the **primary source** for parameter verification; the 2004 PPSN paper
 ([`../papers/2004-ppsn-anthocnet.md`](../papers/2004-ppsn-anthocnet.md))
-confirms formulas and several constants but leaves the items below open.
+confirms formulas and several constants but left the items below open.
 
-No PDF has been supplied yet (this environment cannot fetch academic PDFs —
-proxy-blocked). When one is uploaded, digest it here in the same reference
-form as the papers directory (no full-text reproduction; see
-[`../README.md`](../README.md)).
+**The PDF was supplied on 2026-07-25** and lives in the *private* papers repo at
+`AntHocNet/library/2007-ducatelle-thesis.pdf`. It is not in this repository and
+must not be: this repo keeps digests and citations only (papers-repo golden
+rule 4). Search it with the `pdf-extract` skill rather than reading it into
+context — it is ~570k characters:
 
-## Open questions waiting on this document
+```bash
+python3 .claude/skills/pdf-extract/pdfx.py grep \
+  AntHocNet/library/2007-ducatelle-thesis.pdf 'unloaded' -C 3
+```
 
-| Ticket | Question |
+Glyph caveat: the thesis renders the constant as `thop` (no underscore) and
+keeps ligatures (`ﬁxed`, `diﬀerent`), so search prose fragments ("unloaded",
+"we kept") rather than typeset symbols.
+
+## Status of the questions that were waiting on it
+
+| Ticket | Question | Status |
+|---|---|---|
+| #88 | Numeric `T_hop` | ✅ **Answered and shipped.** `t_hop = 0.003 s` (§ "we kept thop on 0.003 sec"). The repo's provisional 50 ms was **16.7× too large**; `Config::hopTimeSec` now carries the thesis value. Issue closed 2026-07-25 |
+| #58 | The full scenario/parameter table | ✅ **Mined and encoded.** `--scenario=thesis` in `ns3/examples/anthocnet-compare.cc` now carries §5.1.3's values verbatim (below). Issue stays open for its *remaining* half — documenting the calibration-vs-fidelity distinction and actually running the preset |
+| #89 | The "average delay jitter" estimator | ✅ **Definition recovered** (§5.1.5, equation 5.1 — below). ⚠️ It does **not** match what the harness measures; the issue stays open on that mismatch, which is now a decision rather than a lookup |
+| #70 | A2 `(Q_mac+1)·T̂_mac` details vs the thesis version | ⏳ still to check against the source |
+| — | Pheromone diffusion / bootstrapping constants; any evaporation the thesis adds | ⏳ still to check (ADR-0007, ADR-0012 gates) |
+
+## §5.1.3 — the base scenario (#58)
+
+Quoted from the source, and the reason `--scenario=thesis` is no longer a
+reconstruction:
+
+| Parameter | Thesis value |
 |---|---|
-| #88 | Numeric `T_hop` (repo provisional: 50 ms; sweep suggests few-ms is better) |
-| #58 | The full parameter table (intervals, bounds, any values the 2004 paper leaves as "e.g.") |
-| #89 | The exact "average delay jitter" estimator used in the thesis/journal evaluations |
-| #70 | Confirm the A2 `(Q_mac+1)·T̂_mac` details match the thesis version (2004 paper already confirms the formula and α = γ = 0.7) |
-| — | Pheromone diffusion / bootstrapping constants (repo ADR-0007 gates), any evaporation the thesis may add |
+| Nodes | 100 |
+| Area | 2400 × 800 m, open (no obstacles) |
+| Mobility | Random waypoint; speed **0–10 m/s**; pause **30 s** |
+| Duration | 900 s, **repeated 20 times** |
+| Traffic | 20 CBR sessions, random source/destination |
+| Session start | between 0 and 180 s, running to the end |
+| Packet rate / size | **4 packets/s**, **64 bytes** (= 2048 bit/s per session) |
+| Propagation | **Two-ray** ground reflection |
+| PHY | IEEE 802.11 at **2 Mbit/s**; estimated radio range **250 m** |
+| MAC | IEEE 802.11 DCF |
+| Transport | UDP |
+
+Note the harness default is the disk propagation model, not two-ray; a thesis
+reproduction must pass `--propagation=tworay` explicitly. See
+`docs/benchmarks/methodology.md`.
+
+## §5.1.5 — the evaluation measures (#89)
+
+The thesis derives its measures from the IETF MANET group's recommendations and
+defines **average delay jitter** as *the variation in the time interval between
+the arrivals of subsequent packets*, calculated as (equation 5.1):
+
+```
+jitter = Σ(i=2..n) |(tᵢ − tᵢ₋₁) − (tᵢ₋₁ − tᵢ₋₂)|
+```
+
+where `tᵢ` is the arrival time of the *i*-th packet and `n` the total number of
+packets received by a destination during a session.
+
+**Two consequences, both recorded on #89:**
+
+1. The estimator is a function of **arrival times only** — it never references
+   per-packet end-to-end delay. Our harness's jitter column comes from ns-3
+   FlowMonitor's `jitterSum`, which is the RFC 3550 estimator: it subtracts the
+   *sender's* packet spacing and applies exponential smoothing. These are
+   different quantities, so "reproduces the paper's jitter result" is not
+   currently a claim this repo can make.
+2. Equation 5.1 as printed is a **sum**, while the surrounding text and every
+   figure axis say *average* delay jitter — so a normalisation (presumably by
+   the number of terms) is implied but not written. Anyone reproducing a thesis
+   jitter figure has to pick one; say which.
+
+(The printed index also starts the sum at `i = 2` while the summand needs
+`tᵢ₋₂`, so the first valid term is really `i = 3`. Immaterial for large `n`,
+worth knowing if you implement it literally.)


### PR DESCRIPTION
`docs/publications/thesis/README.md` still said *"Thesis — pending / No PDF has been supplied yet"*. The PDF arrived **2026-07-25** and lives in the private papers repo. This turns that page into a status record of what the source settled — and mining it for the two still-open tickets turned up a substantive problem.

## The finding that matters: our jitter column is not the thesis's jitter (#89)

The thesis (§5.1.5) defines **average delay jitter** as *the variation in the time interval between the arrivals of subsequent packets*, equation 5.1:

```
jitter = Σ(i=2..n) |(tᵢ − tᵢ₋₁) − (tᵢ₋₁ − tᵢ₋₂)|
```

where `tᵢ` is the arrival time of the *i*-th packet.

**It is a function of arrival times only — it never references per-packet end-to-end delay.** Our jitter column is ns-3 FlowMonitor's `jitterSum`, i.e. the RFC 3550 estimator, which subtracts the *sender's* packet spacing and applies exponential smoothing. These are different quantities.

That matters more than a metrology footnote:

- **jitter is one of the two contradicted headline claims** in the v1.0 compliance ledger (#91);
- **#21's acceptance test is stated in terms of it** ("≤ AODV on mean jitter + mean delay at ≥ PDR").

So a claim of the form "reproduces the paper's jitter result" is not currently one this repo can make, and #21's bar is being measured with a different instrument than the paper's. #89 therefore stays open — but it is now a **decision** (keep FlowMonitor and document the delta, or compute equation 5.1 at the sink) rather than a lookup.

Two implementation notes recorded for whoever takes it: equation 5.1 is printed as a **sum** while the text and every figure axis say *average*, so a normalisation is implied but unwritten; and the printed lower index (`i = 2`) needs `tᵢ₋₂`, so the first valid term is really `i = 3`.

## A correction: #58's table was already mined

I previously suggested #58's field table was still waiting to be extracted. **That was wrong.** `--scenario=thesis` in `anthocnet-compare.cc` already carries §5.1.3's values, and I verified each against the source:

| Parameter | Thesis | Preset |
|---|---|---|
| Nodes | 100 | ✅ 100 |
| Area | 2400 × 800 m | ✅ 2400 × 800 |
| Speed / pause | 0–10 m/s / 30 s | ✅ 10 / 30 |
| Duration / repeats | 900 s / 20 | ✅ 900 / `runs=20` |
| Sessions | 20 CBR, start 0–180 s | ✅ 20, `startWindow=180` |
| Rate / size | 4 pkt/s, 64 B | ✅ `cbrBps=2048` |
| Radio | 802.11 @ 2 Mbit/s, range 250 m | ✅ 250 m |

The table is now reproduced in the doc so the preset can be audited against the source **without** needing the PDF. What actually remains on #58 is its documentation half (calibration-vs-fidelity distinction) and an actual run — not the mining.

The doc also flags that a thesis reproduction must pass `--propagation=tworay` explicitly, since the thesis uses two-ray ground reflection and the harness defaults to the disk model.

## Status table

| Ticket | Status |
|---|---|
| #88 (`T_hop`) | ✅ answered and shipped — `0.003 s`; the provisional 50 ms was 16.7× too large. Closed 2026-07-25 |
| #58 (scenario table) | ✅ mined and encoded; open for its documentation half + a run |
| #89 (jitter estimator) | ✅ definition recovered; ⚠️ open on the mismatch above |
| #70 (A2 details vs thesis) | ⏳ still unchecked |
| diffusion / evaporation constants | ⏳ still unchecked |

## Boundary

No PDF and no extracted text enters this public repo — citations and digests only, per the papers repo's golden rule 4. The equation and the parameter values are quoted as a normal citation carries them, attributed to §5.1.3 / §5.1.5.

Refs #89, #58, #88, #70, #91, #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1


---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_