### PR TITLE
fix(skills): validate ##BENCH## cells' diagnostic lines, not just the table

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -51,6 +51,34 @@ SINGLE_PATH_DIV_MAX = 1.10
 
 ROW = re.compile(r"^\s*(?:##BENCH##\s+)?([a-z][\w-]*)((?:\s+[-\d.]+|\s+inf)+)\s*$")
 
+# Diagnostic lines of a saved cell ('# paths anthocnet divUsed=1.104 ...').
+# anthocnet-compare prints one per (family, protocol) after the table; they are
+# structured key=value, so parse_results() folds them into the protocol's row
+# and the CSV-born rules fire unchanged on text input (#230 finding 3 — the
+# results gate returned OK on a cell whose diversity figures were out of band,
+# because ROW can never match a '# ' line). '# stddev' is deliberately not a
+# family here: no results-mode rule reads dispersion, so parsing it would be
+# dead weight.
+DIAG_LINE = re.compile(r"^\s*#\s+(paths|energy|drops|reorder)\s+([a-z][\w-]*)\s+(.+)$")
+DIAG_KEYS = {
+    "paths":   {"hopsMean": "hops", "hopsMax": "hops_max", "divUsed": "div",
+                "divMax": "div_max", "entropyBits": "entropy"},
+    # energy(J)/J-per-pkt live at table positions 10/11, which the 9-number
+    # ##BENCH## block does not carry; the '# energy' line adds the residual
+    # bounds. 'pdr' on the '# drops' line is deliberately unmapped — the
+    # table row's pdr is the authoritative one and must not be overwritten
+    # by a rounded duplicate.
+    "energy":  {"initJ": "energy_init", "resMinJ": "res_min",
+                "resMeanJ": "res_mean"},
+    "drops":   {"route": "drop_route", "queue": "drop_queue",
+                "mac": "drop_mac", "chan": "drop_chan", "ttl": "drop_ttl",
+                "setup": "drop_setup", "reconv": "drop_reconv",
+                "repair": "drop_repair"},
+    "reorder": {"ratio": "reorder_ratio", "ratioWorstFlow": "reorder_ratio_max",
+                "extentMean": "reorder_extent_mean",
+                "extentMax": "reorder_extent_max", "bufMax": "reorder_buf_max"},
+}
+
 issues = []
 
 
@@ -178,24 +206,26 @@ def parse_results(path):
     configured initial energy and the first-death time live in the CSV only
     (the human output puts them on a '# energy' line, which ROW does not match).
 
-    Reordering fields (#212) exist only in CSVs produced after the reordering
-    instrumentation landed; older inputs simply omit them and the reordering
-    rules below are skipped. They are CSV-only by design — anthocnet-compare
-    prints them on a '# reorder' line rather than widening the fixed-width
-    results table, and ROW does not match a '# ' line.
+    Reordering (#212), drop-cause (#215) and route-quality (#217) fields ride
+    the '# reorder' / '# drops' / '# paths' / '# energy' diagnostic lines of a
+    saved cell rather than the fixed-width table, and until #230's second
+    finding they were **not parsed at all** on text input — every rule below
+    silently skipped, so `results` on a ##BENCH## cell certified only the four
+    headline invariants while returning the same OK it returns for a fully
+    checked CSV. That is exactly the input the skill's own order-of-operations
+    recommends validating *before* a taxonomy sweep, so the cheap pre-sweep
+    check was the one that could not see the defects the sweep would be full
+    of. DIAG_LINE/DIAG_KEYS below close that: the diagnostic lines are
+    structured key=value, so they parse into the same row dict the CSV branch
+    yields and every existing rule fires unchanged on both input formats.
 
-    Drop-cause fields (#215) are likewise CSV-only and post-instrumentation:
-    anthocnet-compare prints them on a '# drops' line rather than widening the
-    fixed-width table, so a results table yields None for all of them and the
-    drop rules below skip. The three AntHocNet-only causes are deliberately
-    **blank** for the other protocols (the cause does not exist there, as
-    opposed to existing and measuring zero); a blank parses to None and is
-    skipped, exactly like an absent column.
-
-    Route-quality fields (#217) are likewise post-instrumentation and skipped
-    when absent. The results table carries the two headline columns (hops,
-    jain) at positions 12/13; used-path diversity and its entropy live in the
-    CSV only (the human output puts them on a '# paths' line).
+    Fields absent from an input (older runs predating an instrumentation, the
+    energy table columns the 9-number ##BENCH## block does not carry, the
+    AntHocNet-only drop causes printed as '-' for the other protocols) parse
+    to None and their rules skip, exactly like an absent CSV column. If a file
+    holds several tables for the same protocol, diagnostics attach to that
+    protocol's last row — a saved single-point cell has one row per protocol,
+    which is the intended input.
     """
     with open(path) as fh:
         text = fh.read()
@@ -232,25 +262,43 @@ def parse_results(path):
                    "entropy": r.get("path_entropy_bits"),
                    "jain": r.get("jain_pkts")}
         return
+    rows = []          # yielded in table order
+    by_proto = {}      # diagnostics merge into the protocol's last row
     for line in text.splitlines():
         m = ROW.match(line)
-        if not m:
+        if m:
+            proto, nums = m.group(1), m.group(2).split()
+            if proto in ("protocol",) or len(nums) < 5:
+                continue
+            row = {"where": os.path.basename(path), "proto": proto,
+                   "pdr": nums[0], "delay": nums[1], "delay99": nums[2],
+                   "nrl": nums[4]}
+            if len(nums) >= 6:
+                row["jitter"] = nums[5]
+            if len(nums) >= 11:  # #209: ... nrlBytes, energy(J), J/pkt
+                row["energy"] = nums[9]
+                row["energy_per_pkt"] = nums[10]
+            if len(nums) >= 13:  # #217: ... J/pkt, hops, jain
+                row["hops"] = nums[11]
+                row["jain"] = nums[12]
+            rows.append(row)
+            by_proto[proto] = row
             continue
-        proto, nums = m.group(1), m.group(2).split()
-        if proto in ("protocol",) or len(nums) < 5:
+        d = DIAG_LINE.match(line)
+        if not d:
             continue
-        row = {"where": os.path.basename(path), "proto": proto,
-               "pdr": nums[0], "delay": nums[1], "delay99": nums[2],
-               "nrl": nums[4]}
-        if len(nums) >= 6:
-            row["jitter"] = nums[5]
-        if len(nums) >= 11:  # #209: ... nrlBytes, energy(J), J/pkt
-            row["energy"] = nums[9]
-            row["energy_per_pkt"] = nums[10]
-        if len(nums) >= 13:  # #217: ... J/pkt, hops, jain
-            row["hops"] = nums[11]
-            row["jain"] = nums[12]
-        yield row
+        family, proto = d.group(1), d.group(2)
+        row = by_proto.get(proto)
+        if row is None:
+            continue  # diagnostic with no table row above it — nothing to bind to
+        keys = DIAG_KEYS[family]
+        for k, v in re.findall(r"([A-Za-z]\w*)=([-\w.]+)", d.group(3)):
+            # '-' (an AntHocNet-only cause on a baseline row) and other
+            # non-numeric junk are stored as-is; num() turns them into None,
+            # so the rules skip them exactly like an absent CSV blank.
+            if k in keys:
+                row[keys[k]] = v
+    yield from rows
 
 
 def cmd_results(a):

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -319,6 +319,110 @@ def _preflight_static():
            f"window rule fired on a static field\n{out}")
 
 
+# --- ##BENCH## cell input: the diagnostic lines feed the same rules (#230) ----
+#
+# Until this landed, `results` on a saved cell parsed only the table rows: every
+# '# paths' / '# drops' / '# reorder' / '# energy' line was skipped by ROW, so
+# the drop/reorder/route-quality/energy rules never ran and a cell whose
+# diversity figures were out of band still returned OK — measured on run
+# 30379320885, where planting divUsed=9.999 changed nothing. The fixture below
+# is that run's real cell (paper-base, main@6a479fa, time=300, runs=2,
+# pathWindowS=4); its aodv/olsr rows genuinely breach the single-path bound, so
+# the *unmodified* cell must FAIL — that is finding 2 on #230, now gate-visible.
+
+CELL = """\
+##BENCH## anthocnet 71.9 410.8 1797.5 3.63 278.02 212.35 542.5 inf 302.165
+##BENCH## aodv 81.7 41.4 802.5 4.60 60.09 66.65 6.0 inf 31.557
+##BENCH## olsr 76.6 10.2 30.0 3.84 6.45 13.89 1.5 inf 13.284
+##BENCH## dsdv 70.2 16.5 698.0 3.77 33.90 29.13 2.0 inf 23.232
+# paths anthocnet divUsed=1.104 divMax=3.0 entropyBits=0.101 windowS=4.0 hopsMean=3.42 hopsMax=44.5
+# paths aodv divUsed=1.112 divMax=2.5 entropyBits=0.112 windowS=4.0 hopsMean=2.07 hopsMax=7.5
+# paths olsr divUsed=1.117 divMax=2.0 entropyBits=0.117 windowS=4.0 hopsMean=1.69 hopsMax=6.0
+# paths dsdv divUsed=1.057 divMax=2.0 entropyBits=0.057 windowS=4.0 hopsMean=1.73 hopsMax=6.5
+# energy anthocnet initJ=5000.0 resMinJ=4740.6 resMeanJ=4741.9 resSdJ=0.868 firstDeathS=-1.0
+# drops anthocnet pdr=71.88 route=2.33 queue=0.00 mac=0.97 chan=24.01 ttl=0.36 sum=99.56 other=0.00 [route: setup=0.12 reconv=2.26 repair=0.27]
+# drops aodv pdr=81.72 route=3.29 queue=0.00 mac=9.25 chan=5.59 ttl=0.04 sum=99.89 other=0.00 [route: setup=- reconv=- repair=-]
+# reorder anthocnet ratio=0.0077 ratioWorstFlow=0.0358 extentMean=0.23 extentMax=1.00 bufMax=58.00
+"""
+
+
+def run_cell(text):
+    """Check a ##BENCH## cell text; return (levels, printed output)."""
+    fd, path = tempfile.mkstemp(suffix=".txt")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        sc.issues = []
+        args = argparse.Namespace(files=[path], anchor=None)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            try:
+                sc.cmd_results(args)
+            except SystemExit:
+                pass
+        return list(sc.issues), out.getvalue()
+    finally:
+        os.unlink(path)
+
+
+@case("cell: real run 30379320885 FAILs on its own out-of-band baselines")
+def _cell_real():
+    levels, out = run_cell(CELL)
+    expect(levels.count("FAIL") == 2, "cell-real",
+           f"expected exactly the aodv+olsr diversity FAILs, got {levels}\n{out}")
+    expect("aodv: path diversity 1.112" in out and
+           "olsr: path diversity 1.117" in out, "cell-real",
+           f"wrong rows flagged\n{out}")
+
+
+@case("cell: impossible divUsed on a '# paths' line fires (the 9.999 probe)")
+def _cell_div_fires():
+    levels, out = run_cell(CELL.replace("aodv divUsed=1.112",
+                                        "aodv divUsed=9.999"))
+    expect("path diversity 9.999" in out, "cell-div",
+           f"planted divUsed=9.999 not flagged\n{out}")
+
+
+@case("cell: broken drop identity on a '# drops' line fires")
+def _cell_drops_fire():
+    levels, out = run_cell(CELL.replace("chan=24.01", "chan=90.00"))
+    expect("do not account for the offered packets" in out, "cell-drops",
+           f"planted chan=90 left the identity unchecked\n{out}")
+
+
+@case("cell: closing drop identity stays quiet, '-' sub-causes skip")
+def _cell_drops_quiet():
+    levels, out = run_cell(CELL)
+    expect("do not account" not in out and "exit path is not attributed" not in out,
+           "cell-drops-quiet",
+           f"drop rules over-fired on a closing identity / '-' causes\n{out}")
+
+
+@case("cell: out-of-range reorder ratio on a '# reorder' line fires")
+def _cell_reorder_fires():
+    levels, out = run_cell(CELL.replace("ratio=0.0077", "ratio=9.9999"))
+    expect("reorder_ratio 9.9999 outside [0,1]" in out, "cell-reorder",
+           f"planted ratio not flagged\n{out}")
+
+
+@case("cell: residual energy above initial on a '# energy' line fires")
+def _cell_energy_fires():
+    levels, out = run_cell(CELL.replace("resMinJ=4740.6", "resMinJ=5740.6"))
+    expect("exceeds initial" in out, "cell-energy",
+           f"planted residual > initial not flagged\n{out}")
+
+
+@case("cell: rounded pdr on a '# drops' line must NOT overwrite the row pdr")
+def _cell_pdr_authoritative():
+    # The '# drops' pdr is a rounded duplicate; mapping it would let a
+    # corrupted diagnostic line silently replace the table value the headline
+    # rules already checked. Corrupt it and nothing may change.
+    levels, out = run_cell(CELL.replace("# drops anthocnet pdr=71.88",
+                                        "# drops anthocnet pdr=1.00"))
+    base, _ = run_cell(CELL)
+    expect(levels == base, "cell-pdr",
+           f"'# drops' pdr leaked into the row: {levels} vs {base}\n{out}")
+
+
 def main():
     for name, fn in CASES:
         fn()


### PR DESCRIPTION
Closes the third finding on #230: `scenario_check.py results` on a saved `##BENCH##` cell certified only the four headline invariants (PDR bounds, delay99 ≥ mean, non-negatives, anchor floor). Every drop-cause, reordering, route-quality and energy rule silently skipped, because those fields ride `# drops` / `# reorder` / `# paths` / `# energy` diagnostic lines that the `ROW` regex can never match.

**Measured on run [30379320885](https://github.com/danieljoppi/AntHocNet/actions/runs/30379320885):** planting `divUsed=9.999`, a broken drop identity, and `reorder ratio=9.9999` into a cell all returned `OK (0 fail, 0 warn)`.

The inversion this created: the cheap single-point check the skill's own order-of-operations prescribes *before* a taxonomy sweep was the one input format that could not see the defect class (#230) the sweep would be full of. CSV-only parsing was a documented design decision — the diversity control being exactly what the pre-sweep check exists to catch is what changed the calculus.

## Fix

The diagnostic lines are already structured `key=value`, so parse them (`DIAG_LINE` / `DIAG_KEYS`) into the same row dict the CSV branch yields — **every existing rule fires unchanged on both input formats, no new rules**. Deliberate details, each pinned by a test:

- `# drops` carries a rounded `pdr=` duplicate → **unmapped**, so a corrupted diagnostic line cannot overwrite the authoritative table value.
- `-` sub-causes on baseline rows parse to `None` via `num()` and skip, like a blank CSV cell.
- `energy(J)` / `J/pkt` stay table-positional (positions 10/11, which the 9-number `##BENCH##` block does not carry); the `# energy` line adds the residual-bounds inputs only.
- `# stddev` is not parsed: no results-mode rule reads dispersion.

## Tests: 12 → 23 cases

New cell-input family in `test_scenario_check.py`, fixture = run 30379320885's **real cell**, per the file's own rule that fixtures are real campaign readings. Must-fire probes are the exact ones used to demonstrate the blind spot; must-stay-quiet cases pin the closing drop identity (`sum=99.56`), the `-` skip, and pdr non-overwrite.

Worth noting: the *unmodified* real cell now correctly FAILs — its aodv/olsr rows genuinely breach the single-path diversity bound (1.112 / 1.117 > 1.10 at `pathWindowS=4`). That is #230's finding 2 made gate-visible instead of eyeball-only, and the test asserts exactly those two FAILs and no others.

```
python3 .claude/skills/benchmark-results/test_scenario_check.py
23 cases passed
```

Skill code only — core suite untouched; `lint.yml` runs the self-test on every PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_