### PR TITLE
fix(ns2): add missing ns-default.tcl entries for four tcl-bound parameters

### DIFF
--- a/ns2/patch/fragments/ns-default.tcl.fragment
+++ b/ns2/patch/fragments/ns-default.tcl.fragment
@@ -14,4 +14,8 @@ Agent/AntHocNet set enable_directed_reactive_ 0
 Agent/AntHocNet set proactive_bcast_prob_ 0.1
 Agent/AntHocNet set proactive_virtual_margin_ 0.0
 Agent/AntHocNet set session_ttl_ 5.0
+Agent/AntHocNet set tx_failure_threshold_ 3
+Agent/AntHocNet set enable_mac_failure_detector_ 1
+Agent/AntHocNet set repair_wait_factor_ 5.0
+Agent/AntHocNet set repair_timeout_ 1.0
 Agent/AntHocNet set enable_mac_metric_ 0

--- a/ns2/patch/selftest.sh
+++ b/ns2/patch/selftest.sh
@@ -113,3 +113,17 @@ if diff -ru "$PRISTINE" "$TREE"; then
 else
     echo "FAIL: revert did not restore the tree"; exit 1
 fi
+
+# Every tcl-bound variable in ahn_router.cc must have a default in the
+# ns-default.tcl fragment, or it is not settable from a simulation script
+# (issue #251).
+echo ">> bind coverage in ns-default.tcl.fragment"
+FRAGMENT="$SCRIPT_DIR/fragments/ns-default.tcl.fragment"
+missing=""
+for v in $(grep -oP 'bind(_bool)?\("\K[a-z_]+' "$SCRIPT_DIR/../src/ahn_router.cc"); do
+    grep -q "Agent/AntHocNet set $v " "$FRAGMENT" || missing="$missing $v"
+done
+if [ -n "$missing" ]; then
+    echo "FAIL: bound variables missing from ns-default.tcl.fragment:$missing"; exit 1
+fi
+echo "PASS: all bound variables have ns-default.tcl entries"


### PR DESCRIPTION
Closes #251. First of the parallel-agent batch (#251/#258/#259/#260), landed serially.

## The gap

Four variables bound in `ahn_router.cc` had no `ns-default.tcl.fragment` entry, so they were **not settable from a simulation script** — the whole point of binding them. Behaviour was correct by default (values fall back to the C++ constructor), but the knobs were silently NS-3-only, and three of them are exactly the ADR-0008 detector-D / local-repair levers an NS-2 cross-validation run (#25) would need to vary.

## Change

```tcl
Agent/AntHocNet set tx_failure_threshold_ 3
Agent/AntHocNet set enable_mac_failure_detector_ 1
Agent/AntHocNet set repair_wait_factor_ 5.0
Agent/AntHocNet set repair_timeout_ 1.0
```

Values verified against the `AntHocNetAgent` initialiser list (`ns2/src/ahn_router.cc:71-74`) — behaviour-neutral by construction. Parity findings from the verification: `config.h`'s `txFailureThreshold=3`, `repairWaitFactor=5.0`, `repairTimeout=1.0` all agree; `enable_mac_failure_detector_` has no core counterpart by design (adapter-level detector-D gate) and agrees with NS-3's `EnableMacFailureDetector=true`.

## Recurrence guard

`ns2/patch/selftest.sh` now enumerates every `bind(`/`bind_bool(` in `ahn_router.cc` and fails naming any variable missing from the fragment — so the next bind-without-default fails CI instead of warning at runtime in someone's simulation.

Flip-test evidence (guard fires, then stays quiet):

```
FAIL: bound variables missing from ns-default.tcl.fragment: repair_wait_factor_
exit=1
```
```
>> bind coverage in ns-default.tcl.fragment
PASS: all bound variables have ns-default.tcl entries
```

## Verification

`bash ns2/patch/selftest.sh` PASS (round-trip + new guard) · `make test` 24/24 (untouched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_