### PR TITLE
test(bench): satellite validation anchors on the isl topology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,32 @@ jobs:
         # cheap (reuses this job's build).
         if: matrix.version == '3.42'
         run: bash ns3/tools/check-determinism.sh /opt/ns-3
+      - name: Satellite validation anchors (#237, ISL topology)
+        # The ISL analogue of the anchor gate above, and stronger in kind: a
+        # point-to-point link has no contention and no loss model, so the
+        # expected values are *analytic* rather than literature-derived.
+        #   single-isl — 2 satellites, 1 ISL: PDR must be ~100% (the #51
+        #                lesson applied to the p2p stack).
+        #   hop-delay  — 4x4 torus, both flows 2 hops: mean delay must sit in
+        #                [h*d, h*d + slack]. The lower bound is the sharp one —
+        #                below it the packet beat propagation, so either the
+        #                channel delay is not applied (#200) or the topology is
+        #                not the 2-hop path it claims (#226).
+        # Same single-matrix-version placement as the gates above (ADR-0015
+        # also fixes satellite CI to one ns-3 version). Thresholds:
+        # ns3/tools/anchors.yml.
+        if: matrix.version == '3.42'
+        run: |
+          bash ns3/tools/check-sat-anchors.sh /opt/ns-3 single-isl
+          bash ns3/tools/check-sat-anchors.sh /opt/ns-3 hop-delay
+      - name: Determinism gate on the ISL topology (#237 S5)
+        # Run separately from the wifi determinism gate rather than assuming it
+        # follows: the ISL grid exercises a different device and channel, plus
+        # the post-#203 multi-interface next-hop resolution whose peer map is
+        # built from received hellos — an ordering a container-iteration bug
+        # could perturb without ever showing on a single-interface wifi node.
+        if: matrix.version == '3.42'
+        run: bash ns3/tools/check-determinism.sh /opt/ns-3 isl-grid
 
   ns3-asan:
     name: NS-3 module under ASan + LSan

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -249,6 +249,62 @@ enforced locally by
 [`.claude/skills/benchmark-results/scenario_check.py`](../../.claude/skills/benchmark-results/scenario_check.py)
 (#134), which reads `anchors.yml` rather than duplicating it.
 
+### Satellite validation anchors ([#237](https://github.com/danieljoppi/AntHocNet/issues/237))
+
+The anchors above are **literature-derived and approximate** ("AODV ≈ 90–100%")
+because a wifi channel is stochastic — the best available reference is somebody
+else's measurement. The satellite/ISL topology
+([`isl-grid`](../../ns3/examples/isl-grid.cc), [#214](https://github.com/danieljoppi/AntHocNet/issues/214))
+is different in kind: a point-to-point link has **no contention and no loss
+model**, so the expected values are **analytic**. The anchor is a derivation,
+not a remembered number, and a wrong substrate, image or topology cannot hide
+behind "that looks plausible".
+
+Notation: `d` = per-ISL one-way delay (`--islDelayMs`), `h` = hop count,
+`s` = serialisation + queueing (small, bounded).
+
+| anchor | configuration | expected (derived) | what it checks |
+|---|---|---|---|
+| `single-isl` | 2 satellites, 1 ISL, stock AODV | **PDR = 100%** — a p2p link drops nothing | that the link/IP/app stack delivers at all on this device. The ISL analogue of the single-hop anchor, and the same lesson as [#51](https://github.com/danieljoppi/AntHocNet/issues/51) |
+| `hop-delay` | 4×4 torus, both default flows at `h = 2`, uniform `d` | **delay ∈ [h·d, h·d + s]** | topology construction, delay application **and** routing optimality in one number |
+
+**Why `hop-delay` is the strongest number this repo produces.** Its *lower*
+bound is physics: a packet cannot arrive faster than propagation, so
+`delay < h·d` is impossible and means either the channel delay is not being
+applied ([#200](https://github.com/danieljoppi/AntHocNet/issues/200)'s
+load-bearing unknown) or the path is not the `h`-hop one it claims
+([#226](https://github.com/danieljoppi/AntHocNet/issues/226)). Its *upper* bound
+is nearly as sharp, because one extra hop costs a whole `d` — far more than the
+serialisation slack. On the 4×4 torus the wrap makes opposite corners near
+neighbours (`min(3, 4−3) = 1` step per dimension, so `h = 2`), predicting 10 ms
+at `d = 5`; the measured value is **10.39 ms**
+([#214](https://github.com/danieljoppi/AntHocNet/issues/214), CI run
+30190452648), i.e. 0.39 ms of serialisation over an exact floor.
+
+**Identity anchor.** The determinism gate also runs on the ISL topology
+(`check-determinism.sh <dir> isl-grid`) rather than being assumed to follow from
+the wifi case: the grid exercises a different device and channel plus the
+post-[#203](https://github.com/danieljoppi/AntHocNet/issues/203) multi-interface
+next-hop resolution, whose peer map is built from received hellos — an ordering
+a container-iteration bug could perturb without ever showing on a
+single-interface wifi node.
+
+**Enforcement.** [`ns3/tools/check-sat-anchors.sh`](../../ns3/tools/check-sat-anchors.sh),
+thresholds in the same [`anchors.yml`](../../ns3/tools/anchors.yml)
+(`sat_single_isl_pdr_min`, `sat_hop_delay_slack_ms`). Both anchors and the ISL
+determinism gate run in `ci.yml` on the ns-3.42 leg only — per
+[ADR-0015](../adr/0015-satellite-substrate-lives-in-the-image.md), satellite CI
+is pinned to one ns-3 version.
+
+**Still to come** (#237): these are the three anchors runnable *without* a
+satellite substrate. `S3` delay-linearity (sweep `d`, delay must scale linearly)
+and `S4` diameter-scaling follow from the same script with different flags;
+`S6` image-equivalence and `S7` substrate-presence-null need the image from
+[#234](https://github.com/danieljoppi/AntHocNet/issues/234) and are what will
+validate *it* — S7 in particular tests ADR-0015's "one binary" premise directly,
+by requiring `isl-grid` to give **identical** numbers with and without a
+substrate installed.
+
 **Determinism anchor ([#129](https://github.com/danieljoppi/AntHocNet/issues/129)).**
 One further anchor's expected result is not a number but *identity*: golden
 rule 3 (AGENTS.md) routes all randomness through `IRng` and all time through

--- a/ns3/tools/anchors.yml
+++ b/ns3/tools/anchors.yml
@@ -9,6 +9,24 @@
 # while still catching partial regressions.
 single_hop_pdr_min: 99.0
 
+# --- satellite / ISL anchors (#237, consumed by check-sat-anchors.sh) -------
+# These differ in kind from the wifi anchors above: a point-to-point ISL has no
+# contention and no loss model, so the expected values are *analytic*, not
+# literature-derived. Keep them tight — slack here is slack in which a broken
+# substrate or topology can hide.
+
+# 2 satellites, 1 ISL, stock AODV. A p2p link is lossless: the true expected
+# value is exactly 100.0. 99.0 mirrors the wifi single-hop floor and tolerates
+# only route-setup loss at t=0, nothing else.
+sat_single_isl_pdr_min: 99.0
+
+# Serialisation + queueing slack above the h*d propagation floor, in ms, for
+# the hop-delay identity. Measured on the 4x4 torus (h=2, d=5 ms): 10.39 ms,
+# i.e. 0.39 ms of slack over the 10 ms floor (#214, CI run 30190452648). 1.5 ms
+# leaves room for a slower link rate or a larger packet while still catching a
+# path that is not the 2-hop one — a single extra hop costs a whole d.
+sat_hop_delay_slack_ms: 1.5
+
 # Broch/Perkins field at low mobility (pause=900 speed=1), stock AODV.
 # Literature floor ~90% (Broch et al. 1998); measured 92.5% on current main
 # (time=300, runs=3). 85.0 leaves margin for the gate's 2-run average and

--- a/ns3/tools/check-determinism.sh
+++ b/ns3/tools/check-determinism.sh
@@ -10,25 +10,49 @@
 # anchor of docs/benchmarks/methodology.md "Validation anchors": the expected result is
 # not a number but *identical output*.
 #
-# Usage: check-determinism.sh <ns3-dir>
+# Usage: check-determinism.sh <ns3-dir> [compare|isl-grid]
+#
+# `compare` (the default) runs the wifi/MANET field; `isl-grid` runs the same
+# identity check on the satellite ISL topology (S5 of #237).
 #
 # The ns-3 tree must already be configured + built with the anthocnet module's
-# examples enabled (anthocnet-compare builds as part of the module's examples).
+# examples enabled (both harnesses build as part of the module's examples).
 set -euo pipefail
 
 NS3DIR=${1:-}
+HARNESS=${2:-compare}
 if [ -z "$NS3DIR" ]; then
-    echo "usage: $0 <ns3-dir>" >&2
+    echo "usage: $0 <ns3-dir> [compare|isl-grid]" >&2
     exit 2
 fi
 
-# Small, fast, connected field (same shape as ci.yml's e2e delivery smoke,
-# longer run): anthocnet exercises the core's IRng/IClock paths, aodv is a
-# stock control. --runs=1 fixes the RNG run number (seeds 1..runs), so both
-# invocations use identical seeds by construction.
-args="--nNodes=8 --area=150 --flows=2 --time=60 --runs=1"
-protocols="anthocnet,aodv"
-cmd="anthocnet-compare $args --protocols=$protocols"
+case "$HARNESS" in
+    compare)
+        # Small, fast, connected field (same shape as ci.yml's e2e delivery
+        # smoke, longer run): anthocnet exercises the core's IRng/IClock paths,
+        # aodv is a stock control. --runs=1 fixes the RNG run number (seeds
+        # 1..runs), so both invocations use identical seeds by construction.
+        args="--nNodes=8 --area=150 --flows=2 --time=60 --runs=1"
+        protocols="anthocnet,aodv"
+        cmd="anthocnet-compare $args --protocols=$protocols"
+        ;;
+    isl-grid)
+        # S5 of #237 — the same identity anchor on the satellite topology.
+        # Worth running separately rather than assuming it follows from the
+        # wifi case: a p2p ISL grid exercises a different device, a different
+        # channel and (post-#203) the multi-interface next-hop resolution,
+        # whose peer map is populated from received hellos — i.e. from an
+        # ordering that a container-iteration bug could perturb without ever
+        # showing up on a single-interface wifi node.
+        args="--rows=4 --cols=4 --torus=true --flows=2 --time=30 --runs=1"
+        protocols="anthocnet"
+        cmd="isl-grid $args --protocols=$protocols"
+        ;;
+    *)
+        echo "unknown harness '$HARNESS' (want: compare | isl-grid)" >&2
+        exit 2
+        ;;
+esac
 
 # Keep only the summary-table metric rows ("<proto> <number> ..."), the same
 # row pattern paper-benchmark.yml's ##BENCH## awk matches. This drops ./ns3
@@ -39,7 +63,7 @@ filter_rows() {
     awk '$1 ~ /^(anthocnet|aodv|olsr|dsdv)$/ && $2 ~ /^[0-9.]+$/'
 }
 
-echo "[determinism] ./ns3 run \"$cmd\"  (twice; gate: identical metric rows)"
+echo "[determinism:$HARNESS] ./ns3 run \"$cmd\"  (twice; gate: identical metric rows)"
 cd "$NS3DIR"
 
 rows1=
@@ -47,7 +71,7 @@ rows2=
 for i in 1 2; do
     if ! out=$(./ns3 run "$cmd" 2>&1); then
         printf '%s\n' "$out" | tail -n 40
-        echo "FAIL [determinism]: run $i of anthocnet-compare did not run (output tail above)"
+        echo "FAIL [determinism:$HARNESS]: run $i did not run (output tail above)"
         exit 1
     fi
     rows=$(printf '%s\n' "$out" | filter_rows)

--- a/ns3/tools/check-sat-anchors.sh
+++ b/ns3/tools/check-sat-anchors.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Satellite validation-anchor gate (#237): run known-expected ISL-grid
+# scenarios and fail unless the results match values derived *analytically*
+# rather than from a previous run.
+#
+# Usage: check-sat-anchors.sh <ns3-dir> <single-isl|hop-delay> [isl-delay-ms]
+#
+# Why these are stronger than the MANET anchors in check-anchors.sh: those are
+# literature-derived and approximate ("AODV ~90-100%"), because a wifi channel
+# is stochastic. A point-to-point ISL grid with a fixed per-link delay is not —
+# so the expected delivery ratio is exactly 100%, and the expected delay is
+# h*d plus a small bounded serialisation term. A substrate, image or topology
+# bug cannot hide behind "that looks plausible" (cf. #51, where a ~50%
+# single-hop loss silently corrupted every number in the repo until the
+# equivalent MANET anchor caught it).
+#
+# The ns-3 tree must already be configured + built with the anthocnet module's
+# examples enabled (isl-grid builds as part of the module's examples).
+set -euo pipefail
+
+NS3DIR=${1:-}
+ANCHOR=${2:-}
+ISL_MS=${3:-5}
+if [ -z "$NS3DIR" ] || [ -z "$ANCHOR" ]; then
+    echo "usage: $0 <ns3-dir> <single-isl|hop-delay> [isl-delay-ms]" >&2
+    exit 2
+fi
+
+ANCHORS_FILE="$(cd "$(dirname "$0")" && pwd)/anchors.yml"
+
+floor_for() {
+    awk -F': *' -v k="$1" \
+        '$1 == k { print $2 + 0; found = 1 } END { if (!found) exit 1 }' \
+        "$ANCHORS_FILE"
+}
+
+# isl-grid --csv row:
+#   protocol,runs,rows,cols,nodes,links,isl_delay_ms,flows,pdr_pct,delay_ms,...
+# so PDR is field 9 and mean delay field 10.
+csv_field() {  # csv_field <proto> <n>
+    awk -F, -v p="$1" -v n="$2" '$1 == p { v = $n } END { print v }'
+}
+
+case "$ANCHOR" in
+    single-isl)
+        # S1 — two satellites, one ISL, nothing to route around. A
+        # point-to-point link has no contention and no loss model, so anything
+        # below 100% means the stack is broken, not the topology hard. This is
+        # the ISL analogue of check-anchors.sh's single-hop anchor.
+        #
+        # 1x2 open grid = exactly 1 link (AxisLinks(2,false) = 1), asserted by
+        # the example's own CheckTopology (#226).
+        args="--rows=1 --cols=2 --torus=false --flows=1 --time=30 --islDelayMs=$ISL_MS"
+        proto=aodv
+        expect_desc="PDR >= $(floor_for sat_single_isl_pdr_min)"
+        ;;
+    hop-delay)
+        # S2 — the hop-count delay identity, the strongest single number the
+        # satellite harness produces. On a 4x4 torus the wrap makes opposite
+        # corners near neighbours: node 0 (0,0) -> node 15 (3,3) is
+        # min(3, 4-3) = 1 step in each dimension, so h = 2 for both default
+        # flows. With a uniform per-ISL delay d the mean end-to-end delay must
+        # be h*d + s, where s is serialisation/queueing (small, bounded).
+        #
+        # The lower bound is the interesting half: a packet CANNOT arrive
+        # faster than propagation, so delay < h*d is physically impossible and
+        # means the delay is not being applied (the #200 unknown) or the
+        # topology is not what it claims (#226).
+        args="--rows=4 --cols=4 --torus=true --flows=2 --time=30 --islDelayMs=$ISL_MS"
+        proto=anthocnet
+        expect_desc="delay in [h*d, h*d + slack] with h=2, d=$ISL_MS ms"
+        ;;
+    *)
+        echo "unknown anchor '$ANCHOR' (want: single-isl | hop-delay)" >&2
+        exit 2
+        ;;
+esac
+
+cmd="isl-grid --csv --protocols=$proto $args"
+echo "[sat:$ANCHOR] ./ns3 run \"$cmd\"  (gate: $expect_desc)"
+cd "$NS3DIR"
+if ! out=$(./ns3 run "$cmd" 2>&1); then
+    printf '%s\n' "$out" | tail -n 40
+    echo "FAIL [sat:$ANCHOR]: isl-grid did not run (output tail above)"
+    exit 1
+fi
+printf '%s\n' "$out"
+
+pdr=$(printf '%s\n' "$out" | csv_field "$proto" 9)
+delay=$(printf '%s\n' "$out" | csv_field "$proto" 10)
+if [ -z "$pdr" ]; then
+    echo "FAIL [sat:$ANCHOR]: no CSV row for '$proto' — empty result (#28-style silent failure)"
+    exit 1
+fi
+
+case "$ANCHOR" in
+    single-isl)
+        floor=$(floor_for sat_single_isl_pdr_min)
+        if awk -v v="$pdr" -v f="$floor" 'BEGIN { exit (v + 0 >= f + 0) ? 0 : 1 }'; then
+            echo "PASS [sat:single-isl] $proto PDR=$pdr >= $floor (delay=${delay} ms)"
+        else
+            echo "FAIL [sat:single-isl] $proto PDR=$pdr < floor $floor"
+            echo "  A point-to-point ISL is lossless and uncontended, so this floor can only"
+            echo "  regress via the link/IP/app stack or the substrate — not via the protocol."
+            echo "  cf. #51, and see docs/benchmarks/methodology.md 'Satellite validation anchors'."
+            exit 1
+        fi
+        ;;
+    hop-delay)
+        hops=2
+        slack=$(floor_for sat_hop_delay_slack_ms)
+        lo=$(awk -v h="$hops" -v d="$ISL_MS" 'BEGIN { print h * d }')
+        hi=$(awk -v l="$lo" -v s="$slack" 'BEGIN { print l + s }')
+        # Delivery must still be complete, or the delay is an average over a
+        # surviving subset and means nothing.
+        floor=$(floor_for sat_single_isl_pdr_min)
+        if ! awk -v v="$pdr" -v f="$floor" 'BEGIN { exit (v + 0 >= f + 0) ? 0 : 1 }'; then
+            echo "FAIL [sat:hop-delay] $proto PDR=$pdr < $floor — delay average is over a subset"
+            exit 1
+        fi
+        if awk -v v="$delay" -v l="$lo" 'BEGIN { exit (v + 0 >= l + 0) ? 0 : 1 }'; then
+            :
+        else
+            echo "FAIL [sat:hop-delay] delay=${delay} ms < ${lo} ms — FASTER THAN PROPAGATION."
+            echo "  ${hops} hops x ${ISL_MS} ms is a physical lower bound. Below it, either the"
+            echo "  channel delay is not being applied (#200) or the topology is not the"
+            echo "  ${hops}-hop path it claims (#226)."
+            exit 1
+        fi
+        if awk -v v="$delay" -v h="$hi" 'BEGIN { exit (v + 0 <= h + 0) ? 0 : 1 }'; then
+            echo "PASS [sat:hop-delay] delay=${delay} ms in [${lo}, ${hi}] for h=${hops} d=${ISL_MS} (PDR=$pdr)"
+        else
+            echo "FAIL [sat:hop-delay] delay=${delay} ms > ${hi} ms — more than serialisation slack"
+            echo "  above the ${lo} ms propagation floor. Either routing is not taking the"
+            echo "  ${hops}-hop path (torus wrap wrong, or a routing regression), or packets are"
+            echo "  being queued/held — check the hold-time diagnostics."
+            exit 1
+        fi
+        ;;
+esac


### PR DESCRIPTION
Implements the three anchors from #237 that need **no satellite substrate** — so the reference values exist *before* #234's image lands. Without them there is nothing for the substrate image to be compared against later (S6/S7).

## Why

`docs/benchmarks/methodology.md`'s anchor section exists because of #51: the single-hop anchor failing to read ~100% caught a stock 802.11 unicast loss of ~50% per frame that had been corrupting **every number in the repo, for every protocol**, before any multi-hop effect. A new substrate + a new image + a new topology, arriving together, is the same risk class.

## These are stronger in kind than the wifi anchors

The existing anchors are literature-derived and approximate ("AODV ≈ 90–100%") because a wifi channel is stochastic — the best available reference is somebody else's measurement. A point-to-point ISL has **no contention and no loss model**, so expected values are **analytic**:

| Anchor | Configuration | Expected (derived) | Catches |
|---|---|---|---|
| `single-isl` | 2 satellites, 1 ISL, stock AODV | **PDR = 100%** — a p2p link drops nothing | the link/IP/app stack on this device; the #51 lesson |
| `hop-delay` | 4×4 torus, both flows at `h=2`, uniform `d` | **delay ∈ [h·d, h·d + slack]** | topology, delay application **and** routing optimality in one number |
| determinism (`isl-grid` mode) | same seed twice | byte-identical rows | RNG discipline on a different device/channel |

**`hop-delay` is the sharpest number this repo produces.** Its lower bound is *physics*: a packet cannot arrive faster than propagation, so `delay < h·d` is impossible and means either the channel delay isn't applied (#200's load-bearing unknown) or the path isn't the `h`-hop one it claims (#226). The upper bound is nearly as sharp — one extra hop costs a whole `d`, far more than serialisation slack.

On the 4×4 torus the wrap makes opposite corners near neighbours (`min(3, 4−3) = 1` per dimension → `h = 2`), predicting 10 ms at `d = 5`. Measured: **10.39 ms** (#214, CI run 30190452648).

The determinism gate runs on the ISL topology **separately** rather than being assumed to follow from the wifi case — the grid exercises a different device and channel plus the post-#203 multi-interface next-hop resolution, whose peer map is built from received hellos, i.e. an ordering a container-iteration bug could perturb without ever showing on a single-interface wifi node.

## Verification

No ns-3 tree or container runtime here, so I replicated the gate's decision logic in a standalone harness and exercised it against the **real CI CSV row** plus five synthetic defects:

```
bounds: [10, 11.5] for h=2 d=5, pdr floor 99
real CI row (#214, run 30190452648)        pdr=100.0  delay=10.4   -> pass                     OK
delay below propagation (delay unapplied)  pdr=100.0  delay=3.2    -> fail(below-propagation)  OK
delay one extra hop (wrong path/wrap)      pdr=100.0  delay=15.2   -> fail(above-slack)        OK
packets held (queueing)                    pdr=100.0  delay=48.0   -> fail(above-slack)        OK
partial delivery                           pdr=71.4   delay=10.4   -> fail(pdr)                OK
boundary: exactly at propagation floor     pdr=100.0  delay=10.0   -> pass                     OK
boundary: exactly at slack ceiling         pdr=100.0  delay=11.5   -> pass                     OK
```

It passes the real row and **fires on every defect class**, accepting both boundaries exactly. An anchor that only ever passes proves nothing — same discipline as #203 (reverted-fix run) and #226 (broken-wrap run).

## Details

- Thresholds go in the existing `anchors.yml`, not a new file — its own header calls itself the single place to recalibrate. Slack is 1.5 ms, set from the measured 0.39 ms over the floor: room for a slower link or larger packet, still far below the whole `d` an extra hop would cost.
- `check-determinism.sh` gains an optional second arg (`compare` default | `isl-grid`); default behaviour is unchanged.
- Wired into `ci.yml` on the **ns-3.42 leg only**, matching the existing gates and ADR-0015's rule that satellite CI is pinned to one ns-3 version.

## Not in this PR

S3 (delay linearity) and S4 (diameter scaling) follow from the same script with different flags. S6 (image equivalence) and S7 (substrate-presence null) need #234's image and are what will validate *it* — S7 tests ADR-0015's "one binary" premise directly by requiring `isl-grid` to give **identical** numbers with and without a substrate installed.

Refs #237, #233, #214, #226, #200, #51, #59, #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1


---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_