### PR TITLE
fix(bench): carry jitter_eq51_ms through the campaign CSV

### DIFF
--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -134,7 +134,13 @@ METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
            "drop_ttl_pct", "drop_setup_pct", "drop_reconv_pct",
            "drop_repair_pct",
            "path_hops_mean", "path_hops_max", "path_div_used", "path_div_max",
-           "path_entropy_bits", "path_div_window_s", "jain_pkts"]
+           "path_entropy_bits", "path_div_window_s", "jain_pkts",
+           # #89: the thesis's eq 5.1 jitter, a *different quantity* from
+           # jitter_ms (arrival-gap change vs delay change) — both are carried
+           # because paper-parity claims must cite this one. emit() copies only
+           # the names in this list, so a column absent here is silently dropped
+           # from every campaign CSV even though anthocnet-compare emits it.
+           "jitter_eq51_ms"]
 PARAMS = ["runs", "nNodes", "area", "speed", "flows"]
 OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + ["runs", "nNodes", "areaX", "speed", "pause", "flows", "propagation"]


### PR DESCRIPTION
Follow-up to #247, which added `jitter_eq51_ms` to `anthocnet-compare --csv` but **not** to `run-scenarios.py`'s `METRICS` list. The column never reached `docs/benchmarks/campaign/*.csv` or the charts.

## Why it was silent

`emit()` builds its output dict by iterating `METRICS` explicitly:

```python
for m in METRICS:
    out[m] = r.get(m, "")
writer.writerow(out)
```

So a source column absent from `METRICS` is **ignored**, not raised. `csv.DictWriter` has no `extrasaction='ignore'` here, so an *extra key in the dict* would have thrown — but the dict never gets one, because it's constructed from the whitelist rather than from the parsed row. The pipeline ran clean and quietly emitted a CSV without the new metric.

## Why it matters

The metric was invisible to exactly the sweeps that are supposed to cite it. #89's entire conclusion is that paper-parity jitter claims must quote eq 5.1 rather than the FlowMonitor column — and the campaign CSV is where those claims get sourced from. Shipping the column in the harness but not the pipeline means the parity claim still can't be made.

## Change

One entry added to `METRICS`, plus a comment at the list recording the silent-drop behaviour — this list is a second place anyone adding a harness column has to touch, and nothing previously said so.

Downstream consumers are all `csv.DictReader` (by header name), so nothing else needs a change: `make-charts.py`, `update-benchmarks.py` and the `benchmark-results` skill's `scenario_check.py` read what they name and ignore the rest.

## Verification

```
jitter_eq51_ms in METRICS: True
METRICS count: 41
no dupes: True
in OUT_COLUMNS: True
```

Python-only change; no C++ touched, so the core suite and ns-3 build are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_