### PR TITLE
fix(core): restore proactiveInterval to 10 s — #252 leaked the 2 s rate it claimed not to ship

### DIFF
--- a/core/include/anthocnet/core/config.h
+++ b/core/include/anthocnet/core/config.h
@@ -159,13 +159,13 @@ struct Config {
 
     /// Timer intervals (seconds).
     double helloInterval     = 1.0;
-    /// Proactive forward-ant period per active session. **2.0 s is the thesis's
-    /// measured optimum, not its stated default** — the thesis normally clocks
-    /// proactive ants at `t_hello` (1 s) but its §5.3.3 sweep over
-    /// 0.5/1/2/5/10/20/50 s reports *"Sending one ant every 2 s almost always
-    /// gives the best performance"* (lines 6619-6621). Only affordable together
-    /// with `proactiveVirtualMargin` (#180).
-    double proactiveInterval = 2.0;
+    /// Proactive forward-ant period per active session. 10.0 is the
+    /// long-standing repo value with no recorded source (#182); the thesis's
+    /// §5.3.3 measured optimum is 2 s, but adopting it is #248's sweep to
+    /// decide — PR #252 accidentally shipped 2.0 here while claiming not to,
+    /// which the per-merge refresh measured as NRL ×4.7 / PDR −12 pp at
+    /// paper-base (#254). Do not change this default without that A/B.
+    double proactiveInterval = 10.0;
     double lifeAnt           = 2.0;
 
     /// A neighbour is presumed gone after this many missed hellos

--- a/ns2/src/ahn_router.h
+++ b/ns2/src/ahn_router.h
@@ -27,7 +27,7 @@
 #include "anthocnet/ant_packet_ns2.h"
 
 #define AHN_HELLO_INTERVAL      1.0
-#define AHN_PROACTIVE_INTERVAL  2.0
+#define AHN_PROACTIVE_INTERVAL  10.0
 #define AHN_NETWORK_DIAMETER    30
 #define AHN_LIFE_ANT            2.0
 #define AHN_QUEUE_MAX           64      // total pending packets cap (B1)

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -40,7 +40,7 @@ RoutingProtocol::RoutingProtocol()
     : m_started(false),
       m_queue(64, Seconds(3)),
       m_helloInterval(Seconds(1.0)),
-      m_proactiveInterval(Seconds(2.0)),
+      m_proactiveInterval(Seconds(10.0)),
       m_alpha(0.7),
       m_betaAnts(1.0),
       m_betaData(2.0),
@@ -83,13 +83,8 @@ TypeId RoutingProtocol::GetTypeId() {
                           TimeValue(Seconds(1.0)),
                           MakeTimeAccessor(&RoutingProtocol::m_helloInterval),
                           MakeTimeChecker())
-            .AddAttribute("ProactiveInterval",
-                          "Proactive forward-ant interval per active session. "
-                          "Default 2 s = the Ducatelle 2007 thesis's measured "
-                          "optimum (sec 5.3.3: \"Sending one ant every 2 s almost "
-                          "always gives the best performance\"), not its stated "
-                          "t_hello=1 s default (#180).",
-                          TimeValue(Seconds(2.0)),
+            .AddAttribute("ProactiveInterval", "Proactive forward-ant interval.",
+                          TimeValue(Seconds(10.0)),
                           MakeTimeAccessor(&RoutingProtocol::m_proactiveInterval),
                           MakeTimeChecker())
             .AddAttribute("Alpha", "Pheromone evaporation weight (ALFA).",


### PR DESCRIPTION
Root cause and fix for **#254** (P1): per-merge quick refresh showed AntHocNet **PDR −12.1 pp, NRL ×4.7, delay ×3.4** at paper-base between `b8da428` and `7478a9d`, with every baseline byte-identical.

## Attribution chain

1. **Refresh time series convicted the window** — AODV/OLSR/DSDV rows byte-identical across all refreshes ⇒ harness + seeds unchanged ⇒ AntHocNet code.
2. **Bisect cleared #224.** scenario-matrix quick `paper-base` at exactly `0ac878f` (rescued as `docs/benchmarks/campaign/30513828001-run.csv`): anthocnet **84.4 / 82.0 / 1278.0 / 55.610** — *byte-identical* to the pre-window refresh. #224's "correct on single-interface nodes" claim is empirically confirmed; I had named it prime suspect on #254 and have retracted that there.
3. **Default sweep found the leak.** Diffing every `Config` default on `main` against `b8da428` left exactly one unexplained change: `proactiveInterval` **10.0 → 2.0**, in all three trees (`config.h`, `AHN_PROACTIVE_INTERVAL`, ns-3 ctor + `ProactiveInterval` attribute).

## What happened in #252

Its PR body states: *"NOT landing: the rate change (proactiveInterval 10 s → 2 s)."* The cherry-pick applied the #188 branch's per-file diffs, which carried the rate change; I flipped the margin defaults back to `0` and verified "no 0.10 remnants" — **and never grepped for the interval**. So `main` shipped the one arm #188's investigation says is never safe alone: **5× faster rate, no gate** — the exact `rate ONLY (gate off, 2s)` configuration `exp_gate_cascade` measures at proact **720 vs 138**. The refresh regression is that arm measured by accident: emission ×5 → NRL ×4.7, contention → PDR −12 pp.

## Why every gate missed it

`make test` cannot see a timer default (the testbench drives timers itself); CI's e2e smokes run seconds; the CI-legs anchors don't cover paper-base. The only instrument that caught it was the per-merge benchmark refresh — **two days later**. Follow-up noted on #254: a config-defaults regression test (assert documented defaults verbatim in `make test`) turns this class of leak from a two-day benchmark find into a compile-time one.

## Fix

- All four sites restored to **10 s**.
- The #188-derived comments justifying 2 s replaced with the true state: 10 s is the long-standing unsourced value (#182), the thesis optimum is 2 s, and adopting it is **#248's sweep to decide** — this incident is now the second reason that A/B is mandatory.
- `docs/` needed no change — `configuration.md` said `10.0` throughout; only code leaked.
- The #252 gate mechanism itself is untouched and still default-off.

## Verification

```
make test                 24/24
ns2/patch/selftest.sh     PASS
```

Definitive verification is the **next quick refresh returning anthocnet to ~84.4 PDR / ~55.6 NRL** at paper-base — the refresh fires on this merge. #254 stays open until that number is in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_