### PR TITLE
docs(adr): record the directed-reactive decision (ADR-0016) and its open hazard

### DIFF
--- a/docs/adr/0007-proactive-diffusion-gated.md
+++ b/docs/adr/0007-proactive-diffusion-gated.md
@@ -1,6 +1,11 @@
 # ADR-0007: Keep virtual pheromone / proactive diffusion, but gate it
 
-- **Status:** Accepted — implementation tracked in
+- **Status:** Accepted — **partly superseded on one point by
+  [ADR-0016](0016-directed-reactive-discovery-is-gated-and-off.md)**, which lets
+  a *reactive ant* be steered by virtual pheromone too (gated,
+  default off). The invariant this ADR was protecting is unchanged: **data still
+  never reads virtual pheromone.** Read "one consumer … reactive paths never read
+  it" below as the state at the time of writing. Implementation tracked in
   item 03,
   item 04, measured by
   item 07 /

--- a/docs/adr/0016-directed-reactive-discovery-is-gated-and-off.md
+++ b/docs/adr/0016-directed-reactive-discovery-is-gated-and-off.md
@@ -1,0 +1,121 @@
+# ADR-0016: Reactive ants may follow the diffusion gradient, gated and default-off
+
+- **Status:** Accepted — mechanism shipped in
+  [#243](https://github.com/danieljoppi/AntHocNet/pull/243), measured by
+  [#244](https://github.com/danieljoppi/AntHocNet/issues/244)
+- **Date:** 2026-07-27
+
+## Context
+
+[ADR-0007](0007-proactive-diffusion-gated.md) kept virtual pheromone and stated
+its consumer boundary explicitly: virtual pheromone is read by **one** consumer,
+proactive-ant next-hop selection, and "data/reactive paths never read it."
+
+That boundary has a cost that ADR-0007 did not weigh. [1] §3.1 broadcasts a
+reactive forward ant whenever the current node has no pheromone for the
+destination — full stop, no exceptions. But "no pheromone" there means no
+**regular** pheromone. A node can simultaneously hold a perfectly usable
+*virtual* gradient toward that destination, diffused to it through hello adverts,
+and still flood, because `selectNextHop` blends the virtual table in only when
+the ant is proactive.
+
+So the protocol collects information and then declines to use it at the one
+moment it is most expensive not to: route discovery, where the alternative is a
+network-wide broadcast.
+
+Two adjacent questions arrived at the same time and sharpened this one:
+
+- **Satellites** ([#192](https://github.com/danieljoppi/AntHocNet/issues/192)).
+  On a constellation the topology is knowable, so blind flooding looks
+  obviously wrong. But knowing the topology is not the same as holding a next
+  hop — see [`network-regimes.md`](../network-regimes.md) §5. What a node lacks
+  is *direction*, and direction is exactly what a diffusion gradient is.
+- **Ant-type ablation.** Asking "which ant types earn their keep?" required
+  per-type gates anyway, and the same PR was the natural place for both.
+
+## Decision
+
+**Let a reactive forward ant consult the virtual table before falling back to
+broadcast, behind `Config::enableDirectedReactive`, default `false`.**
+
+When the regular table has no entry for the destination and the virtual table
+does, the ant is **unicast** along that gradient instead of broadcast. Applied at
+two sites: in-transit ants (`onReceiveAnt`) and the origin (`onDataPacket`) —
+the origin being the more valuable of the two, since that broadcast is
+generation 0, the one every downstream copy descends from.
+
+**ADR-0007's load-bearing invariant is preserved: data still never reads virtual
+pheromone.** What changes is narrower than "reactive paths never read it" — a
+reactive *ant* may now be steered by it. Data forwarding
+([ADR-0010](0010-data-forwarding-prevhop-excluded-stochastic.md)) is untouched.
+
+Default `false` because this is a mechanism **not present in either source**, and
+the repo's standing rule is that a non-source mechanism ships off until a
+benchmark justifies the switch — the same treatment `enableMacMetric` gets, and
+the inverse of `enableEvaporation` ([ADR-0012](0012-evaporation-is-a-secondary-safety-net.md)),
+which ships on and is gated so the faithful ablation stays runnable. Here the
+faithful behaviour *is* the default, so the gate exists to make the deviation
+runnable rather than the fidelity.
+
+Observable: `AntRouterLogic::directedSteers()`, surfaced as ns-3
+`DirectedSteers()` and printed by `anthocnet-compare --diag`.
+
+## Two properties that bound the claim
+
+Both were established while implementing, and both constrain what a result from
+[#244](https://github.com/danieljoppi/AntHocNet/issues/244) can say.
+
+1. **It is not position-based.** Unlike LAR or GPSR, nothing here needs
+   coordinates, a location service, or an orbital model — the "direction" is
+   pheromone the node already received. This is why it is a MANET mechanism that
+   *also* applies to a constellation, rather than a satellite special case. It
+   is also why it degrades safely: with no gradient it floods exactly as before,
+   rather than producing a wrong answer.
+
+2. **It cannot help a cold start.** Diffusion advertises only destinations the
+   advertiser already has regular pheromone for, so the first discovery in a
+   fresh network has no gradient at all and the directed ant floods identically.
+   This was found by the unit test asserting `steers > 0` and failing. Directed
+   reactive discovery is therefore a **reconvergence / known-destination**
+   optimisation — which is also the case where flooding is most wasteful, so the
+   restriction is less damaging than it first sounds. Any scenario built to
+   measure it must establish a gradient first, or it will measure nothing.
+
+## Alternatives considered
+
+- **Do it unconditionally, no flag.** Rejected on the same reasoning ADR-0007
+  used for the inverse case: an unmeasured mechanism should not silently become
+  the shipped protocol, and a flag costs almost nothing while yielding a free
+  A/B.
+- **Let data forwarding use virtual pheromone too.** Rejected — this is
+  ADR-0007's actual invariant and the reason virtual pheromone can afford to be
+  optimistic. An advert says "I can reach X", not "I have measured a good path
+  to X"; steering an *ant* by that is a cheap probe, steering *data* by it is a
+  delivery bet on unverified information.
+- **Broadcast and unicast (steer as a hint, keep the flood as insurance).**
+  Rejected for now: it removes the entire overhead saving, which is the only
+  reason to do this. But it is the natural mitigation if the hazard below turns
+  out to bite — see
+  [#245](https://github.com/danieljoppi/AntHocNet/issues/245).
+- **Make it satellite-only.** Rejected: nothing in the mechanism is
+  satellite-specific, and scoping it that way would have made it untestable on
+  the scenarios we actually run.
+
+## Consequences
+
+- One ablation axis added to the benchmark matrix, and one new question for it
+  to answer: does a directed walk find the destination as reliably as a flood?
+- **Known hazard, tracked in
+  [#245](https://github.com/danieljoppi/AntHocNet/issues/245):** the steer
+  *replaces* the broadcast rather than supplementing it, so a stale gradient can
+  send the single ant down a dead end where a flood would have found a path.
+  Where the failure is local (dead next hop) detector D
+  ([ADR-0008](0008-neighbour-liveness-two-detectors.md)) eventually prunes it;
+  where the gradient is stale further downstream there is no local signal at
+  all, and the origin will re-steer to the same place on each
+  `reactiveRetryInterval`. This is the reason the default is off, and it is a
+  correctness question that must be answered before the default could change.
+- No wire-format change: the virtual table is local state and no new field
+  travels ([ADR-0006](0006-on-wire-protocol-version.md)).
+- ADR-0007's consumer list is now out of date as written; the invariant it was
+  protecting (data never reads virtual pheromone) is intact.

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -25,6 +25,7 @@ The living compliance ledger is [issue #91](https://github.com/danieljoppi/AntHo
 | Stochastic data routing, pheromone² | 3.2 | `betaData=2` (#70/#100) | ✅ aligned |
 | Proactive ants, unsquared pheromone, broadcast≤2 | 3.3 | `betaAnts=1`, `proactiveMaxBroadcasts=2` (#45/#70) | ✅ |
 | Pheromone diffusion via hello ants | 3.3 | `enableDiffusion` (ADR-0007) | ✅ |
+| Reactive ant floods when it has no pheromone | 3.1 | default behaviour; `enableDirectedReactive` steers instead (ADR-0016) | ✅ faithful by default — the deviation is **off** |
 | Hello beacons (1 s, 2 missed → remove) | 3.3 fn.1 | `helloInterval`, `allowedHelloLoss` | ✅ |
 | Link-failure detection + notification | 3.4 | detectors A/D (#19/#44/#54) | ✅ |
 | Bounded local repair (≤2 broadcasts, wait 5×) | 3.4 | `repairMaxBroadcasts`, `repairWaitFactor` | ✅ |
@@ -138,7 +139,16 @@ possible". Provenance for each parameter is in
    leaves a usable alternate next-hop is absorbed rather than always notified
    (paper §3.4 always notifies). Benchmark-justified (#96): notification floods
    cost PDR on the ns-3 channel.
-6. **Cross-simulator parity is not guaranteed** — NS-2 and NS-3 have different
+6. **Directed reactive discovery** (`enableDirectedReactive`, default **off**;
+   ADR-0016) — a mechanism in **neither source**: a reactive forward ant may be
+   unicast along the diffused virtual gradient instead of broadcast. Listed here
+   for completeness rather than as an active deviation — with the default off the
+   shipped protocol matches [1] §3.1 exactly, and the gate exists to make the
+   *deviation* runnable (the inverse of item 3, where the gate makes the
+   *fidelity* runnable). #244 measures it; #245 tracks the open hazard that a
+   stale gradient can strand the single steered ant where a flood would not have
+   been.
+7. **Cross-simulator parity is not guaranteed** — NS-2 and NS-3 have different
    MAC/PHY; the NS-2 adapter also has no pending-queue hold cap yet. Treat
    cross-sim comparison as behaviour re-validation, not a bit-for-bit port.
 


### PR DESCRIPTION
Docs only. No code change, no behaviour change.

PR #243 shipped `enableDirectedReactive` without the ADR it needed. AGENTS.md requires updating the relevant doc/ADR when a documented decision changes, and one did: **ADR-0007 stated that virtual pheromone has exactly one consumer** — proactive-ant next-hop selection — **and that "data/reactive paths never read it."** A reactive ant may now be steered by it. This closes that gap.

## ADR-0016 (new)

Records the decision, and — more usefully than the decision itself — the two properties that bound what #244 can claim from it:

- **Not position-based.** No coordinates, no location service, no orbital model; the direction is pheromone the node already received. That is why it is a MANET mechanism that *also* applies to a constellation rather than a satellite special case, and why it degrades to "flood as before" instead of to a wrong answer.
- **Cannot help a cold start.** Diffusion advertises only destinations the advertiser already reaches, so a first discovery in a fresh network floods identically. It is a reconvergence / known-destination optimisation. Found by the unit test asserting `steers > 0` and failing — recorded so it is not rediscovered.

Default-off is justified in the repo's own terms: a non-source mechanism ships off until a benchmark justifies it (as `enableMacMetric` does). That is the *inverse* of ADR-0012's evaporation, where the gate exists to make the **fidelity** runnable rather than the deviation. Here the faithful behaviour is the default.

Alternatives recorded and rejected with reasons: unconditional adoption; letting data forwarding read virtual pheromone (that is ADR-0007's real invariant — an advert says "I can reach X", not "I have measured a good path to X", which is fine for steering a probe and not for betting delivery on); steer-and-broadcast; and scoping the mechanism to satellites.

## ADR-0007 (amended)

Status line marks it partly superseded on that one point and flags the consumer list as the state at time of writing. The invariant it was protecting is called out as intact: **data still never reads virtual pheromone.**

## `docs/fidelity.md`

- Mechanisms table gains the [1] §3.1 flooding row, marked faithful **by default** — the deviation is the off state.
- Known-deviations list gains item 6, explicitly noting it is listed for completeness rather than as an active deviation, pointing at #244 (measurement) and #245 (hazard).

## Companion issue #245

The steer **replaces** the broadcast rather than supplementing it, so a stale gradient can strand the single ant where a flood would have found a path. Two failure modes, unequally recoverable:

1. **Dead next hop** — MAC failure, detector D prunes it (ADR-0008). Costs `txFailureThreshold` × `reactiveRetryInterval`, and this path does not exist on adapters without MAC feedback.
2. **Gradient stale downstream** — the unicast succeeds, the ant dies further along, and there is **no local signal at all**; the origin re-steers to the same dead end every `reactiveRetryInterval`.

Carved out of #244 deliberately: aggregate PDR/NRL across seeds is the wrong instrument for a rare-but-total failure, and a mis-steer affecting one flow in fifty would vanish into the dispersion #28 is adding error bars for. #244 is now explicitly barred from recommending a default flip while #245 is open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_