### PR TITLE
fix(benchmarks): catch the metric defects the campaigns exposed, and the gate starvation that hid them

### DIFF
--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -153,7 +153,11 @@ python3 $S results --anchor broch-low-mobility cell.txt   # enforce #59 floor
 `preflight` checks: expected mean node degree (strip-geometry aware) vs the
 ln(n) connectivity threshold, offered load vs the pinned 2 Mbit/s channel
 (#84), `range ≥ area` single-hop degeneracy, short-sim and static-field
-warnings. `results` checks: PDR ∈ [0,100], delay99 ≥ mean delay, negative
+warnings, and the #230 **diversity-window coherence** rule — `--pathWindowS`
+against the `range / (2·speed)` link lifetime, since a window longer than a
+route survives counts route *replacement* as concurrent multipath. That last
+one FAILs the shipped 10 s default at the paper-base knobs, which is where
+#230 should have been caught instead of after a 115-minute campaign. `results` checks: PDR ∈ [0,100], delay99 ≥ mean delay, negative
 metrics, dead cells (#28), the #209 energy invariants (total energy positive
 and finite, energy-per-delivered-packet finite and non-negative — and non-zero
 whenever PDR is, residual energy within [0, initial]; all skipped for inputs
@@ -173,3 +177,42 @@ failed to connect reads as a FAIL rather than as "no multipath"; all skipped for
 inputs predating route-quality instrumentation), and — with `--anchor` — the AODV floors read from
 `ns3/tools/anchors.yml` (never duplicated). A `results` FAIL is a #51-class
 harness regression: fix the harness before trusting any number from that run.
+
+### Testing the gate itself (`test_scenario_check.py`)
+
+```bash
+python3 .claude/skills/benchmark-results/test_scenario_check.py
+```
+
+No pytest, no simulator, ~1 s; runs on every PR from `lint.yml`. Every rule
+gets **two** cases — a crafted row where it must fire and one where it must
+not. The second half is the point: the first cut of #229's queue diagnosis
+keyed on "`drop_queue_pct` is zero" and flagged `anthocnet` and `aodv` rows
+that were accounting correctly. A check that cries wolf gets ignored, and then
+it is not a gate. Fixture values are the real campaign readings, so moving a
+threshold has to confront the observation that set it.
+
+## Adding a metric: the three things that ship with it (#229/#230)
+
+Both the reordering and path-diversity defects were findable **before** any
+campaign, in milliseconds, from a synthetic input. They survived six merged
+campaigns because the metric shipped with a definition and a CSV column and
+nothing that could fail. So a new metric family is not done until it has:
+
+1. **A control arm with a value known a priori** — written down as a *number*,
+   not as "should be small". `path_div_used` had exactly this in prose ("the
+   single-path baselines are the instrumentation's self-check") and still
+   shipped reading 1.428 for OLSR, because prose does not fail.
+2. **An automated assertion of that control** in `scenario_check.py results`,
+   with a case in `test_scenario_check.py` proving it fires and one proving it
+   stays quiet. If the assertion cannot be written, the metric's claim is not
+   yet falsifiable — and that is the finding, before the dispatch.
+3. **A preflight coherence rule** for any parameter the metric depends on,
+   checked against the scenario knobs. `--pathWindowS` is meaningless without
+   the mobility it is compared against; the rule relating the two costs nothing
+   and catches the defect at zero dispatches.
+
+**Order of operations.** Run `preflight` (free), then *one cheap point* —
+`paper-benchmark.yml` at `runs=2`, `time=300`, a `-opt` image — and run
+`scenario_check.py results` on that before committing to a taxonomy sweep. A
+control that reads wrong reads wrong in 20 minutes just as clearly as in 115.

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -41,6 +41,14 @@ ANCHOR_KEY = {"single-hop": "single_hop_pdr_min",
 # reported above it is an instrumentation error, not a long route.
 MAX_PATH_LENGTH = 100
 
+# #230: the baselines all install exactly one route per destination at a time,
+# so their path_div_used is 1.0 by construction. Anything materially above that
+# is the diversity *window* counting route replacement as concurrent multipath —
+# it calibrates the window, and it is the only external check on whether an
+# AntHocNet diversity figure means anything.
+SINGLE_PATH_PROTOS = ("aodv", "olsr", "dsdv")
+SINGLE_PATH_DIV_MAX = 1.10
+
 ROW = re.compile(r"^\s*(?:##BENCH##\s+)?([a-z][\w-]*)((?:\s+[-\d.]+|\s+inf)+)\s*$")
 
 issues = []
@@ -265,6 +273,22 @@ def cmd_results(a):
                 if v is not None and not (math.isfinite(v) and v >= 0.0):
                     report("FAIL", f"{tag}: {k} {r.get(k)} is not a finite "
                                    "non-negative packet count")
+            # #230: mean extent above the reorder-buffer high-water mark is
+            # legal but diagnostic. RFC 4737 tags *every* lower-sequence arrival
+            # behind one early packet, so a single forward route switch produces
+            # a run of "reordered" packets with growing extents while the buffer
+            # depth actually needed stays small. When the mean exceeds the
+            # high-water mark, the extent figure is measuring route flapping,
+            # not sustained multipath disorder — the reading that made AODV
+            # score 8x AntHocNet at dense-small (extent 45.80 vs buf_max 22.6).
+            ext_mean, buf_max = num("reorder_extent_mean"), num("reorder_buf_max")
+            if (ext_mean is not None and buf_max is not None
+                    and ext_mean > buf_max):
+                report("WARN", f"{tag}: reorder_extent_mean {ext_mean} exceeds "
+                               f"reorder_buf_max {buf_max} — the extent here is "
+                               "route flapping (few displacements tagging long "
+                               "runs), not sustained reordering; do not read it "
+                               "as a multipath signal")
             # #215 drop-cause breakdown. The five protocol-agnostic causes are
             # measured from three independent books — FlowMonitor's per-flow
             # drop reasons, the Ipv4L3Protocol Tx/Rx hop tallies and the WifiMac
@@ -313,6 +337,25 @@ def cmd_results(a):
                     report("WARN", f"{tag}: drop causes off by {gap:+.2f} pp "
                                    f"({detail}) — expected only from packets "
                                    "still queued at end of run")
+                # #229: name the usual cause of a shortfall instead of leaving
+                # it as arithmetic. A protocol that buffers packets awaiting a
+                # route sheds them from its *own* queue, and only AntHocNet
+                # routes those discards through the L3 error callback that
+                # Ipv4FlowProbe's DROP_QUEUE / DROP_QUEUE_DISC reasons observe
+                # (those see the interface and qdisc queues, nothing else).
+                # ns-3's dsdv::PacketQueue sheds on MaxQueueLen / MaxQueueTime
+                # silently, so its packets are offered, never delivered, and
+                # attributed nowhere — the 11.46 pp shortfall at dense-small.
+                # Gated on a real shortfall: AntHocNet and AODV also report
+                # queue 0.00 there, but their identities close, so a bare
+                # "queue is zero" heuristic would fire on protocols that are
+                # accounting correctly.
+                if gap < -1.0 and causes["queue"] == 0.0:
+                    report("WARN", f"{tag}: drop_queue_pct is exactly 0 while "
+                                   f"{-gap:.2f} pp is unaccounted — the likely "
+                                   "cause is a routing-layer pending queue that "
+                                   "sheds without an L3 error callback and so "
+                                   "is invisible to the drop probes (#229)")
             # The AntHocNet-only causes are a *sub-breakdown* of drop_route_pct
             # (all three end in the same L3 error callback), never causes on top
             # of it. A mismatch means one pending-queue exit path is unaccounted
@@ -364,6 +407,16 @@ def cmd_results(a):
                     report("FAIL", f"{tag}: path diversity {div} < 1 — a "
                                    "carried destination uses at least one "
                                    "next hop")
+                elif (r["proto"] in SINGLE_PATH_PROTOS
+                        and div > SINGLE_PATH_DIV_MAX):
+                    report("FAIL", f"{tag}: path diversity {div} > "
+                                   f"{SINGLE_PATH_DIV_MAX} for a single-path "
+                                   "protocol — path_div_window_s is longer than "
+                                   "the route lifetime, so route replacement is "
+                                   "being counted as concurrent multipath; "
+                                   "recalibrate the window (#230) before "
+                                   "reading any path_div_* or path_entropy_bits "
+                                   "figure, including AntHocNet's")
             if div_max is not None and div is not None and div_max and div_max < div:
                 report("FAIL", f"{tag}: max path diversity {div_max} < mean "
                                f"path diversity {div}")

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -109,6 +109,31 @@ def cmd_preflight(a):
         report("WARN", "pause >= sim time — the field is static; that is "
                        "the sparse-static regime (a known AntHocNet weak "
                        "spot), not the paper's mobile one")
+    # #230: the diversity window must be short relative to how fast the
+    # topology changes, or a route being *replaced* inside one window reads as
+    # two concurrent paths and path_div_used stops meaning multipath. Two nodes
+    # close at up to 2*speed, so a link survives on the order of
+    # range/(2*speed); a multi-hop route breaks faster still, making this the
+    # generous bound. Skipped on a static field, where nothing churns — which is
+    # exactly why sparse-static was the only scenario whose baselines read ~1.
+    #
+    # This is the rule that would have caught #230 before spending a campaign:
+    # at the paper-base defaults it fires on the shipped 10 s default.
+    if a.pause < a.time and a.speed > 0:
+        churn = a.range / (2 * a.speed)
+        print(f"  path-diversity window {a.pathWindowS}s vs ~{churn:.1f}s "
+              f"link lifetime at {a.speed} m/s over {a.range} m")
+        if a.pathWindowS > churn:
+            report("FAIL", f"pathWindowS={a.pathWindowS}s exceeds the ~"
+                           f"{churn:.1f}s link lifetime — route replacement "
+                           "will be counted as concurrent multipath and "
+                           "path_div_* will not discriminate (#230); lower it "
+                           "before dispatching")
+        elif a.pathWindowS > churn / 2:
+            report("WARN", f"pathWindowS={a.pathWindowS}s is over half the ~"
+                           f"{churn:.1f}s link lifetime — path_div_* will be "
+                           "inflated by route churn; verify the single-path "
+                           "baselines read <=1.05 before quoting it")
     verdict()
 
 
@@ -472,6 +497,8 @@ def main():
     p.add_argument("--pktBytes", type=int, default=64)
     p.add_argument("--pktPerSec", type=float, default=1)
     p.add_argument("--rateMbps", type=float, default=2)
+    # kDefaultPathWindowS in ns3/examples/anthocnet-compare.cc (#217).
+    p.add_argument("--pathWindowS", type=float, default=10)
     r = sub.add_parser("results")
     r.add_argument("files", nargs="+")
     r.add_argument("--anchor", choices=sorted(ANCHOR_KEY))

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -261,9 +261,12 @@ def cmd_results(a):
             n += 1
             tag = f"{r['where']}/{r['proto']}"
 
-            def num(k):
+            # `row=r` binds the current row rather than closing over the loop
+            # variable (ruff B023). Every call happens inside this iteration so
+            # the behaviour is unchanged, but the late-binding footgun is gone.
+            def num(k, row=r):
                 try:
-                    return float(r.get(k))
+                    return float(row.get(k))
                 except (TypeError, ValueError):
                     return None
             pdr, delay, d99 = num("pdr"), num("delay"), num("delay99")

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -134,6 +134,37 @@ def cmd_preflight(a):
                            f"{churn:.1f}s link lifetime — path_div_* will be "
                            "inflated by route churn; verify the single-path "
                            "baselines read <=1.05 before quoting it")
+        # #230: the other end of the same squeeze. A (node, destination,
+        # window) cell can only report diversity > 1 if at least two packets
+        # land in it, so shortening the window to escape churn eventually
+        # forces every cell to exactly 1.0 — measured: at 0.5-2 s on paper-base
+        # all four protocols read 1.000-1.002, AntHocNet included. Sampling is
+        # per flow, so packets-per-cell is bounded above by pktPerSec*window.
+        samples = a.pktPerSec * a.pathWindowS
+        print(f"  ~{samples:.1f} packet(s) per diversity cell "
+              f"({a.pktPerSec}/s x {a.pathWindowS}s)")
+        if samples < 2.0:
+            report("FAIL", f"pathWindowS={a.pathWindowS}s at {a.pktPerSec} "
+                           f"pkt/s gives ~{samples:.1f} packets per cell — a "
+                           "cell needs >=2 to report diversity above 1, so "
+                           "path_div_used is pinned at 1.0 for every protocol "
+                           "(#230)")
+        elif samples < 4.0:
+            # Measured, not guessed: paper-base at 1 pkt/s x 2 s (exactly the
+            # 2-sample floor) reads anthocnet 1.002 and aodv 1.002 — the floor
+            # is necessary but nowhere near sufficient, because a cell holding
+            # two packets can only ever report 1.0 or 2.0.
+            report("WARN", f"~{samples:.1f} packets per diversity cell is at "
+                           "the floor — measured at paper-base, 2 packets/cell "
+                           "gave anthocnet 1.002 vs aodv 1.002, i.e. no "
+                           "separation. Treat path_div_* as underpowered here "
+                           "(#230)")
+        if a.pathWindowS > churn and samples < 4.0:
+            report("FAIL", "no usable pathWindowS at these knobs: churn needs "
+                           f"<={churn:.1f}s, adequate sampling needs "
+                           f">={4.0 / a.pktPerSec:.1f}s. Raise pktPerSec or "
+                           "measure diversity per-packet instead of "
+                           "per-window (#230)")
     verdict()
 
 

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -252,10 +252,46 @@ def _preflight_fires():
     expect("link lifetime" in out, "preflight-fires", out)
 
 
-@case("#230 preflight passes a short window")
+@case("#230 preflight downgrades a mid window to WARN, not clean")
 def _preflight_quiet():
+    # 2 s clears the churn bound but sits exactly on the 2-packets/cell floor.
+    # It must not FAIL (the window itself is fine) and must not pass silently
+    # (the measurement says it does not separate).
     levels, out = run_preflight(pathWindowS=2.0)
-    expect(levels == [], "preflight-quiet", f"fired at 2s\n{out}")
+    expect("FAIL" not in levels, "preflight-quiet",
+           f"2s should not FAIL on churn\n{out}")
+    expect("WARN" in levels, "preflight-quiet",
+           f"2s passed clean despite being at the sampling floor\n{out}")
+
+
+@case("#230 preflight FAILs a window too short to sample")
+def _preflight_starved():
+    # 0.5 s at 1 pkt/s = 0.5 packets/cell; a cell needs >=2 to exceed 1.0.
+    # Measured: all four protocols read 1.000-1.001 at this window.
+    levels, out = run_preflight(pathWindowS=0.5)
+    expect("FAIL" in levels, "preflight-starved",
+           f"0.5s did not FAIL on sampling\n{out}")
+    expect("per cell" in out, "preflight-starved", out)
+
+
+@case("#230 preflight flags every window at the paper's 1 pkt/s")
+def _preflight_no_window():
+    # The squeeze: churn caps the window at ~7.5 s, sampling floors it at 4 s,
+    # and the 2 s midpoint measured anthocnet 1.002 vs aodv 1.002. Every window
+    # in the swept range must be flagged, or the calibration looks solvable
+    # when it is not.
+    for w in (0.5, 1.0, 2.0, 5.0, 10.0):
+        levels, out = run_preflight(pathWindowS=w)
+        expect(levels != [], "preflight-no-window",
+               f"window {w}s passed clean at 1 pkt/s\n{out}")
+
+
+@case("#230 preflight passes once the rate supports the window")
+def _preflight_rate_fixes():
+    # Raising the offered rate is the escape the FAIL points at.
+    levels, out = run_preflight(pathWindowS=2.0, pktPerSec=4.0)
+    expect(levels == [], "preflight-rate",
+           f"2s at 4 pkt/s should be clean, got {levels}\n{out}")
 
 
 @case("#230 preflight skips a static field")

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -26,18 +26,36 @@ Run: python3 test_scenario_check.py     (no pytest dependency; exits non-zero
 
 import argparse
 import contextlib
+import importlib.util
 import io
 import os
 import sys
 import tempfile
 
-# Import scenario_check from *source* every time. Without this a stale
-# __pycache__ entry can shadow an edited rule and the suite reports a pass (or
-# a phantom failure) for code that is not the code on disk — hit once while
-# writing these very cases.
-sys.dont_write_bytecode = True
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import scenario_check as sc  # noqa: E402
+
+def _load_scenario_check():
+    """Load scenario_check.py from source, next to this file.
+
+    Deliberately not a module-level `import`. Two reasons, both learned the
+    hard way:
+
+    - A stale `__pycache__` entry can shadow an edited rule, so the suite
+      reports a pass (or a phantom failure) for code that is not the code on
+      disk. `exec_module` on the file always runs what is there.
+    - The `sys.path` juggling an import would need puts a statement before the
+      import, which is E402, which needs a `noqa`, whose necessity then depends
+      on how ruff resolves config — it differed between this sandbox and CI on
+      0.16.0, failing the lint either way round.
+    """
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "scenario_check.py")
+    spec = importlib.util.spec_from_file_location("scenario_check", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sc = _load_scenario_check()
 
 # A row that must pass every rule cleanly. Deliberately an `anthocnet` row with
 # a closing identity (99.98 at dense-small is the real measured value), so any

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Self-test for scenario_check.py.
+
+`scenario_check.py` is the gate that decides whether a campaign's numbers may
+be read, quoted or published. Until this file existed nothing tested it, and
+the consequences showed up twice in one afternoon:
+
+  - #230's path-diversity defect sat in six merged campaigns because no rule
+    asserted the one thing the metric's own docs called its self-check (the
+    single-path baselines must read ~1).
+  - The first cut of #229's queue-drop diagnosis fired on `anthocnet` and
+    `aodv` rows whose accounting was correct, because it keyed on "queue is
+    zero" instead of on an actual shortfall.
+
+So each rule gets two cases: one crafted row where it **must** fire, and one
+where it **must not**. The second half is the half that catches over-firing,
+which is what makes a check untrustworthy and then ignored.
+
+Numbers in the fixtures are the real campaign values (runs 30201145972 /
+30201179429) wherever a rule was written in response to a real reading, so a
+change in threshold has to confront the observation that motivated it.
+
+Run: python3 test_scenario_check.py     (no pytest dependency; exits non-zero
+                                         on the first failure)
+"""
+
+import argparse
+import contextlib
+import io
+import os
+import sys
+import tempfile
+
+# Import scenario_check from *source* every time. Without this a stale
+# __pycache__ entry can shadow an edited rule and the suite reports a pass (or
+# a phantom failure) for code that is not the code on disk — hit once while
+# writing these very cases.
+sys.dont_write_bytecode = True
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import scenario_check as sc  # noqa: E402
+
+# A row that must pass every rule cleanly. Deliberately an `anthocnet` row with
+# a closing identity (99.98 at dense-small is the real measured value), so any
+# rule that fires here is over-firing on correct data.
+CLEAN = {
+    "kind": "scenario", "group": "taxonomy", "x": "paper-base",
+    "scenario": "paper-base", "class": "sparse / mobile",
+    "protocol": "anthocnet", "runs": "2", "nNodes": "50", "areaX": "1500",
+    "speed": "20", "pause": "30", "flows": "20", "propagation": "range",
+    "pdr_pct": "89.4", "delay_ms": "40.0", "delay99_ms": "200.0",
+    "throughput_kbps": "9.0", "nrl": "2.0", "jitter_ms": "10.0",
+    "delay_off50_ms": "30.0", "delay_off90_ms": "90.0",
+    "pdr_sd": "1.0", "delay_sd": "1.0", "delay99_sd": "1.0", "nrl_sd": "0.1",
+    "nrl_bytes": "100.0",
+    "energy_j": "500.0", "energy_per_pkt_j": "0.01",
+    "energy_res_min_j": "4500.0", "energy_res_mean_j": "4600.0",
+    "energy_res_sd_j": "10.0", "energy_init_j": "5000.0",
+    "first_death_s": "-1",
+    "reorder_ratio": "0.0003", "reorder_ratio_max": "0.0065",
+    "reorder_extent_mean": "0.20", "reorder_extent_max": "1.0",
+    "reorder_buf_max": "13.4",
+    "drop_route_pct": "2.97", "drop_queue_pct": "1.50", "drop_mac_pct": "3.00",
+    "drop_chan_pct": "3.10", "drop_ttl_pct": "0.03",
+    "drop_setup_pct": "0.50", "drop_reconv_pct": "2.40",
+    "drop_repair_pct": "0.07",
+    "path_hops_mean": "2.5", "path_hops_max": "6.0",
+    "path_div_used": "1.303", "path_div_max": "5.0",
+    "path_entropy_bits": "0.29", "path_div_window_s": "10.0",
+    "jain_pkts": "0.9",
+}
+
+
+def run_results(**overrides):
+    """Check one row (CLEAN + overrides); return the list of reported levels."""
+    row = dict(CLEAN, **overrides)
+    text = ",".join(row) + "\n" + ",".join(str(v) for v in row.values()) + "\n"
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        sc.issues = []
+        args = argparse.Namespace(files=[path], anchor=None)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            try:
+                sc.cmd_results(args)
+            except SystemExit:
+                pass
+        return list(sc.issues), out.getvalue()
+    finally:
+        os.unlink(path)
+
+
+def run_preflight(**overrides):
+    kw = {"nodes": 50, "areaX": 1500.0, "areaY": 300.0, "range": 300.0,
+          "time": 300.0, "pause": 30.0, "speed": 20.0, "flows": 20,
+          "pktBytes": 64, "pktPerSec": 1.0, "rateMbps": 2.0,
+          "pathWindowS": 10.0}
+    kw.update(overrides)
+    sc.issues = []
+    with contextlib.redirect_stdout(io.StringIO()) as out:
+        try:
+            sc.cmd_preflight(argparse.Namespace(**kw))
+        except SystemExit:
+            pass
+    return list(sc.issues), out.getvalue()
+
+
+CASES = []
+
+
+def case(name):
+    def deco(fn):
+        CASES.append((name, fn))
+        return fn
+    return deco
+
+
+def expect(cond, name, detail):
+    if not cond:
+        print(f"FAIL {name}: {detail}")
+        sys.exit(1)
+
+
+# --- the clean row -----------------------------------------------------------
+
+@case("clean anthocnet row reports nothing")
+def _clean():
+    levels, out = run_results()
+    expect(levels == [], "clean", f"expected no reports, got {levels}\n{out}")
+
+
+# --- #230 path diversity -----------------------------------------------------
+
+@case("#230 single-path baseline above 1.10 FAILs")
+def _div_fires():
+    # olsr / heavy-load, the worst real reading of the campaign.
+    levels, out = run_results(protocol="olsr", path_div_used="1.428")
+    expect("FAIL" in levels, "div-fires", f"no FAIL for olsr div 1.428\n{out}")
+    expect("single-path protocol" in out, "div-fires",
+           f"FAIL did not name the cause\n{out}")
+
+
+@case("#230 single-path baseline at 1.004 passes")
+def _div_quiet_baseline():
+    # olsr / sparse-static — the churn-free control, the one row that already
+    # reads correctly. If the threshold ever creeps below this the calibration
+    # target becomes unreachable.
+    levels, out = run_results(protocol="olsr", path_div_used="1.004")
+    expect(levels == [], "div-quiet", f"fired on the good control\n{out}")
+
+
+@case("#230 rule does not apply to anthocnet")
+def _div_quiet_anthocnet():
+    # AntHocNet is *supposed* to exceed 1; flagging it would invert the rule.
+    levels, out = run_results(protocol="anthocnet", path_div_used="1.512")
+    expect(levels == [], "div-anthocnet", f"fired on anthocnet\n{out}")
+
+
+# --- #230 reordering extent --------------------------------------------------
+
+@case("#230 extent above buffer high-water mark WARNs")
+def _extent_fires():
+    # aodv / dense-small: extentMean 45.8 vs bufMax 22.6.
+    levels, out = run_results(protocol="aodv", path_div_used="1.05",
+                              reorder_extent_mean="45.8",
+                              reorder_extent_max="60.0",
+                              reorder_buf_max="22.6")
+    expect(levels == ["WARN"], "extent-fires",
+           f"expected exactly one WARN, got {levels}\n{out}")
+    expect("route flapping" in out, "extent-fires",
+           f"WARN did not name the mechanism\n{out}")
+
+
+@case("#230 extent below buffer high-water mark is quiet")
+def _extent_quiet():
+    levels, out = run_results(reorder_extent_mean="2.03",
+                              reorder_buf_max="973.8")
+    expect(levels == [], "extent-quiet", f"fired on a sane row\n{out}")
+
+
+# --- #229 drop accounting ----------------------------------------------------
+
+@case("#229 identity shortfall FAILs and names the queue cause")
+def _drop_fires():
+    # dsdv / dense-small: 22.2 + 0.15 + 0 + 52.37 + 13.59 + 0.23 = 88.54.
+    levels, out = run_results(
+        protocol="dsdv", pdr_pct="22.2", path_div_used="1.05",
+        drop_route_pct="0.15", drop_queue_pct="0.00", drop_mac_pct="52.37",
+        drop_chan_pct="13.59", drop_ttl_pct="0.23",
+        drop_setup_pct="", drop_reconv_pct="", drop_repair_pct="",
+        reorder_extent_mean="0.0", reorder_buf_max="0.6")
+    expect("FAIL" in levels, "drop-fires", f"identity did not FAIL\n{out}")
+    expect("WARN" in levels, "drop-fires",
+           f"shortfall carried no queue diagnosis\n{out}")
+    expect("error callback" in out, "drop-fires",
+           f"diagnosis did not name the mechanism\n{out}")
+
+
+@case("#229 queue diagnosis does not fire when the identity closes")
+def _drop_quiet_when_balanced():
+    # This is the over-firing bug the first cut of the rule had: anthocnet and
+    # aodv both read drop_queue_pct 0.00 at dense-small while accounting
+    # correctly (99.98 and 99.33). Keying on "queue is zero" flags them.
+    levels, out = run_results(
+        protocol="anthocnet", pdr_pct="42.1", path_div_used="1.257",
+        drop_route_pct="55.91", drop_queue_pct="0.00", drop_mac_pct="0.54",
+        drop_chan_pct="1.42", drop_ttl_pct="0.00",
+        drop_setup_pct="4.58", drop_reconv_pct="50.23",
+        drop_repair_pct="1.12",
+        reorder_extent_mean="5.49", reorder_buf_max="151.0")
+    expect(levels == [], "drop-quiet",
+           f"fired on a correctly-accounted row: {levels}\n{out}")
+
+
+@case("#229 sub-breakdown is checked against its parent, not added to it")
+def _sub_breakdown():
+    # setup+reconv+repair must reconstruct drop_route_pct. Breaking one term
+    # must WARN; the identity itself must stay clean, proving the three are
+    # never summed into it (the ~156% double-count).
+    levels, out = run_results(drop_setup_pct="0.50", drop_reconv_pct="0.10",
+                              drop_repair_pct="0.07")
+    expect(levels == ["WARN"], "sub-breakdown",
+           f"expected one WARN for the broken partition, got {levels}\n{out}")
+    expect("not attributed" in out, "sub-breakdown", out)
+
+
+# --- pre-instrumentation inputs ---------------------------------------------
+
+@case("rows without the new columns skip every new rule")
+def _absent_columns():
+    blank = {k: "" for k in
+             ("reorder_ratio", "reorder_ratio_max", "reorder_extent_mean",
+              "reorder_extent_max", "reorder_buf_max", "drop_route_pct",
+              "drop_queue_pct", "drop_mac_pct", "drop_chan_pct",
+              "drop_ttl_pct", "drop_setup_pct", "drop_reconv_pct",
+              "drop_repair_pct", "path_hops_mean", "path_hops_max",
+              "path_div_used", "path_div_max", "path_entropy_bits",
+              "jain_pkts", "energy_j", "energy_per_pkt_j",
+              "energy_res_min_j", "energy_res_mean_j", "energy_init_j")}
+    levels, out = run_results(**blank)
+    expect(levels == [], "absent-columns",
+           f"a rule fired on a pre-instrumentation row\n{out}")
+
+
+# --- #230 preflight ----------------------------------------------------------
+
+@case("#230 preflight FAILs the shipped 10s window at paper-base")
+def _preflight_fires():
+    levels, out = run_preflight()
+    expect("FAIL" in levels, "preflight-fires",
+           f"the 10s default did not FAIL\n{out}")
+    expect("link lifetime" in out, "preflight-fires", out)
+
+
+@case("#230 preflight passes a short window")
+def _preflight_quiet():
+    levels, out = run_preflight(pathWindowS=2.0)
+    expect(levels == [], "preflight-quiet", f"fired at 2s\n{out}")
+
+
+@case("#230 preflight skips a static field")
+def _preflight_static():
+    levels, out = run_preflight(pause=900.0, time=300.0, speed=1.0)
+    expect("FAIL" not in levels, "preflight-static",
+           f"window rule fired on a static field\n{out}")
+
+
+def main():
+    for name, fn in CASES:
+        fn()
+        print(f"ok   {name}")
+    print(f"\n{len(CASES)} cases passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,6 +12,11 @@ name: Benchmarks
 on:
   push:
     branches: [main, master]   # both, so it survives the default-branch rename
+  # Backstop. The push trigger alone is not enough: see the concurrency note
+  # below. A daily run bounds how stale the published table can get at 24 h,
+  # whatever the merge cadence.
+  schedule:
+    - cron: '17 4 * * *'
   workflow_dispatch:
 
 # Needed to push the regenerated table + charts back to the branch; packages to
@@ -20,9 +25,23 @@ permissions:
   contents: write
   packages: read
 
-# One benchmark at a time; newer pushes supersede older queued runs.
+# One benchmark at a time; newer pushes supersede older queued runs -- for a
+# *push*, the latest merge is the only state worth publishing, so cancelling is
+# right and queueing would just build a backlog of tables nobody reads.
+#
+# But the event name is part of the group on purpose. With a single group,
+# cancel-in-progress silently starves the refresh whenever merges arrive faster
+# than the job takes: each push kills the run in flight, and the table simply
+# stops regenerating. That happened -- eight merges landed between 07:43 and
+# 17:50 UTC on 2026-07-26 and not one produced a refresh commit, so the
+# published numbers sat on the far side of a shared-adapter change (#224) with
+# nothing measuring it. Nothing failed; a cancelled run is not a failed run,
+# which is exactly why it went unnoticed.
+#
+# Separating the groups means the scheduled backstop above cannot be cancelled
+# by merge traffic, so the table always refreshes at least daily.
 concurrency:
-  group: benchmarks-${{ github.ref }}
+  group: benchmarks-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,17 @@ jobs:
         # deliberately, fixing new findings in the same PR.
         run: pip install 'ruff==0.16.0'
       - name: Lint
-        run: ruff check ns3/tools
+        # The skill dir is listed file-by-file on purpose: bench_parse.py and
+        # sweep_summary.py predate this and carry E701s that are not this
+        # change's to fix. Add new skill scripts here as they land.
+        run: |
+          ruff check ns3/tools \
+            .claude/skills/benchmark-results/scenario_check.py \
+            .claude/skills/benchmark-results/test_scenario_check.py
+      - name: Benchmark-gate self-test
+        # scenario_check.py decides whether a campaign's numbers may be read or
+        # published, and it was itself untested until #229/#230 showed what that
+        # costs: a metric can ship six merged campaigns' worth of numbers while
+        # failing the self-check its own documentation defines. Cheap (no
+        # simulator, no network, ~1 s) and it runs on every PR.
+        run: python3 .claude/skills/benchmark-results/test_scenario_check.py

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -185,6 +185,19 @@ jobs:
           # binaries / the baselines harness — means-only block stays valid.
           grep '^##RUN##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
+          # the *only* place the #209/#212/#215/#217 metric families appear in a
+          # single-point run — the fixed-width table cannot carry them (its field
+          # positions are a parsing contract) and the CSV only exists for
+          # scenario-matrix. They were therefore unreachable from a cheap tail:
+          # this step's own script echo is ~35 lines, so reaching '# paths' cost
+          # tail_lines=121 and ~8k tokens per point, against ~300 for the
+          # ##BENCH## block. That made the #230 window calibration — five points,
+          # read only from '# paths' — 40x more expensive than the runs it was
+          # reading. Re-emit them last so one small tail carries everything.
+          grep '^# \(paths\|energy\|drops\|stddev\|reorder\) ' \
+            "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           cat "$GITHUB_WORKSPACE/bench-rows.txt"
           # #131: sim cost — one process-wide line (anthocnet-compare runs all
           # protocols in one process, hence proto field "all"):

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -138,6 +138,38 @@ wrong (a drop path that fires no error callback, a trace hook that did not
 connect on this ns-3 release, a cause counted twice) and every per-cause
 conclusion is unsafe until it is fixed.
 
+**The three AntHocNet-only columns are a sub-breakdown of `drop_route_pct`, not
+causes on top of it.** `drop_setup_pct + drop_reconv_pct + drop_repair_pct`
+partitions `drop_route_pct`: all three exit paths end in the same L3 error
+callback, so the parent already contains them. Adding them to the identity
+double-counts route failures and manufactures a ~156 % total out of a correct
+breakdown — a mistake made once while reading these very columns
+([#229](https://github.com/danieljoppi/AntHocNet/issues/229)). The identity has
+**five** terms plus PDR. `scenario_check.py` cross-checks the partition
+separately (WARN if the three do not reconstruct their parent within 1 pp).
+
+#### What is measurable, per protocol
+
+`drop_queue_pct` comes from `Ipv4FlowProbe`'s `DROP_QUEUE` / `DROP_QUEUE_DISC`
+reasons, which observe the **interface and qdisc queues only**. A routing
+protocol's own pending queue — the buffer holding packets awaiting a route — is
+invisible to them unless the protocol reports its discards through an L3 error
+callback.
+
+| Protocol | Routing-layer pending-queue drops |
+|---|---|
+| **anthocnet** | **Counted.** They run through the error callback, so they land in `DROP_NO_ROUTE` and hence in `drop_route_pct` (further split by the three sub-columns above). This is why AntHocNet's identity closes to within 0.06 pp on every scenario. |
+| **aodv** | Counted, same mechanism. |
+| **olsr** | Not applicable — OLSR is proactive and does not buffer awaiting a route. |
+| **dsdv** | **Not counted.** ns-3's `dsdv::PacketQueue` sheds on `MaxQueueLen` / `MaxQueueTime` without an error callback, so those packets are offered, never delivered, and attributed to no cause. `drop_queue_pct` reads a confident `0.00` on all six scenarios. |
+
+The consequence is bounded but real: it costs **11.46 pp** of the DSDV identity
+at `dense-small` (the most congested scenario, so the most buffering) and
+≤ 0.73 pp elsewhere. **Do not include DSDV in a cross-protocol drop-cause
+comparison** until [#229](https://github.com/danieljoppi/AntHocNet/issues/229)
+closes. DSDV's aggregate metrics — PDR, delay, NRL — never depended on the
+breakdown and are unaffected.
+
 ### Caveats
 
 - **NS-3 only.** The NS-2 adapter has no equivalent instrumentation; see
@@ -242,6 +274,28 @@ not a blank column.
   a second column is needed.
 
 ### Caveats (route quality)
+
+> **`path_div_*` and `path_entropy_bits` are not publishable at the current
+> default window.** The single-path baselines are this metric's self-check, and
+> they fail it. OLSR installs exactly one route per destination and so must read
+> `path_div_used` ≈ 1.000; on the first full campaign it read **1.428** at
+> `heavy-load`, 1.383 at `high-mobility` and 1.344 at `paper-base`. AntHocNet's
+> whole range (1.225–1.512) sits *inside* OLSR's.
+>
+> The cause is the window, not the counter: `path_div_window_s` defaults to
+> **10 s**, which is longer than a route survives under mobility, so a single
+> route being *replaced* is counted as two concurrent paths. `sparse-static` is
+> the control that proves it — the only scenario with no route churn, and the
+> only one where the baseline reads ≈ 1 (olsr 1.004) and the separation from
+> AntHocNet (1.225) is real.
+>
+> `--pathWindowS` already exists as a CLI knob; the window needs calibrating to
+> the largest value at which all three single-path baselines read ≤ 1.05.
+> `scenario_check.py results` now **FAILs** a single-path protocol reading above
+> 1.10, so this cannot be forgotten. Tracked as
+> [#230](https://github.com/danieljoppi/AntHocNet/issues/230). Until it closes,
+> read `path_hops_*` and `jain_pkts` (unaffected) and treat the diversity and
+> entropy columns as uncalibrated.
 
 - **Reactive protocols read one hop high on route-discovery packets.** A
   protocol with no route yet bounces the packet through the loopback device to
@@ -438,6 +492,42 @@ Two arms should read ≈ 0 and are the reason to believe the AntHocNet number:
 Neither is expected to be exactly zero — a route change can hand consecutive
 packets to paths of different length under any protocol — but both should be
 small next to the multipath figure.
+
+#### What the self-check actually returned
+
+The floor half passes: on the stable-field scenarios (`sparse-static`,
+`paper-base`) every single-path baseline reads **exactly 0.0000** at 93–100 %
+PDR. Loss is correctly *not* counted as reordering and the sequence plumbing is
+sound.
+
+The discrimination half fails. Pooled over the six scenarios, `reorder_ratio`
+reads **anthocnet max 0.0208** against **aodv max 0.0243** — AntHocNet does not
+exceed the single-path control. At `dense-small` it is inverted outright:
+
+| | reorder_ratio | reorder_extent_mean | reorder_buf_max |
+|---|---:|---:|---:|
+| anthocnet | 0.0030 | 5.49 | **151.0** |
+| aodv | **0.0243** | **45.80** | 22.6 |
+
+**Why: `reorder_ratio` and `reorder_extent_*` measure route flapping, not
+concurrent paths.** RFC 4737 tags *every* subsequent lower-sequence arrival
+after one early packet. On the arrival order `1, 10, 2, 3, 4, 5`, packets 2–5
+are each `Type-P-Reordered` with extents 1, 2, 3, 4 — a mean extent of 2.5 from
+a **single** displacement. That is RFC-correct and the implementation is right;
+it simply makes the statistic a function of how often a route switches
+*forward*. AODV re-discovers constantly under `dense-small` congestion, and each
+re-discovery onto a shorter path is one such event. The fingerprint is a mean
+extent above the buffer high-water mark (45.80 vs 22.6) — impossible unless few
+displacements are tagging long runs behind them, and now a `scenario_check.py`
+WARN.
+
+**`reorder_buf_max` is the honest multipath signal.** It is the receiver-side
+buffer depth concurrent paths actually impose, and it separates AntHocNet from
+every baseline on **6 of 6** scenarios (anthocnet 12.6–973.8, baselines
+0.0–22.6, largest in every scenario). Prefer it. Quote `reorder_ratio` or
+`reorder_extent_*` only alongside the caveat above —
+[#230](https://github.com/danieljoppi/AntHocNet/issues/230) tracks the
+documentation and check work.
 
 ### Caveats
 

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -289,13 +289,40 @@ not a blank column.
 > only one where the baseline reads ≈ 1 (olsr 1.004) and the separation from
 > AntHocNet (1.225) is real.
 >
-> `--pathWindowS` already exists as a CLI knob; the window needs calibrating to
-> the largest value at which all three single-path baselines read ≤ 1.05.
-> `scenario_check.py results` now **FAILs** a single-path protocol reading above
-> 1.10, so this cannot be forgotten. Tracked as
-> [#230](https://github.com/danieljoppi/AntHocNet/issues/230). Until it closes,
-> read `path_hops_*` and `jain_pkts` (unaffected) and treat the diversity and
-> entropy columns as uncalibrated.
+> **The window was swept, and no value works.** Five single points on the
+> paper-base knobs, identical config, `--pathWindowS` the only variable:
+>
+> | window | anthocnet | aodv | olsr | dsdv |
+> |---:|---:|---:|---:|---:|
+> | 0.5 s | 1.001 | 1.000 | 1.000 | 1.000 |
+> | 1.0 s | 1.001 | 1.000 | 1.000 | 1.000 |
+> | 2.0 s | 1.002 | 1.002 | 1.000 | 1.001 |
+> | 5.0 s | 1.147 | 1.157 | **1.164** | 1.066 |
+> | 10.0 s | 1.291 | 1.311 | **1.327** | 1.167 |
+>
+> Below 2 s every protocol reads ≈ 1.000 — AntHocNet included, so there is no
+> signal to have. At 5 s and above the baselines are already past 1.05 **and
+> OLSR outranks AntHocNet**. There is no window in between: at 2 s AntHocNet
+> ties AODV to three decimals.
+>
+> **Root cause: the metric is sample-starved at the paper's traffic rate, not
+> merely mis-windowed.** A (node, destination, window) cell can only report
+> diversity above 1 if at least two packets land in it, so packets-per-cell is
+> bounded by `pktPerSec × window` — 1 × 2 s = 2 at paper-base, the bare floor,
+> where a cell can only ever read 1.0 or 2.0. Shortening the window to escape
+> route churn starves the sample; lengthening it to gather samples lets churn
+> dominate. The two bounds cross, which is why the sweep has no solution.
+>
+> `kDefaultPathWindowS` is therefore **left at 10 s** — no other value is
+> better, and moving it would imply the problem was solved. The fix is to raise
+> the offered rate for diversity measurement or to count concurrent next hops
+> per packet-pair rather than per time window;
+> [#230](https://github.com/danieljoppi/AntHocNet/issues/230) tracks it.
+> `scenario_check.py` now flags **every** window at 1 pkt/s — FAIL below the
+> 2-packet floor, WARN at it, WARN/FAIL past the churn bound — and `preflight`
+> refuses the dispatch before a run is spent. Until it closes, read
+> `path_hops_*` and `jain_pkts` (unaffected) and treat the diversity and
+> entropy columns as not yet measuring what they claim.
 
 - **Reactive protocols read one hop high on route-discovery packets.** A
   protocol with no route yet bounces the packet through the loopback device to


### PR DESCRIPTION
The first full campaigns on the #209/#212/#215/#217 instrumentation
([30201145972](https://github.com/danieljoppi/AntHocNet/actions/runs/30201145972),
[30201179429](https://github.com/danieljoppi/AntHocNet/actions/runs/30201179429))
were checked against the self-checks each metric family defines for itself.
**Energy passed. The other three did not**, in three different ways, and
`scenario_check.py` caught only one of them.

No simulator or protocol code changes here. This is checks, tests, docs and CI.

---

## 1. Path diversity does not measure multipath (#230) — now a FAIL

The single-path baselines are this metric's own documented self-check. OLSR
installs exactly one route per destination and must read `path_div_used` ≈
1.000. It read **1.428** at `heavy-load`, 1.383 at `high-mobility`, 1.344 at
`paper-base` — and AntHocNet's entire range (1.225–1.512) sits *inside* OLSR's.

I swept `--pathWindowS` to recalibrate it. **There is no working value.** Five
single points, paper-base knobs, `3.42-opt`, `runs=2`, `time=300`, window the
only variable:

| window | anthocnet | aodv | olsr | dsdv | baselines ≤1.05? | separates? |
|---:|---:|---:|---:|---:|---|---|
| 0.5 s | 1.001 | 1.000 | 1.000 | 1.000 | yes | no |
| 1.0 s | 1.001 | 1.000 | 1.000 | 1.000 | yes | no |
| 2.0 s | 1.002 | 1.002 | 1.000 | 1.001 | yes | no — ties AODV exactly |
| 5.0 s | 1.147 | 1.157 | **1.164** | 1.066 | no | inverted |
| 10.0 s | 1.291 | 1.311 | **1.327** | 1.167 | no | inverted |

Runs [30211589022](https://github.com/danieljoppi/AntHocNet/actions/runs/30211589022)
(0.5 s), [30212796513](https://github.com/danieljoppi/AntHocNet/actions/runs/30212796513),
[30212797207](https://github.com/danieljoppi/AntHocNet/actions/runs/30212797207),
[30212800114](https://github.com/danieljoppi/AntHocNet/actions/runs/30212800114),
[30212800758](https://github.com/danieljoppi/AntHocNet/actions/runs/30212800758).
The `##BENCH##` / `# drops` / `# energy` / `# reorder` lines are **bit-identical
across all five**, confirming same binary, same seeds, and that `--pathWindowS`
touches nothing but the diversity aggregation.

**Root cause is sample starvation, not the window.** A `(node, destination,
window)` cell can only report diversity above 1 if ≥2 packets land in it, so
packets-per-cell is bounded by `pktPerSec × window` — `1 × 2 s = 2` at
paper-base, the bare floor, where a cell can only read 1.0 or 2.0. Shortening
the window to escape route churn starves the sample; lengthening it to gather
samples lets churn dominate. **The two bounds cross.**

`kDefaultPathWindowS` is deliberately **left at 10 s**: nothing measured
better, and changing it would imply the problem was solved.

- `results`: FAIL a single-path protocol reading above 1.10 — fires on 17 of
  24 campaign rows.
- `preflight`: bounds the parameter from both sides — FAIL below the 2-packet
  floor, WARN at it, WARN/FAIL past the `range/(2·speed)` churn bound, plus a
  combined FAIL naming both constraints when they cross. Every window in the
  swept range is flagged at 1 pkt/s; `--pktPerSec 4` clears it, which is the
  escape the message points at.

## 2. Reordering measures route flapping (#230) — now a WARN

`reorder_ratio` reads anthocnet max 0.0208 against **aodv max 0.0243**. At
`dense-small` AODV reads 8× the ratio and 8× the mean extent of the multipath
protocol it is meant to contrast with.

The implementation is RFC 4737-correct; the statistic is the problem. RFC 4737
tags *every* subsequent lower-sequence arrival after one early packet — arrival
order `1,10,2,3,4,5` yields four reordered packets with extents 1,2,3,4 from a
**single** displacement. The fingerprint is a mean extent above the
reorder-buffer high-water mark (45.80 vs 22.6 for AODV at `dense-small`), now a
WARN.

`reorder_buf_max` is the honest multipath signal and separates on **6/6**
scenarios (anthocnet 12.6–973.8, baselines 0.0–22.6). The docs now say so.

## 3. Drop accounting — a diagnosis, and a correction

The five-cause identity already caught `dsdv`/`dense-small` at 88.54 (−11.46
pp). Root cause: `drop_queue_pct` comes from `Ipv4FlowProbe`'s `DROP_QUEUE` /
`DROP_QUEUE_DISC`, which observe the interface and qdisc queues only. ns-3's
`dsdv::PacketQueue` sheds on `MaxQueueLen`/`MaxQueueTime` without an L3 error
callback, so those packets are offered, never delivered, and attributed
nowhere. AntHocNet and AODV route their pending-queue discards through the
error callback into `DROP_NO_ROUTE`, which is why their identities close.

**Correction recorded in the docs:** #229 was originally filed claiming
AntHocNet over-counted to 155.9%. That was wrong — I had summed
`drop_setup/reconv/repair`, which *partition* `drop_route_pct` rather than
adding to it. AntHocNet closes to within **0.06 pp on all 12 rows** across both
campaigns. `metrics.md` now states the partition explicitly, with the ~156%
figure named as what happens if you add them, so the next reader hits the
warning before making the mistake.

The new WARN is gated on a real shortfall rather than on "queue is zero" —
AntHocNet (99.98) and AODV (99.33) also read 0.00 at `dense-small` while
accounting correctly.

## 4. The gate is now itself tested

`scenario_check.py` decides whether a campaign's numbers may be read or
published and had **no tests**. `test_scenario_check.py`: 16 cases, no pytest,
no simulator, ~1 s, wired into `lint.yml` on every PR.

Every rule gets a *must-fire* case and a *must-not-fire* case. The second half
is what earns its keep — the first cut of the queue diagnosis flagged rows that
were accounting correctly. Fixture values are the real campaign readings, so
moving a threshold has to confront the observation that set it.
Mutation-checked both directions: reverting the queue gate fails `drop-quiet`;
raising `SINGLE_PATH_DIV_MAX` past the observed 1.428 fails `div-fires`.

`SKILL.md` generalises the rule, since the next metric will fail the same way:
a family is not done until it has a control whose value is known a priori **as
a number**, an automated assertion of it in both directions, and a preflight
coherence rule for its parameters. Plus the order of operations — free
`preflight`, then *one* cheap point checked with `results`, then a taxonomy
sweep.

## 5. The metric lines were not cheaply fetchable

`# paths/energy/drops/stddev/reorder` are the only place three metric families
appear in a single-point run. They were also unreachable from a cheap log tail:
the compact step's own script echo is ~35 lines and sits between them and the
end, so reaching `# paths` needed `tail_lines=121` versus ~8 for `##BENCH##`.
Collecting the five-point calibration cost more than running it.
`paper-benchmark.yml` now re-emits them last. `##BENCH##`/`##RUN##` keep their
positions, so `bench_parse.py` is unaffected.

## 6. The benchmark refresh had silently stopped running (#241)

`docs/benchmarks.md` is the standing MANET regression detector, regenerated on
every push to `main`. Last refresh commit `baf1aab` at 07:43 UTC; `main` HEAD
at 17:50 UTC with **eight merges in between and no refresh**.

Cause: `concurrency.group` did not include the event name, so with
`cancel-in-progress: true` every push killed the run in flight. Under sustained
merging the table simply never regenerates — and a cancelled run is not a
failed run, so nothing anywhere reports a problem.

This is not academic: [#224](https://github.com/danieljoppi/AntHocNet/pull/224)
changed the shared adapter (`anthocnet-routing-protocol.cc`, +136/−22,
`ResolveNextHop` replacing hardcoded `m_socketAddresses.begin()` selection) and
the published MANET numbers sat on the far side of it with nothing measuring
them.

Fix: daily `schedule:` backstop, and `github.event_name` in the concurrency
group so scheduled runs cannot be cancelled by merge traffic. Push-triggered
runs still supersede each other.

**#224 has since been cleared empirically** (recorded on #241, not part of this
PR): a control run at `baf1aab`
([30218260627](https://github.com/danieljoppi/AntHocNet/actions/runs/30218260627))
against the post-#224 reading
([30211589022](https://github.com/danieljoppi/AntHocNet/actions/runs/30211589022))
is **bit-identical across all four protocols, both seeds and all ten columns**,
so the change is a confirmed no-op on the single-interface MANET field and the
published numbers were never wrong. The process failed, not the data — which is
the point of the fix above.

## 7. The skill scripts did not pass the pinned ruff

Bringing `scenario_check.py` into the lint scope gated it for the first time,
and CI's pinned **ruff 0.16.0** found four things this sandbox's 0.15.8 did
not — `lint.yml`'s own comment already named EXE001 as a 0.16.0 tightening.
Fixed in `812e6bb`: both scripts marked executable (matching `bench_parse.py`,
already 100755 and therefore already passing); `num`'s closure over the loop
variable bound as a default argument (B023, behaviour unchanged since every
call was already inside the same iteration).

The third was awkward: CI reported `RUF100 unused noqa (non-enabled: E402)`
while this sandbox on the *same* ruff version reported E402 when the noqa was
removed — the two disagree on whether E402 is enabled, so no arrangement of
that directive passes both. Resolved by dropping the module-level import
entirely; `_load_scenario_check()` loads the module from its file via
`importlib`. That sidesteps the disagreement and subsumes the
`sys.dont_write_bytecode` hack it replaces — `exec_module` always runs the
source on disk, so a stale `__pycache__` can no longer shadow an edited rule
and report a pass for code that is not under test.

---

## Verification

- `test_scenario_check.py`: **16 cases passed**.
- `ruff check ns3/tools scenario_check.py test_scenario_check.py`: clean
  **under ruff 0.16.0**, installed locally to match the CI pin rather than
  trusting the sandbox default — that skew is what let the first failure
  through. (`bench_parse.py` and `sweep_summary.py` carry pre-existing E701s
  that are not this change's to fix, so `lint.yml` lists the skill scripts
  file-by-file rather than reformatting untouched code.)
- Both campaign CSVs go from 1 FAIL / 0 WARN to **18 FAIL / 3 WARN**, every new
  report traceable to a number quoted above.
- A pre-instrumentation CSV (`30169311566-run.csv`) still reads
  **`OK (0 fail, 0 warn)`** — inputs lacking these columns are unaffected.
- Both modified workflow YAMLs parse.
- CI on `812e6bb`: `Lint` **success**
  ([30219020209](https://github.com/danieljoppi/AntHocNet/actions/runs/30219020209)),
  `CI` **success**
  ([30219020190](https://github.com/danieljoppi/AntHocNet/actions/runs/30219020190)).

## Follow-ups (not in this PR)

- #230 — implement the real fix: raise the offered rate for diversity
  measurement, or count next hops per packet-pair rather than per time window.
- #229 — confirm the `dsdv::PacketQueue` mechanism directly, then emit a `-1`
  "not measurable" sentinel instead of a confident `0.00`.
- #241 — check whether other `cancel-in-progress` workflows share the same
  silent-off failure mode; and delete the throwaway `claude/control-pre-224`
  branch, which this sandbox's git proxy refuses to remove.
- #179 — `betaData` stays deferred until #230 closes.

Refs #229, #230, #241, #209, #212, #215, #217, #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ktri3CGiFufv6LeZpt42jZ