### PR TITLE
feat(core): per-ant-type gates and directed reactive discovery

### DIFF
--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -64,6 +64,12 @@ public:
     /// Per-destination advertisements dropped by the origin cooldown
     /// (config.linkfailNotifyInterval, issue #20).
     std::uint64_t linkfailOriginsSuppressed() const { return linkfailOriginsSuppressed_; }
+    /// Reactive forward ants steered along the diffusion gradient instead of
+    /// being broadcast (config.enableDirectedReactive). This is the number that
+    /// says whether directed discovery is doing anything at all: zero means the
+    /// virtual table never held a hint where the regular one was empty, so the
+    /// gate is inert rather than harmful.
+    std::uint64_t directedSteers() const { return directedSteers_; }
     /// Local repairs that expired without a backward ant and therefore released
     /// the data buffered for their destination — the number of DiscardPending
     /// decisions this node has emitted ([1] §3.5, D6; drop-cause breakdown,
@@ -212,6 +218,7 @@ private:
     std::uint64_t linkfailBudgetDrops_  = 0;        ///< budget-suppressed propagations (issue #20)
     std::uint64_t linkfailOriginsSuppressed_ = 0;   ///< cooldown-suppressed advertisements (issue #20)
     std::uint64_t repairDiscards_ = 0;              ///< expired local repairs that discarded pending data (#215)
+    std::uint64_t directedSteers_ = 0;              ///< reactive ants unicast along the diffusion gradient
     std::map<NodeAddress, double> lastLinkfailNotify_;  ///< dest -> last originated LinkFail time
 };
 

--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -67,6 +67,54 @@ struct Config {
     bool enableProactive = true;   ///< master: proactive ants + diffusion.
     bool enableDiffusion = true;   ///< hello pheromone adverts + virtual table.
 
+    /// Per-ant-type gates, completing the ablation surface the other
+    /// `enable*` flags already provide. **All default true: turning none of
+    /// them off reproduces current behaviour exactly.** They exist so the
+    /// question "which ant types earn their keep in regime X?" is a
+    /// measurement rather than an argument — the same discipline that chose
+    /// the multipath and A2 defaults.
+    ///
+    /// There is deliberately **no** hello gate: ADR-0008 makes the
+    /// hello-timeout detector the one mandatory liveness path, and hello also
+    /// carries the diffusion adverts (`enableDiffusion`) and, on
+    /// multi-interface adapters, the canonical→link-local peer mapping. Use
+    /// `helloInterval` to make it cheaper; do not remove it.
+    ///
+    /// Note `enableReactive = false` removes the only source of *regular*
+    /// pheromone in the default configuration, so routes never form unless
+    /// something else installs them — which is exactly the interaction
+    /// `enableDirectedReactive` + `enableDiffusion` is there to test.
+    bool enableReactive = true;  ///< reactive forward ants (route discovery).
+    bool enableRepair   = true;  ///< local repair ants after a link break ([1] §3.5).
+    bool enableLinkFail = true;  ///< link-failure notifications ([1] §3.5).
+
+    /// Directed reactive discovery (default **off** — an explicit deviation
+    /// from [1] §3.1, kept behind a gate until a benchmark justifies it).
+    ///
+    /// [1] broadcasts a reactive forward ant wherever the current node has no
+    /// pheromone for the destination. That is the right move when nothing is
+    /// known — but it ignores information the protocol has already collected:
+    /// the **virtual** pheromone table, built from hello diffusion adverts
+    /// (ADR-0007), frequently holds a usable gradient toward a destination for
+    /// which no *regular* pheromone exists yet. `selectNextHop` only blends the
+    /// virtual table in for proactive ants, so a reactive ant floods past it.
+    ///
+    /// With this on, a reactive forward ant consults the virtual table before
+    /// falling back to broadcast, and unicasts along it when it finds one. The
+    /// flood becomes a directed walk wherever diffusion has reached, and stays
+    /// a flood everywhere else.
+    ///
+    /// Deliberately **not** position- or topology-specific: the gradient is
+    /// the protocol's own, so this behaves identically on a MANET and on a
+    /// satellite ISL mesh, and needs neither GPS (cf. LAR/GPSR) nor an orbital
+    /// model. Nothing new travels on the wire — the virtual table is local
+    /// state — so this costs no `kWireVersion` bump.
+    ///
+    /// Risk to measure, not assume: a stale or wrong gradient sends the ant
+    /// down a dead end where a flood would have found a path, trading overhead
+    /// for discovery latency and possibly for delivery.
+    bool enableDirectedReactive = false;
+
     /// Per-hop probability that an in-transit proactive forward ant is broadcast
     /// to explore for new paths rather than unicast along pheromone ([1] §3.3).
     double proactiveBroadcastProb = 0.1;

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -77,6 +77,10 @@ std::vector<RouteDecision> AntRouterLogic::onMaintenanceTick() {
         out.push_back({RouteAction::DiscardPending, dest, false, {}});
         ++repairDiscards_;  // #215 drop cause "repair discard" (event count)
 
+        // Ablation gate: the DiscardPending above is the packets' fate and
+        // always happens; only the deferred notification is suppressed.
+        if (!config_.enableLinkFail) continue;
+
         // Same origin cooldown as reportNeighborLoss (issue #20): the break
         // that armed this repair usually already advertised dest's loss.
         if (config_.linkfailNotifyInterval > 0.0) {
@@ -145,6 +149,10 @@ std::vector<RouteDecision> AntRouterLogic::reportNeighborLoss(NodeAddress n) {
     }
 
     loseNeighbor(n);  // prune n from the table + last-seen
+
+    // Ablation gate: the pruning above is the *correctness* half and always
+    // runs; only the outbound notification is suppressed.
+    if (!config_.enableLinkFail) return {};
 
     AntMessage note;
     const double now = clock_.now();
@@ -220,7 +228,7 @@ std::vector<RouteDecision> AntRouterLogic::reportTxFailure(NodeAddress next,
     // neighbour, skip the repair ant. Rate-limit per destination so a burst of
     // failures to one dest can't spawn a stream of repair ants. broadcastForward
     // counts the ant (--diag repair>0) and caps re-broadcasts (repairMaxBroadcasts).
-    if (dataDest != kInvalidAddress && dataDest != address_ &&
+    if (config_.enableRepair && dataDest != kInvalidAddress && dataDest != address_ &&
         table_.bestRegular(dataDest) <= config_.minPheromone) {
         const double now = clock_.now();
         auto it = lastRepair_.find(dataDest);
@@ -269,6 +277,9 @@ std::vector<RouteDecision> AntRouterLogic::handleLinkFail(const AntMessage& note
         }
     }
     if (prop.helloDests.empty()) return {};  // absorbed: our best path is intact
+    // Ablation gate: the pheromone updates above (applying what the note told
+    // us) already happened — only onward propagation is suppressed.
+    if (!config_.enableLinkFail) return {};
 
     prop.type      = AntType::LinkFail;
     prop.direction = AntDirection::Up;
@@ -582,6 +593,16 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
         }
 
         NodeAddress next = selectNextHop(ant.dst, proactive);
+        if (next == kInvalidAddress && ant.type == AntType::Reactive &&
+            config_.enableDirectedReactive) {
+            // Directed reactive discovery (config-gated, default off): before
+            // flooding, consult the *virtual* table — the diffusion gradient
+            // built from hello adverts (ADR-0007). selectNextHop blends it in
+            // only for proactive ants, so an unmodified reactive ant floods
+            // straight past a usable hint the node already holds.
+            next = selectNextHop(ant.dst, /*blendVirtual=*/true);
+            if (next != kInvalidAddress) ++directedSteers_;
+        }
         if (next == kInvalidAddress) {
             // No pheromone for the destination: the ant explores by broadcast.
             // For a reactive forward ant that is the flood, and it must be
@@ -636,12 +657,24 @@ std::vector<RouteDecision> AntRouterLogic::onDataPacket(NodeAddress dest,
         // per destination per reactiveRetryInterval so a stream of packets to an
         // unreachable destination doesn't flood ants ([1] §4.2).
         std::vector<RouteDecision> out{{RouteAction::Queue, dest, false, {}}};
+        if (!config_.enableReactive) return out;  // ablation gate: hold, never discover
         const double now = clock_.now();
         auto it = lastReactive_.find(dest);
         if (it == lastReactive_.end() || now - it->second >= config_.reactiveRetryInterval) {
             lastReactive_[dest] = now;
             AntMessage refa = createForwardAnt(AntType::Reactive, dest);
-            out.push_back(sendAnt(RouteAction::Broadcast, kInvalidAddress, refa));
+            // Directed discovery applies at the origin too, and this is the
+            // most valuable place for it: this broadcast is generation 0, the
+            // one every downstream copy descends from.
+            NodeAddress steer = config_.enableDirectedReactive
+                                    ? selectNextHop(dest, /*blendVirtual=*/true)
+                                    : kInvalidAddress;
+            if (steer != kInvalidAddress) {
+                ++directedSteers_;
+                out.push_back(sendAnt(RouteAction::Unicast, steer, refa));
+            } else {
+                out.push_back(sendAnt(RouteAction::Broadcast, kInvalidAddress, refa));
+            }
         }
         return out;
     }

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ANTHOCNET_TESTS
   test_reactive_hop_reach
   test_reactive_flood_bound
   test_reactive_source_band
+  test_ant_type_gates
 )
 
 foreach(test ${ANTHOCNET_TESTS})

--- a/core/tests/test_ant_type_gates.cpp
+++ b/core/tests/test_ant_type_gates.cpp
@@ -1,0 +1,191 @@
+// Per-ant-type gates and directed reactive discovery.
+//
+// Two things are asserted here, and they are different in kind.
+//
+// 1. THE GATES ARE INERT BY DEFAULT. enableReactive / enableRepair /
+//    enableLinkFail all default true, so nothing about the shipped protocol
+//    changes; the surrounding suite (23 tests) is the real evidence for that,
+//    and this file only pins the "off" direction — each gate must actually
+//    suppress the ant type it names, without breaking the correctness half it
+//    is entangled with (pruning a dead neighbour, releasing buffered packets).
+//
+// 2. DIRECTED REACTIVE DISCOVERY DOES SOMETHING. [1] §3.1 broadcasts a reactive
+//    forward ant wherever the node has no pheromone for the destination. But
+//    the node may already hold a *virtual* pheromone gradient for it, diffused
+//    through hello adverts (ADR-0007) — selectNextHop only blends that in for
+//    proactive ants, so a reactive ant floods straight past it. With
+//    enableDirectedReactive the ant follows the gradient instead.
+//
+//    The test that matters is not "it is cheaper" (that is a benchmark
+//    question, on a real PHY, via the benchmark-results skill) but "the
+//    mechanism engages and still finds the destination" — a directed ant that
+//    walks into a dead end and never arrives would be a regression no overhead
+//    number would excuse.
+#include "test_support.h"
+#include "testbench.h"
+
+using namespace anthocnet;
+
+namespace {
+
+// A line 0-1-2-...-(n-1). Long enough that discovery is multi-hop, so the
+// difference between flooding and steering is visible.
+void buildLine(test::Testbench& tb, int n) {
+    for (int i = 0; i + 1 < n; ++i) tb.linkUp(i, i + 1);
+}
+
+core::Config baseConfig() {
+    core::Config cfg;
+    // Keep the periodic machinery quiet unless a case needs it, so a counter
+    // change is attributable to the gate under test.
+    cfg.enableEvaporation = false;
+    cfg.enableProactive = false;
+    return cfg;
+}
+
+// --- 1. gates suppress what they name ---------------------------------------
+
+void testReactiveGateSuppressesDiscovery() {
+    for (bool enabled : {true, false}) {
+        core::Config cfg = baseConfig();
+        cfg.enableDiffusion = false;  // no other route source
+        cfg.enableReactive = enabled;
+        test::Testbench tb(5, cfg);
+        buildLine(tb, 5);
+        tb.runUntil(3.0);              // let hello establish neighbours
+        tb.sendData(0, 4);
+        tb.runUntil(10.0);
+
+        if (enabled) {
+            CHECK(tb.dataDelivered > 0);  // reactive on: the line must be discovered and delivered
+        } else {
+            CHECK(tb.dataDelivered == 0);  // reactive off: no discovery, so nothing can be delivered
+            // The data must be *held*, not silently dropped — the gate removes
+            // discovery, not the pending queue.
+            CHECK(tb.pending(0, 4) > 0);  // reactive off: the packet must still be queued
+        }
+    }
+}
+
+void testLinkFailGateKeepsPruning() {
+    // With the gate off a dead neighbour must still be pruned locally — only
+    // the outbound notification disappears. Pruning is correctness; the note
+    // is an optimisation for everyone else.
+    core::Config cfg = baseConfig();
+    cfg.enableLinkFail = false;
+    test::Testbench tb(3, cfg);
+    buildLine(tb, 3);
+    tb.runUntil(3.0);
+    tb.sendData(0, 2);
+    tb.runUntil(8.0);
+    CHECK(tb.dataDelivered > 0);  // route must form with linkfail notes off
+
+    const std::uint64_t before = tb.node(0).controlPacketsSent();
+    tb.linkDown(0, 1);
+    tb.runUntil(20.0);  // past allowedHelloLoss * helloInterval
+    // Node 0 must have dropped 1 from its table (correctness half kept)...
+    CHECK(tb.node(0).table().bestRegular(2) <= cfg.minPheromone);  // the dead neighbour's routes must still be pruned
+    // ...without emitting a LinkFail note for it.
+    CHECK(tb.node(0).antsSent(core::AntType::LinkFail) == 0);  // linkfail off: no notification may be originated
+    (void) before;
+}
+
+void testRepairGateSuppressesRepairAnts() {
+    for (bool enabled : {true, false}) {
+        core::Config cfg = baseConfig();
+        cfg.enableRepair = enabled;
+        // Detector D debounces at txFailureThreshold consecutive failures
+        // (#19); this test is about the gate, not the debounce, so make one
+        // failed unicast enough.
+        cfg.txFailureThreshold = 1;
+        test::Testbench tb(4, cfg);
+        buildLine(tb, 4);
+        tb.runUntil(3.0);
+        tb.sendData(0, 3);
+        tb.runUntil(8.0);
+        tb.linkDown(1, 2);           // break the middle of an active path
+        tb.sendData(0, 3);
+        tb.runUntil(25.0);
+
+        const std::uint64_t repairs =
+            tb.node(0).antsSent(core::AntType::Repair) +
+            tb.node(1).antsSent(core::AntType::Repair);
+        if (enabled) {
+            CHECK(repairs > 0);  // repair on: a broken active path must launch a repair ant
+        } else {
+            CHECK(repairs == 0);  // repair off: no repair ant may be launched
+        }
+    }
+}
+
+// --- 2. directed reactive discovery -----------------------------------------
+
+// TWO PRECONDITIONS, both found by this test failing first.
+//
+// 1. Diffusion advertises only destinations a node already has pheromone for.
+//    On a *cold* first discovery nobody knows the destination, so the virtual
+//    table is empty and a directed ant floods exactly as an undirected one
+//    would. Directed reactive discovery is therefore a **reconvergence /
+//    known-destination** optimisation, not a cold-start one — the scenario
+//    below establishes a gradient first, which is also the realistic case
+//    (a destination other sessions already reach).
+//
+// 2. Adverts ride hellos only when enableProactive is also on
+//    (ant_router_logic.cpp, "Diffusion adverts are gated (ADR-0007)"). So the
+//    directed cases re-enable proactive, unlike the gate cases above.
+void testDirectedReactiveEngagesAndStillDelivers() {
+    core::Config cfg = baseConfig();
+    cfg.enableProactive = true;
+    cfg.enableDiffusion = true;
+    cfg.enableDirectedReactive = true;
+
+    test::Testbench tb(6, cfg);
+    buildLine(tb, 6);
+    tb.runUntil(3.0);
+    // Node 4 reaches 5 (its direct neighbour), so pheromone for destination 5
+    // exists somewhere; hello diffusion then walks that knowledge back down the
+    // line, one hop per helloInterval.
+    tb.sendData(4, 5);
+    tb.runUntil(18.0);
+    // Now a *distant* node discovers the same destination. Its regular table is
+    // still empty for 5, but the diffused virtual table is not.
+    tb.sendData(0, 5);
+    tb.runUntil(30.0);
+
+    std::uint64_t steers = 0;
+    for (int i = 0; i < 6; ++i) steers += tb.node(i).directedSteers();
+
+    CHECK(steers > 0);  // the diffusion gradient must steer at least one ant
+    CHECK(tb.dataDelivered > 0);  // and steering must still reach the destination
+}
+
+void testDirectedReactiveOffLeavesNoSteers() {
+    core::Config cfg = baseConfig();
+    cfg.enableProactive = true;
+    cfg.enableDiffusion = true;
+    cfg.enableDirectedReactive = false;   // the shipped default
+
+    test::Testbench tb(6, cfg);
+    buildLine(tb, 6);
+    tb.runUntil(3.0);
+    tb.sendData(4, 5);          // same gradient-establishing shape as above
+    tb.runUntil(18.0);
+    tb.sendData(0, 5);
+    tb.runUntil(30.0);
+
+    std::uint64_t steers = 0;
+    for (int i = 0; i < 6; ++i) steers += tb.node(i).directedSteers();
+    CHECK(steers == 0);  // default off: no ant may be steered
+    CHECK(tb.dataDelivered > 0);  // default path must still deliver
+}
+
+}  // namespace
+
+int main() {
+    testReactiveGateSuppressesDiscovery();
+    testLinkFailGateKeepsPruning();
+    testRepairGateSuppressesRepairAnts();
+    testDirectedReactiveEngagesAndStillDelivers();
+    testDirectedReactiveOffLeavesNoSteers();
+    return RUN_TESTS();
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,7 @@ The `ns-3 attribute` column is the name you pass to
 `--ns3::anthocnet::RoutingProtocol::<name>`; `—` means the field is core-only
 (edit `config.h` and rebuild).
 
-### 3.1 All 31 fields
+### 3.1 All 35 fields
 
 | parameter | default | unit | ns-3 attribute | source | what it affects |
 |---|---|---|---|---|---|
@@ -116,6 +116,10 @@ The `ns-3 attribute` column is the name you pass to
 | `reactiveRetryInterval` | `1.0` | s | — (see note) | **`unknown`** (number only) — the *mechanism* is real and belongs to **thesis §4.1.2**; `config.h`'s `[1] §4.2` citation is wrong, because §4.2 of the PPSN paper is the *results* section (see §3.3 below). Neither source states a numeric interval, so the 1.0 s stays unsourced ([#182](https://github.com/danieljoppi/AntHocNet/issues/182)). | At most one reactive forward ant per destination per window, so packets to an unreachable destination cannot flood ants. Also rate-limits repair-ant launches. |
 | `enableProactive` | `true` | bool | `EnableProactive` | Mechanism `[1] §3.3`; **the gate** is `repo choice` ([ADR-0007](adr/0007-proactive-diffusion-gated.md)) so the ablation is runnable. | Master switch for proactive ants **and** diffusion. Off = purely reactive AntHocNet. |
 | `enableDiffusion` | `true` | bool | `EnableDiffusion` | Mechanism `[1] §3.3` (hello messages as pheromone diffusion); **the gate** is `repo choice` (ADR-0007). | Whether hellos carry pheromone adverts and the virtual table is maintained. Virtual pheromone guides proactive ants only, never data. |
+| `enableReactive` | `true` | bool | `EnableReactive` | Mechanism `[1] §3.1`; **the gate** is `repo choice` — an ablation switch, symmetric with `enableProactive`. Neither source contemplates running without reactive discovery. | Whether a data packet for an unknown destination launches a reactive forward ant. Off = **no source of regular pheromone at all**: data is queued and (barring diffusion) never delivered. Use it to measure what reactive setup buys, not as an operating mode. |
+| `enableRepair` | `true` | bool | `EnableRepair` | Mechanism `[1] §3.5` (local route repair); **the gate** is `repo choice`. | Whether a link break on an active path launches a repair ant. Off = reconvergence falls back to a fresh reactive discovery, so expect a longer outage and a wider flood per break. |
+| `enableLinkFail` | `true` | bool | `EnableLinkFail` | Mechanism `[1] §3.5` (link-failure notification); **the gate** is `repo choice`. | Whether this node *originates* a LinkFail notification. Off suppresses only the outbound note — local pruning of the dead neighbour and the release of packets held for it still run, because those are correctness, not signalling. Pairs with `linkfailNotifyInterval` (rate-limit) as the off-switch end of the same storm question ([#20](https://github.com/danieljoppi/AntHocNet/issues/20)). |
+| `enableDirectedReactive` | `false` | bool | `EnableDirectedReactive` | **`repo choice`** — not in either source. [1] §3.1 broadcasts a reactive forward ant whenever the node has no pheromone for the destination, full stop. | When the regular table has no entry but the *virtual* table (diffusion, [ADR-0007](adr/0007-proactive-diffusion-gated.md)) does, unicast the reactive ant along that gradient instead of broadcasting. **Default off** so the shipped protocol stays [1]-faithful and the A/B arm is explicit. Only engages once a gradient exists — diffusion advertises only destinations a node already reaches, so this is a *reconvergence / known-destination* optimisation, not a cold-start one. |
 | `proactiveBroadcastProb` | `0.1` | probability per hop | `ProactiveBroadcastProb` | `thesis §4.3.4 (superseded version)` — mechanism `[1] §3.3` ("a small probability of being broadcast"), which states no value; the thesis *does* state our exact 10%, but in **§4.3.4, "Older versions of AntHocNet"**. In the shipped thesis algorithm the mechanism does not exist: proactive forward ants are "**never broadcast**: when they arrive at a node that does not have any routing information for their destination, they are discarded" ([#182](https://github.com/danieljoppi/AntHocNet/issues/182)). Read as [1]'s algorithm, not the thesis's — see [`fidelity.md`](fidelity.md). | How often an in-transit proactive ant explores by broadcast instead of following pheromone. Higher = more exploration, more control overhead. |
 | `sessionTtl` | `5.0` | s | `SessionTtl` | `repo choice` — an implementation *necessity* with no source, which is a different thing from an unexplained number ([#182](https://github.com/danieljoppi/AntHocNet/issues/182)). The thesis's simulator knows session boundaries directly — proactive ants are scheduled "only from the moment a session is started, and until the end of it" — so it never needs an inactivity timeout; we have no such oracle. [1] §3.3 clocks proactive ants to the *data rate* (one per n packets) and has no session-TTL concept either. The 5 s value is still not sweep-backed. | How long after the last locally-originated data packet a destination keeps being probed by proactive ants. |
 | `helloInterval` | `1.0` | s | `HelloInterval` | `[1] §3.3 fn.1` — `t_hello`, "e.g. 1 s". | Beacon rate, and (with `allowedHelloLoss`) the neighbour-liveness window. Drives baseline control overhead. |
@@ -295,6 +299,57 @@ Keep that in mind before attributing an overhead difference to the algorithm.
 pheromone, so ants can no longer be guided toward destinations this node has
 never reached. `proactiveBroadcastProb` and `proactiveInterval` both buy
 adaptivity with control overhead — sweep them against NRL, not just PDR.
+
+### Ant-type gates & directed discovery — `enableReactive`, `enableRepair`, `enableLinkFail`, `enableDirectedReactive`
+
+Four switches that exist for one purpose: making the *ablation* runnable, so a
+claim like "repair ants are worth their overhead in regime X" is measured rather
+than asserted. All three gates default **on** and the directed switch defaults
+**off**, so the shipped protocol is unchanged by their existence.
+
+There is deliberately **no hello gate**. Hello is not an optional ant type here:
+it is detector A of ADR-0008 (the only always-on link-failure detector), the
+carrier for diffusion adverts (ADR-0007), and the sole source of the neighbour
+map every other mechanism selects over. Gating it would not ablate a feature, it
+would break the node.
+
+The three gates are each entangled with a piece of correctness, and only the
+signalling half is removed:
+
+* `enableReactive=false` still **queues** the packet — discovery disappears, the
+  pending queue does not. Note this is the harshest gate: reactive ants are the
+  only producer of *regular* pheromone, so with it off the protocol has no way
+  to learn a route to anywhere it is not already told about.
+* `enableRepair=false` still detects the break and prunes; only the repair ant
+  is not launched.
+* `enableLinkFail=false` still prunes the dead neighbour, still discards its
+  pending entries, and still applies an *incoming* neighbour's notification —
+  only the locally *originated* note is suppressed.
+
+`enableDirectedReactive` is the one that adds a mechanism rather than removing
+one, and it is the A/B the rest of the group is scaffolding for. Stock [1] §3.1
+floods a reactive forward ant when the regular table is empty for the
+destination — even when the node is holding a perfectly good *virtual* gradient
+for it from diffusion, because `selectNextHop` blends virtual pheromone in for
+proactive ants only. With the switch on, that gradient steers the ant by unicast
+instead. Two things to hold on to before reading a result:
+
+1. **It is not position-based.** Unlike LAR or GPSR, nothing here needs
+   coordinates or a location service; the "direction" is pheromone the node
+   already received. That is what makes it applicable to MANET and not just to
+   a constellation with a known topology.
+2. **It cannot help a cold start.** Diffusion advertises only destinations the
+   advertiser already has regular pheromone for, so the very first discovery in
+   a fresh network has no gradient to follow and the directed ant floods exactly
+   as the undirected one does. The win, if there is one, is on *re*-discovery
+   after a break and on destinations other sessions already reach — which is
+   also the case where flooding is most wasteful.
+
+The observable is `AntRouterLogic::directedSteers()`: the count of reactive ants
+that took the gradient instead of the broadcast. `directedSteers() == 0` on an
+enabled run means the precondition above was never met, not that the switch is
+broken — check that `enableProactive` **and** `enableDiffusion` are both on,
+since adverts only ride hellos when proactive is enabled.
 
 ### Neighbour liveness & link failure — `helloInterval`, `allowedHelloLoss`, `txFailureThreshold`, `linkfailNotifyInterval`
 

--- a/docs/network-regimes.md
+++ b/docs/network-regimes.md
@@ -129,8 +129,22 @@ AntHocNet's mechanisms split cleanly along this line:
 
 - **Reactive discovery** — flooding forward ants to find a path nobody knows —
   is its answer to *unknown topology*. A constellation does not have that
-  problem. On 1584 nodes with four links each, the flood is cost without
-  benefit.
+  problem: the +Grid is a known graph and every node can compute where a
+  destination *is*.
+
+  Be precise about what that does and does not buy, though. Knowing the topology
+  is not the same as a node already holding a **next hop** for a given
+  destination: it still has to acquire direction, and on 1584 nodes with four
+  links each, acquiring it by flooding is the expensive way. The correction is
+  not "discovery is free" — it is that discovery here is *steerable* rather than
+  blind, because the direction is derivable instead of unknown.
+
+  That is exactly the gap `enableDirectedReactive`
+  ([`configuration.md`](configuration.md)) probes, and it does so without
+  assuming a constellation: it steers along the diffused virtual gradient, which
+  is pheromone the node already received, not a coordinate. So the same switch
+  is testable on a MANET, where it degrades to "no gradient yet, flood as
+  before" rather than to "wrong answer".
 - **Multipath with delay-weighted pheromone** is a different mechanism
   entirely: it responds to *load*, and load is precisely what orbits cannot
   predict.

--- a/ns2/patch/fragments/ns-default.tcl.fragment
+++ b/ns2/patch/fragments/ns-default.tcl.fragment
@@ -7,6 +7,10 @@ Agent/AntHocNet set beta_ants_ 1.0
 Agent/AntHocNet set beta_data_ 2.0
 Agent/AntHocNet set enable_proactive_ 1
 Agent/AntHocNet set enable_diffusion_ 1
+Agent/AntHocNet set enable_reactive_ 1
+Agent/AntHocNet set enable_repair_ 1
+Agent/AntHocNet set enable_linkfail_ 1
+Agent/AntHocNet set enable_directed_reactive_ 0
 Agent/AntHocNet set proactive_bcast_prob_ 0.1
 Agent/AntHocNet set session_ttl_ 5.0
 Agent/AntHocNet set enable_mac_metric_ 0

--- a/ns2/src/ahn_router.cc
+++ b/ns2/src/ahn_router.cc
@@ -61,6 +61,10 @@ AntHocNetAgent::AntHocNetAgent(nsaddr_t id)
       beta_data_(2.0),
       enable_proactive_(1),
       enable_diffusion_(1),
+      enable_reactive_(1),
+      enable_repair_(1),
+      enable_linkfail_(1),
+      enable_directed_reactive_(0),
       proactive_bcast_prob_(0.1),
       session_ttl_(5.0),
       tx_failure_threshold_(3),
@@ -78,6 +82,10 @@ AntHocNetAgent::AntHocNetAgent(nsaddr_t id)
     bind("beta_data_", &beta_data_);
     bind_bool("enable_proactive_", &enable_proactive_);
     bind_bool("enable_diffusion_", &enable_diffusion_);
+    bind_bool("enable_reactive_", &enable_reactive_);
+    bind_bool("enable_repair_", &enable_repair_);
+    bind_bool("enable_linkfail_", &enable_linkfail_);
+    bind_bool("enable_directed_reactive_", &enable_directed_reactive_);
     bind("proactive_bcast_prob_", &proactive_bcast_prob_);
     bind("session_ttl_", &session_ttl_);
     bind("tx_failure_threshold_", &tx_failure_threshold_);
@@ -102,6 +110,10 @@ void AntHocNetAgent::startProtocol() {
     config_.betaData          = beta_data_;
     config_.enableProactive   = enable_proactive_ != 0;
     config_.enableDiffusion   = enable_diffusion_ != 0;
+    config_.enableReactive    = enable_reactive_ != 0;
+    config_.enableRepair      = enable_repair_ != 0;
+    config_.enableLinkFail    = enable_linkfail_ != 0;
+    config_.enableDirectedReactive = enable_directed_reactive_ != 0;
     config_.proactiveBroadcastProb = proactive_bcast_prob_;
     config_.sessionTtl        = session_ttl_;
     config_.txFailureThreshold = tx_failure_threshold_;

--- a/ns2/src/ahn_router.h
+++ b/ns2/src/ahn_router.h
@@ -127,6 +127,10 @@ private:
     double beta_data_;
     int    enable_proactive_;
     int    enable_diffusion_;
+    int    enable_reactive_;           // reactive forward-ant gate (ablation)
+    int    enable_repair_;             // local-repair ant gate (ablation)
+    int    enable_linkfail_;           // link-failure notification gate (ablation)
+    int    enable_directed_reactive_;  // steer reactive ants by the virtual table
     double proactive_bcast_prob_;
     double session_ttl_;
     int    tx_failure_threshold_;

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -1197,6 +1197,11 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             // (origins = antTx[linkfail] - linkfailProp; budgetDrop counts
             // propagations suppressed by the inherited broadcastBudget).
             uint64_t lfProp = 0, lfBudget = 0, lfSuppressed = 0;
+            // Reactive ants steered by the diffusion gradient instead of
+            // broadcast (EnableDirectedReactive). Always 0 with the default
+            // gate off; on an enabled arm it is the "did the mechanism engage"
+            // number to read *before* comparing NRL between the two arms.
+            uint64_t steers = 0;
             for (uint32_t i = 0; i < nodes.GetN(); ++i) {
                 Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
                 if (!ip) continue;
@@ -1206,10 +1211,12 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                 lfProp += ahn->LinkfailPropagations();
                 lfBudget += ahn->LinkfailBudgetDrops();
                 lfSuppressed += ahn->LinkfailOriginsSuppressed();
+                steers += ahn->DirectedSteers();
             }
             std::cout << " linkfailProp=" << lfProp
                       << " linkfailBudgetDrop=" << lfBudget
-                      << " linkfailOrigSuppressed=" << lfSuppressed;
+                      << " linkfailOrigSuppressed=" << lfSuppressed
+                      << " directedSteers=" << steers;
 
             // Issue #133: pheromone-table size gauge at end of run. Per node
             // the table grows with destinations x neighbours (regular +

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -47,6 +47,10 @@ RoutingProtocol::RoutingProtocol()
       m_gamma(0.7),
       m_enableProactive(true),
       m_enableDiffusion(true),
+      m_enableReactive(true),
+      m_enableRepair(true),
+      m_enableLinkFail(true),
+      m_enableDirectedReactive(false),
       m_proactiveBroadcastProb(0.1),
       m_sessionTtl(5.0),
       m_txFailureThreshold(3),
@@ -107,6 +111,35 @@ TypeId RoutingProtocol::GetTypeId() {
                           "Hello pheromone adverts + virtual table.",
                           BooleanValue(true),
                           MakeBooleanAccessor(&RoutingProtocol::m_enableDiffusion),
+                          MakeBooleanChecker())
+            .AddAttribute("EnableReactive",
+                          "Reactive forward ants ([1] §3.1 route discovery). Off "
+                          "removes the only source of regular pheromone, so data "
+                          "for an unknown destination stays queued — an ablation "
+                          "switch, not an operating mode.",
+                          BooleanValue(true),
+                          MakeBooleanAccessor(&RoutingProtocol::m_enableReactive),
+                          MakeBooleanChecker())
+            .AddAttribute("EnableRepair",
+                          "Local repair ants after a link break ([1] §3.5). Off "
+                          "leaves reconvergence to a fresh reactive discovery.",
+                          BooleanValue(true),
+                          MakeBooleanAccessor(&RoutingProtocol::m_enableRepair),
+                          MakeBooleanChecker())
+            .AddAttribute("EnableLinkFail",
+                          "Link-failure notifications ([1] §3.5). Off suppresses "
+                          "only the outbound note; local pruning and the pending "
+                          "queue release still run.",
+                          BooleanValue(true),
+                          MakeBooleanAccessor(&RoutingProtocol::m_enableLinkFail),
+                          MakeBooleanChecker())
+            .AddAttribute("EnableDirectedReactive",
+                          "Steer a reactive forward ant along the diffused virtual "
+                          "gradient (ADR-0007) instead of broadcasting, when the "
+                          "regular table has no entry. Default off: this is the "
+                          "A/B arm against stock [1] §3.1 flooding.",
+                          BooleanValue(false),
+                          MakeBooleanAccessor(&RoutingProtocol::m_enableDirectedReactive),
                           MakeBooleanChecker())
             .AddAttribute("ProactiveBroadcastProb",
                           "Per-hop explore-broadcast probability for proactive ants.",
@@ -363,6 +396,10 @@ void RoutingProtocol::DoInitialize() {
     m_config.gamma = m_gamma;
     m_config.enableProactive = m_enableProactive;
     m_config.enableDiffusion = m_enableDiffusion;
+    m_config.enableReactive = m_enableReactive;
+    m_config.enableRepair = m_enableRepair;
+    m_config.enableLinkFail = m_enableLinkFail;
+    m_config.enableDirectedReactive = m_enableDirectedReactive;
     m_config.proactiveBroadcastProb = m_proactiveBroadcastProb;
     m_config.sessionTtl = m_sessionTtl;
     m_config.helloInterval = m_helloInterval.GetSeconds();
@@ -432,6 +469,10 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         m_config.gamma = m_gamma;
         m_config.enableProactive = m_enableProactive;
         m_config.enableDiffusion = m_enableDiffusion;
+        m_config.enableReactive = m_enableReactive;
+        m_config.enableRepair = m_enableRepair;
+        m_config.enableLinkFail = m_enableLinkFail;
+        m_config.enableDirectedReactive = m_enableDirectedReactive;
         m_config.proactiveBroadcastProb = m_proactiveBroadcastProb;
         m_config.sessionTtl = m_sessionTtl;
         m_config.helloInterval = m_helloInterval.GetSeconds();

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -115,6 +115,14 @@ public:
         return m_logic ? m_logic->linkfailOriginsSuppressed() : 0;
     }
 
+    /// Directed reactive discovery diagnostics: reactive forward ants unicast
+    /// along the diffusion gradient instead of broadcast (EnableDirectedReactive).
+    /// Zero on an enabled run means the gradient never covered a destination the
+    /// regular table was missing, i.e. the switch was inert for this scenario.
+    uint64_t DirectedSteers() const {
+        return m_logic ? m_logic->directedSteers() : 0;
+    }
+
     /// Issue #133 observability: per-node pheromone-table size gauge from the
     /// core — current (neighbor, dest) entry counts, split regular vs virtual.
     /// Read by the comparison harness under --diag to watch table growth.
@@ -273,6 +281,10 @@ private:
     double m_gamma;
     bool m_enableProactive;
     bool m_enableDiffusion;
+    bool m_enableReactive;            ///< reactive forward-ant gate (ablation)
+    bool m_enableRepair;              ///< local-repair ant gate (ablation)
+    bool m_enableLinkFail;            ///< link-failure notification gate (ablation)
+    bool m_enableDirectedReactive;    ///< steer reactive ants by the virtual table
     double m_proactiveBroadcastProb;
     double m_sessionTtl;
     uint32_t m_txFailureThreshold;


### PR DESCRIPTION
Adds four `Config` switches — three ablation gates plus one new, default-off mechanism — and exposes them on both adapters.

**Nothing about the shipped protocol changes.** The three gates default `true` and the mechanism defaults `false`, so a run that sets none of them is byte-identical to before. The 23 pre-existing core tests passing unchanged is the evidence for that; the new file pins only the "off" direction.

## Why

Two questions kept coming up with no way to answer either.

1. **Which ant types earn their keep in a given regime?** The repo already gates proactive/diffusion ([ADR-0007](../blob/main/docs/adr/0007-proactive-diffusion-gated.md)) and evaporation ([ADR-0012](../blob/main/docs/adr/0012-evaporation-is-a-secondary-safety-net.md)) precisely so those ablations are runnable. Reactive, repair and linkfail had no such switch, so "repair ants are worth their overhead here" could only be asserted, never measured.

2. **Is flooding the right move when the node already holds a hint?** [1] §3.1 broadcasts a reactive forward ant wherever the regular table is empty for the destination. But the **virtual** table, built from hello diffusion adverts (ADR-0007), frequently holds a usable gradient for exactly that destination — `selectNextHop` blends it in for *proactive* ants only, so a reactive ant floods straight past information the node already has.

## Ablation gates — `enableReactive`, `enableRepair`, `enableLinkFail`

Each ant type is entangled with a piece of correctness, and only the **signalling** half is removed:

| gate off | still happens (correctness) | suppressed (signalling) |
|---|---|---|
| `enableReactive` | packet is **queued** | the reactive forward ant |
| `enableRepair` | break detected, neighbour pruned | the repair ant |
| `enableLinkFail` | neighbour pruned, expired-repair `DiscardPending`, **incoming** notes still applied | the locally originated / propagated note |

The gate sits *after* the correctness half at all three `enableLinkFail` sites (`reportNeighborLoss`, `onMaintenanceTick`, `handleLinkFail`) — deliberately, and worth preserving in review.

`enableReactive=false` is the harshest of the three: reactive ants are the only producer of *regular* pheromone, so with it off the protocol cannot learn a route to anywhere it is not told about. It is an ablation switch, not an operating mode, and both the header comment and `configuration.md` say so.

**There is no hello gate**, and that is a decision rather than an omission. Hello is detector A of ADR-0008 (the one always-on liveness path), the carrier for diffusion adverts, and the sole source of the neighbour map every other mechanism selects over — on the ns-3 adapter it also feeds the canonical→link-local peer map. Gating it would not ablate a feature, it would break the node. `helloInterval` is the knob for making it cheaper.

## Directed reactive discovery — `enableDirectedReactive`, default **off**

When the regular table has no entry, consult the virtual table before falling back to broadcast, and unicast along the gradient if one is found. Applied at two sites: in-transit ants (`onReceiveAnt`) and — more valuably — at the origin (`onDataPacket`), which is generation 0, the broadcast every downstream copy descends from. The flood becomes a directed walk wherever diffusion has reached and stays a flood everywhere else.

Two properties bound what any result here can claim:

- **Not position-based.** Unlike LAR or GPSR this needs no coordinates and no location service — the "direction" is pheromone the node already received. So it is testable on a MANET, not only on a constellation with known geometry, and where no gradient exists it degrades to "flood as before" rather than to a wrong answer.
- **Cannot help a cold start.** Diffusion advertises only destinations the advertiser already has regular pheromone for, so the very first discovery in a fresh network has no gradient and the directed ant floods exactly as the undirected one does. The win, if there is one, is on *re*-discovery after a break and on destinations other sessions already reach — which is also where flooding is most wasteful.

That second point was found the hard way: the test asserting `steers > 0` failed first, and the scenario had to establish a gradient before a distant node could be steered. It is recorded in the test's header comment so the next reader does not have to rediscover it.

Nothing new travels on the wire — the virtual table is local state — so no `kWireVersion` bump.

**Risk to measure rather than assume:** a stale or wrong gradient sends the ant down a dead end where a flood would have found a path, trading overhead for discovery latency and possibly for delivery. That is why the default is off, and why the observable below exists.

## Observability

`AntRouterLogic::directedSteers()` counts reactive ants that took the gradient instead of the broadcast; surfaced as `RoutingProtocol::DirectedSteers()` and printed by `anthocnet-compare --diag` as `directedSteers=`.

Read it **before** comparing NRL between arms. `directedSteers=0` on an enabled run means the mechanism never engaged — usually because `enableProactive` or `enableDiffusion` is off, since adverts only ride hellos when proactive is enabled — not that the two arms are equivalent.

## Tests

New `core/tests/test_ant_type_gates.cpp`, 5 cases, suite 23 → 24:

- each gate suppresses the ant type it names **and** leaves its correctness half intact — reactive-off still queues, linkfail-off still prunes the dead neighbour;
- directed reactive engages (`steers > 0`) **and still delivers** — a directed ant that walks into a dead end and never arrives would be a regression no overhead number could excuse;
- the shipped default (`enableDirectedReactive=false`) records zero steers and delivers.

The repair case sets `txFailureThreshold = 1`: detector D debounces at 3 consecutive failures (#19), and this test is about the gate, not the debounce.

```
100% tests passed, 0 tests failed out of 24
```

## Adapters

- **ns-3** — `EnableReactive` / `EnableRepair` / `EnableLinkFail` / `EnableDirectedReactive` attributes, plumbed at *both* config-sync sites (`DoInitialize` and the first-interface path in `NotifyInterfaceUp`).
- **ns-2** — `enable_reactive_` / `enable_repair_` / `enable_linkfail_` / `enable_directed_reactive_` binds with matching `ns-default.tcl` entries.

## Docs

`docs/configuration.md` gains the four rows (field count 31 → 35) and a new *"Ant-type gates & directed discovery"* section covering the entanglement, the absent hello gate, and how to read `directedSteers`.

`docs/network-regimes.md` §5 **corrected**: it claimed a constellation "does not have" the unknown-topology problem, so reactive flooding there is "cost without benefit". Knowing the topology is not the same as holding a **next hop** — a node still has to acquire direction. The honest statement is that discovery there is *steerable* rather than blind, and that is exactly what `enableDirectedReactive` probes, without assuming a constellation.

## Follow-up

The A/B itself (enabled vs disabled, MANET and ISL grid) is a benchmark question for a separate ticket — this PR ships the switch and the observable, not the result.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_