### PR TITLE
feat(bench): split the benchmark surface into MANET and satellite views

### DIFF
--- a/.github/workflows/satellite-benchmark.yml
+++ b/.github/workflows/satellite-benchmark.yml
@@ -1,0 +1,161 @@
+name: Satellite benchmark (manual)
+
+# The satellite regime's counterpart of paper-benchmark.yml (#192 track).
+# Runs the isl-grid harness — a +Grid torus of point-to-point ISLs, every node
+# holding one interface per link — instead of the wifi MANET field. Manual
+# dispatch only: like the paper scenario, a real grid at runs>=5 is too heavy
+# for per-merge CI, and the CI matrix already runs the fast pieces of this
+# suite on every PR (the 4x4 delivery smoke on every leg; the analytic anchor
+# gate and the ISL determinism gate on the 3.42 leg — see ci.yml and
+# ns3/tools/check-sat-anchors.sh).
+#
+# Results interpretation lives in docs/benchmarks/satellite/isl-grid.md.
+# The precomputed-shortest-path control row this suite ultimately needs is
+# #216's scope and does not exist yet: until it lands, AODV/OLSR/DSDV are
+# secondary references, not the claim.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'ns-3 image tag. Suffix -opt (e.g. 3.42-opt) selects the optimized-profile image (#123); use it for campaign runs.'
+        default: '3.42'
+      rows:
+        description: 'Orbital planes (grid rows)'
+        default: '4'
+      cols:
+        description: 'Satellites per plane (grid columns)'
+        default: '4'
+      torus:
+        description: 'Wrap the grid edges (+Grid torus); false = open grid'
+        default: 'true'
+      islDelayMs:
+        description: 'One-way ISL propagation delay (ms) — ~3-13 ms for LEO'
+        default: '5'
+      islRate:
+        description: 'ISL data rate'
+        default: '10Mbps'
+      time:
+        description: 'Sim time (s)'
+        default: '300'
+      runs:
+        description: 'RNG runs to average'
+        default: '3'
+      flows:
+        description: 'Number of CBR flows'
+        default: '8'
+      cbrBps:
+        description: 'Per-flow CBR rate (bits/s)'
+        default: '4096'
+      protocols:
+        description: 'Comma-separated protocol list. anthocnet,aodv is the #250 hop-delay discriminator pair.'
+        default: 'anthocnet,aodv,olsr,dsdv'
+      extraArgs:
+        description: 'Extra isl-grid args appended verbatim (e.g. --ns3::anthocnet::RoutingProtocol::EnableDirectedReactive=true for the #244 satellite arm)'
+        default: ''
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  satellite:
+    name: isl-grid scenario + diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/ns3:${{ github.event.inputs.version }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install AntHocNet module
+        run: make install-ns3 NS3DIR=/opt/ns-3
+      - name: Resolve ns-3 build profile (#123)
+        # Same rule as paper-benchmark.yml: the reconfigure below must not
+        # silently downgrade an optimized image to the default profile. Source
+        # of truth is NS3_PROFILE from the image env; tag-suffix fallback for
+        # pre-#123 images.
+        env:
+          VERSION_TAG: ${{ github.event.inputs.version }}
+        run: |
+          profile="${NS3_PROFILE:-}"
+          if [ -z "$profile" ]; then
+            case "$VERSION_TAG" in
+              *-opt) profile=release ;;
+              *)     profile=default ;;
+            esac
+            echo "image has no NS3_PROFILE env (pre-#123 image); inferred from tag '$VERSION_TAG'"
+          fi
+          flag=""
+          [ "$profile" = "default" ] || flag="-d $profile"
+          echo "ns-3 build profile: $profile (configure flag: '${flag:-<none>}')"
+          echo "NS3_PROFILE=$profile" >> "$GITHUB_ENV"
+          echo "NS3_PROFILE_FLAG=$flag" >> "$GITHUB_ENV"
+      - name: Configure
+        run: |
+          cd /opt/ns-3
+          # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
+          ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
+            --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+      - name: Build
+        run: cd /opt/ns-3 && ./ns3 build && ./ns3 show profile
+      - name: Run isl-grid scenario
+        # bash explicitly: container jobs default to sh, where pipefail is an
+        # illegal option (the paper-benchmark run 29664072922 lesson).
+        shell: bash
+        run: |
+          cd /opt/ns-3
+          cmd="isl-grid \
+            --rows=${{ github.event.inputs.rows }} \
+            --cols=${{ github.event.inputs.cols }} \
+            --torus=${{ github.event.inputs.torus }} \
+            --islDelayMs=${{ github.event.inputs.islDelayMs }} \
+            --islRate=${{ github.event.inputs.islRate }} \
+            --time=${{ github.event.inputs.time }} \
+            --runs=${{ github.event.inputs.runs }} \
+            --flows=${{ github.event.inputs.flows }} \
+            --cbrBps=${{ github.event.inputs.cbrBps }} \
+            --diag --protocols=${{ github.event.inputs.protocols }}"
+          if [ -n "${{ github.event.inputs.extraArgs }}" ]; then
+            cmd="$cmd ${{ github.event.inputs.extraArgs }}"
+          fi
+          echo "$cmd"
+          # pipefail + captured stderr, per the #28 hardening in
+          # paper-benchmark.yml: a bad extraArgs attribute must fail the job,
+          # not pass it with an empty table.
+          set -o pipefail
+          timewrap=""
+          if [ -x /usr/bin/time ]; then
+            timewrap="/usr/bin/time -v -o $GITHUB_WORKSPACE/time-v.log"
+          fi
+          $timewrap ./ns3 run "$cmd" 2>"$GITHUB_WORKSPACE/ns3-stderr.log" \
+            | tee "$GITHUB_WORKSPACE/satellite-results.txt" \
+            || { echo "--- ns-3 run FAILED; stderr tail ---"; \
+                 tail -n 60 "$GITHUB_WORKSPACE/ns3-stderr.log"; exit 1; }
+          if [ -s "$GITHUB_WORKSPACE/ns3-stderr.log" ]; then
+            echo "--- ns-3 stderr tail (non-fatal) ---"
+            tail -n 20 "$GITHUB_WORKSPACE/ns3-stderr.log"
+          fi
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: satellite-benchmark
+          path: |
+            satellite-results.txt
+            ns3-stderr.log
+            time-v.log
+          retention-days: 30
+      - name: Compact result block (cheap to fetch via get_job_logs tail)
+        # Re-run the identical scenario in --csv mode? No — that doubles the
+        # sim cost. The human table + ##RUN## lines are already in the results
+        # file; print its tail plus a ##PERF## line so a 20-line log fetch
+        # captures the numbers, mirroring paper-benchmark's contract.
+        shell: bash
+        run: |
+          tail -n 30 "$GITHUB_WORKSPACE/satellite-results.txt"
+          if [ -f "$GITHUB_WORKSPACE/time-v.log" ]; then
+            wall=$(grep -oP 'Elapsed \(wall clock\) time.*: \K.*' "$GITHUB_WORKSPACE/time-v.log" || true)
+            rss=$(grep -oP 'Maximum resident set size \(kbytes\): \K\d+' "$GITHUB_WORKSPACE/time-v.log" || true)
+            echo "##PERF## isl-grid all ${wall:-?} ${rss:-?}"
+          fi

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,5 +1,17 @@
 # Benchmarks
 
+Two regimes, two suites, one protocol build ([ADR-0015](adr/0015-satellite-substrate-lives-in-the-image.md)
+— the build never forks; only the scenario harness and the baselines change):
+
+| Regime | Suite | Baselines | Status |
+|---|---|---|---|
+| **MANET** (original) | this page — discrete taxonomy + sweeps, wifi field | AODV / OLSR / DSDV | per-merge refresh + manual campaigns |
+| **Satellite** (ISL) | [satellite/isl-grid.md](benchmarks/satellite/isl-grid.md) — +Grid torus, point-to-point ISLs | same, until [#216](https://github.com/danieljoppi/AntHocNet/issues/216)'s precomputed-shortest-path control lands | manual dispatch + per-PR analytic anchor/determinism gates; no committed results yet |
+
+A number is only comparable **within** its regime — the regimes differ in what
+routing even has to solve ([network-regimes.md](network-regimes.md)). Everything
+below this table is the **MANET** suite.
+
 AntHocNet measured against the standard NS-3 MANET routing protocols
 (**AODV**, **OLSR**, **DSDV**) on identical scenarios — same node layout,
 mobility and traffic, driven from the same RNG runs so every protocol sees the
@@ -21,6 +33,8 @@ index: the headline cross-scenario summary, plus a link to every detail page.
 | [area](benchmarks/sweeps/area.md) | Paper Fig. 1 — long edge 1500→2500 m. |
 | [pause](benchmarks/sweeps/pause.md) | Paper Fig. 2 — pause time 0→900 s. |
 | [scale](benchmarks/sweeps/scale.md) | Paper Fig. 3 — terrain ×f, nodes ×f² (50→200 nodes). |
+| **Satellite suite** | |
+| [satellite/isl-grid.md](benchmarks/satellite/isl-grid.md) | The ISL-grid regime: harness, analytic anchors, how to dispatch, and what it is waiting on (#216). |
 | [benchmarks/README.md](benchmarks/README.md) | How the figures and this folder are generated. |
 
 ## Results

--- a/docs/benchmarks/satellite/isl-grid.md
+++ b/docs/benchmarks/satellite/isl-grid.md
@@ -1,0 +1,95 @@
+# Satellite suite: the ISL grid
+
+**Regime:** satellite / inter-satellite-link mesh — the second of the two
+regimes this project measures. The MANET suite (the original) lives under
+[`scenarios/`](../../benchmarks.md); why the two regimes are different enough
+to need separate suites is [`network-regimes.md`](../../network-regimes.md).
+
+[← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) ·
+[Methodology](../methodology.md)
+
+## What this suite is, and is not
+
+One harness, [`ns3/examples/isl-grid.cc`](../../../ns3/examples/isl-grid.cc):
+an R×C **+Grid torus** of point-to-point ISLs — one `/30` subnet per link, so
+every satellite holds one interface *per neighbour* (degree 4 on the torus).
+That multi-interface shape is the point: it is what the MANET suite can never
+exercise, and it is what #203 broke on before [#224](https://github.com/danieljoppi/AntHocNet/pull/224)
+fixed next-hop resolution per interface. Metrics mirror `anthocnet-compare`'s
+definitions at the same IP-layer counting point, so a number here is comparable
+in *kind* (never in regime) to a MANET number.
+
+It is a **static snapshot** grid: no orbital mechanics, no GSL handover, no
+link churn. That makes it the quiet-cell instrument — the regime where the
+[#216](https://github.com/danieljoppi/AntHocNet/issues/216) precomputed
+shortest-path control is expected to win and AntHocNet is expected to lose.
+The adversarial cells that could show the opposite (unpredicted ISL loss,
+asymmetric congestion, handover churn) are #216's scope and **do not exist
+yet**; until they do, results from this page support harness-validation
+claims, not protocol-advantage claims.
+
+## Configuration
+
+| knob | default | meaning |
+|---|---|---|
+| `rows` × `cols` | 4 × 4 | orbital planes × satellites per plane |
+| `torus` | true | wrap the edges (+Grid); false = open grid |
+| `islDelayMs` | 5 | one-way ISL propagation delay (LEO ISLs are ~3–13 ms) |
+| `islRate` | 10Mbps | ISL data rate |
+| `flows` / `cbrBps` | 8 / 4096 | CBR load |
+| `protocols` | anthocnet,aodv,olsr,dsdv | `anthocnet,aodv` is the [#250](https://github.com/danieljoppi/AntHocNet/issues/250) hop-delay discriminator pair |
+
+## How to run it
+
+- **Dispatch** the manual **Satellite benchmark** workflow
+  (`satellite-benchmark.yml`) — the regime's counterpart of the MANET
+  `paper-benchmark.yml`. Same contract: results file + `time -v` artifact, a
+  compact tail block cheap to fetch from the job log, `extraArgs` for ns-3
+  attribute overrides (e.g.
+  `--ns3::anthocnet::RoutingProtocol::EnableDirectedReactive=true` for the
+  [#244](https://github.com/danieljoppi/AntHocNet/issues/244) satellite arm).
+- **Locally**, with an ns-3 tree carrying the module:
+  `./ns3 run "isl-grid --rows=4 --cols=4 --runs=3 --protocols=anthocnet,aodv"`.
+
+## Validation gates (run on every PR, 3.42 CI leg)
+
+The satellite suite's anchors are **analytic**, and therefore stricter than
+the MANET suite's literature-derived ones
+([methodology](../methodology.md#validation-anchors-known-expected-results)):
+a point-to-point grid with fixed per-link delay has no stochastic channel, so
+
+- **single-isl**: delivery over one ISL must be ≥ `sat_single_isl_pdr_min`
+  (99.0 — physics says 100);
+- **hop-delay**: mean delay must sit within `sat_hop_delay_slack_ms` (1.5 ms)
+  of the analytic floor `hops × islDelayMs`;
+- **determinism**: the same seed twice must be byte-identical
+  (`check-determinism.sh … isl-grid`).
+
+Values live in [`ns3/tools/anchors.yml`](../../../ns3/tools/anchors.yml);
+the gate is [`ns3/tools/check-sat-anchors.sh`](../../../ns3/tools/check-sat-anchors.sh)
+(#237/#238). Known open question against the hop-delay floor: the ~0.25 ms
+excess tracked in [#250](https://github.com/danieljoppi/AntHocNet/issues/250)
+— inside the slack, not yet attributed.
+
+## Results
+
+**No committed results yet.** This suite has no per-merge refresh (the MANET
+quick taxonomy keeps that job); satellite numbers are produced by manual
+dispatch and should be recorded here (and on the driving issue, per ADR-0013)
+when a campaign-grade run exists. Do not quote the CI smoke numbers — they are
+delivery gates at tiny scale, not measurements.
+
+What the suite is waiting on, in dependency order:
+
+1. [#216](https://github.com/danieljoppi/AntHocNet/issues/216) — the
+   precomputed-shortest-path control row and the satellite scenario class in
+   the taxonomy (with the adversarial cells). **The control is what makes a
+   satellite result a result.**
+2. [#206](https://github.com/danieljoppi/AntHocNet/issues/206) — per-next-hop
+   congestion signal, precondition for the congestion cell.
+3. [#244](https://github.com/danieljoppi/AntHocNet/issues/244) /
+   [#245](https://github.com/danieljoppi/AntHocNet/issues/245) — the directed
+   reactive A/B and its open steering hazard.
+4. The strategy frame for reading any of it:
+   [#192 analysis](https://github.com/danieljoppi/AntHocNet/issues/192)
+   (detect+reconverge race, path-stretch cost, bootstrap uniformity).


### PR DESCRIPTION
Gives the project the two-regime structure the satellite track (#192) has needed since #214: the ISL suite existed as CI gates and an example binary, but had **no view** (the benchmarks index presented MANET as the only regime) and **no dispatchable benchmark** (nothing ran `isl-grid` outside second-scale CI smokes).

**One build, two views.** This deliberately does *not* fork the protocol or the images — ADR-0015 decided that and nothing here reopens it. What splits is presentation and instrumentation: which harness, which baselines, which gates, which results pages.

| | MANET (original) | Satellite (ISL) |
|---|---|---|
| harness | `anthocnet-compare` (wifi field) | `isl-grid` (+Grid torus, p2p ISLs, one interface per link) |
| suite entry | `docs/benchmarks.md` | `docs/benchmarks/satellite/isl-grid.md` (new) |
| dispatch | `paper-benchmark.yml` / `scenario-matrix.yml` | **`satellite-benchmark.yml` (new)** |
| per-PR gates | anchors + determinism (literature-derived) | anchors + determinism (**analytic** — stricter, #237/#238) |
| results | per-merge refresh + committed campaigns | manual dispatch; **none committed yet, by design** |

## `satellite-benchmark.yml`

Mirror of `paper-benchmark.yml` for the grid's own knobs (`rows/cols/torus/islDelayMs/islRate/flows/cbrBps/runs/protocols/extraArgs`), inheriting its hardening **by construction**: bash+pipefail+captured stderr (#28 — a bad `extraArgs` must fail the job, not pass with an empty table), explicit build-profile resolution (#123), `/usr/bin/time -v` with a `##PERF##` wall+maxrss line (#131 — the instrumentation #256 wished its sibling had when the 900 s run died with an unmeasured SIGKILL), compact tail block for cheap log fetches.

Two waiting consumers become one-dispatch runs: `protocols=anthocnet,aodv` is the **#250** hop-delay discriminator pair, and `extraArgs` carries the **#244** `EnableDirectedReactive` satellite arm.

## The satellite page is honest about its own status

It states explicitly: static snapshot grid = the quiet-cell instrument where the #216 control is *expected* to win; no committed results and no per-merge refresh; results support harness-validation claims only until #216's precomputed-shortest-path control lands. Dependency order (#216 → #206 → #244/#245, read through the #192 analysis) is written down so no future session re-derives it.

## Index

`docs/benchmarks.md` now opens with the two-regime table and the comparability rule — **a number is only comparable within its regime** — and everything below it is unchanged MANET content; the machine-updated results table is untouched.

## Verification

Link check clean over both edited pages · workflow YAML parses · `make test` 24/24 (docs + workflow only, no protocol code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_