### PR TITLE
test(core): pin every Config default; add cross-tree parity check

### DIFF
--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -376,7 +376,7 @@ def _cell_real():
 
 @case("cell: impossible divUsed on a '# paths' line fires (the 9.999 probe)")
 def _cell_div_fires():
-    levels, out = run_cell(CELL.replace("aodv divUsed=1.112",
+    _levels, out = run_cell(CELL.replace("aodv divUsed=1.112",
                                         "aodv divUsed=9.999"))
     expect("path diversity 9.999" in out, "cell-div",
            f"planted divUsed=9.999 not flagged\n{out}")
@@ -384,14 +384,14 @@ def _cell_div_fires():
 
 @case("cell: broken drop identity on a '# drops' line fires")
 def _cell_drops_fire():
-    levels, out = run_cell(CELL.replace("chan=24.01", "chan=90.00"))
+    _levels, out = run_cell(CELL.replace("chan=24.01", "chan=90.00"))
     expect("do not account for the offered packets" in out, "cell-drops",
            f"planted chan=90 left the identity unchecked\n{out}")
 
 
 @case("cell: closing drop identity stays quiet, '-' sub-causes skip")
 def _cell_drops_quiet():
-    levels, out = run_cell(CELL)
+    _levels, out = run_cell(CELL)
     expect("do not account" not in out and "exit path is not attributed" not in out,
            "cell-drops-quiet",
            f"drop rules over-fired on a closing identity / '-' causes\n{out}")
@@ -399,14 +399,14 @@ def _cell_drops_quiet():
 
 @case("cell: out-of-range reorder ratio on a '# reorder' line fires")
 def _cell_reorder_fires():
-    levels, out = run_cell(CELL.replace("ratio=0.0077", "ratio=9.9999"))
+    _levels, out = run_cell(CELL.replace("ratio=0.0077", "ratio=9.9999"))
     expect("reorder_ratio 9.9999 outside [0,1]" in out, "cell-reorder",
            f"planted ratio not flagged\n{out}")
 
 
 @case("cell: residual energy above initial on a '# energy' line fires")
 def _cell_energy_fires():
-    levels, out = run_cell(CELL.replace("resMinJ=4740.6", "resMinJ=5740.6"))
+    _levels, out = run_cell(CELL.replace("resMinJ=4740.6", "resMinJ=5740.6"))
     expect("exceeds initial" in out, "cell-energy",
            f"planted residual > initial not flagged\n{out}")
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,3 +40,11 @@ jobs:
         # failing the self-check its own documentation defines. Cheap (no
         # simulator, no network, ~1 s) and it runs on every PR.
         run: python3 .claude/skills/benchmark-results/test_scenario_check.py
+      - name: Config default parity (core vs ns-2 vs ns-3)
+        # A Config default that drifts in one tree only is the #252/#254
+        # failure mode: proactiveInterval leaked 10 -> 2 in a PR that claimed
+        # not to change it, and the benchmark regression took two days to
+        # trace. core/tests/test_config_defaults.cpp pins the core values;
+        # this pins the adapter copies to core. Cheap (stdlib-only regexes,
+        # <1 s) and it runs on every PR. See #258.
+        run: python3 ns3/tools/check-default-parity.py

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Each test is a standalone executable returning non-zero on failure.
 set(ANTHOCNET_TESTS
+  test_config_defaults
   test_pheromone_table
   test_pheromone_engine
   test_ant_history

--- a/core/tests/test_config_defaults.cpp
+++ b/core/tests/test_config_defaults.cpp
@@ -1,0 +1,60 @@
+/**
+ * Pins every documented default of anthocnet::core::Config, verbatim and in
+ * declaration order, against docs/configuration.md §3.1 (issue #258).
+ *
+ * A default that changes without this test changing is a silent leak: PR #252
+ * shipped proactiveInterval 10 -> 2 while claiming not to, and the resulting
+ * NRL x4.7 / PDR -12 pp took a two-day benchmark hunt to trace (#254). With
+ * this test, `make test` fails at the offending commit and names the field.
+ *
+ * If a default is changed *deliberately*, update the assertion here, the table
+ * in docs/configuration.md §3.1, and the adapter defaults checked by
+ * ns3/tools/check-default-parity.py in the same commit.
+ */
+#include "anthocnet/core/config.h"
+#include "test_support.h"
+
+using anthocnet::core::Config;
+
+int main() {
+    const Config c;
+
+    CHECK_EQ(c.alpha, 0.7);                     // legacy ALFA; meaning per ADR-0012
+    CHECK_EQ(c.gamma, 0.7);                     // legacy GAMA; [1] §3.1
+    CHECK_EQ(c.betaAnts, 1.0);                  // [1] §3.3 unsquared (#70)
+    CHECK_EQ(c.betaData, 2.0);                  // [1] §3.2 squared (#70)
+    CHECK_EQ(c.hopTimeSec, 0.003);              // #88 thesis 3ms
+    CHECK_EQ(c.enableMacMetric, false);         // A2 gate, default off
+    CHECK_EQ(c.minPheromone, 0.00001);          // legacy MIN_PHEROMONE
+    CHECK_EQ(c.enableEvaporation, true);        // ADR-0012
+    CHECK_EQ(c.evaporationInterval, 1.0);       // ADR-0012
+    CHECK_EQ(c.reactiveRetryInterval, 1.0);     // mechanism [1] §4.2 cite (thesis §4.1.2)
+    CHECK_EQ(c.enableProactive, true);          // ADR-0007
+    CHECK_EQ(c.enableDiffusion, true);          // ADR-0007
+    CHECK_EQ(c.enableReactive, true);           // ant-type ablation gate
+    CHECK_EQ(c.enableRepair, true);             // [1] §3.5 gate
+    CHECK_EQ(c.enableLinkFail, true);           // [1] §3.5 gate
+    CHECK_EQ(c.enableDirectedReactive, false);  // repo choice, deviation from [1] §3.1, off
+    CHECK_EQ(c.proactiveBroadcastProb, 0.1);    // [1] §3.3
+    CHECK_EQ(c.sessionTtl, 5.0);                // repo choice
+    CHECK_EQ(c.proactiveVirtualMargin, 0.0);    // #180 gate OFF — deliberately NOT thesis 0.10
+    CHECK_EQ(c.helloInterval, 1.0);             // [1] §3.3 fn.1
+    CHECK_EQ(c.proactiveInterval, 10.0);        // #182 repo value; thesis 2s is #248's A/B (#252/#254 leak)
+    CHECK_EQ(c.lifeAnt, 2.0);                   // legacy constant (inert, #182)
+    CHECK_EQ(c.allowedHelloLoss, 2);            // [1] §3.5 (digest: §3.3 fn.1)
+    CHECK_EQ(c.repairMaxBroadcasts, 2);         // [1] §3.5 (digest: §3.4)
+    CHECK_EQ(c.linkfailNotifyInterval, 5.0);    // #20 sweep
+    CHECK_EQ(c.txFailureThreshold, 3);          // #19 / ADR-0008 detector D
+    CHECK_EQ(c.reactiveMaxBroadcasts, -1);      // #177 unbounded (band self-limits; unit history #169/#173)
+    CHECK_EQ(c.enableMultipath, true);          // [1] §3.1 / #96
+    CHECK_EQ(c.antAcceptanceFactor, 0.9);       // thesis a1 (#177)
+    CHECK_EQ(c.antAcceptanceFactorNewHop, 2.0); // thesis a2 (#177)
+    CHECK_EQ(c.proactiveMaxBroadcasts, 2);      // [1] §3.3 / #45
+    CHECK_EQ(c.repairWaitFactor, 5.0);          // [1] §3.5 (digest: §3.4)
+    CHECK_EQ(c.repairTimeout, 1.0);             // repo fallback, unsourced
+    CHECK_EQ(c.networkDiameter, 30);            // legacy constant (dead in core/, #182)
+    CHECK_EQ(c.maxPathLength, static_cast<std::size_t>(100));  // golden rule 5; wire kMaxVisitedOnWire
+    CHECK_EQ(c.maxHistory, static_cast<std::size_t>(4096));    // golden rule 5
+
+    return RUN_TESTS();
+}

--- a/ns3/tools/check-default-parity.py
+++ b/ns3/tools/check-default-parity.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Cross-tree Config default parity check (issue #258).
+
+The same protocol default lives in up to four places:
+
+  core   core/include/anthocnet/core/config.h      (default member initializers)
+  ns2.h  ns2/src/ahn_router.h                      (AHN_* compile-time macros)
+  ns2.cc ns2/src/ahn_router.cc                     (tcl-bound constructor initializers)
+  ns2.tcl ns2/patch/fragments/ns-default.tcl.fragment (Agent/AntHocNet set ...)
+  ns3    ns3/model/anthocnet-routing-protocol.cc   (constructor initializers)
+
+PR #252 leaked proactiveInterval 10 -> 2 in one tree while claiming not to;
+tracing the resulting benchmark regression cost two days (#254). This script
+fails (exit 1) naming any field whose literal defaults disagree across the
+trees it appears in. Only fields with a certain name mapping are compared;
+the checked list is printed so coverage is visible.
+
+Deliberately NOT mapped: ns-3 m_reactiveRetryInterval — it is the adapter's
+own retry timer, a different quantity from core reactiveRetryInterval
+(docs/configuration.md §3.3 item 2). Adapter-only knobs (queue caps, MAC
+failure detector, MAC service EWMA) have no core counterpart and are skipped.
+
+Runs on stdlib only: python3 ns3/tools/check-default-parity.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+CONFIG_H = REPO / "core/include/anthocnet/core/config.h"
+NS2_H = REPO / "ns2/src/ahn_router.h"
+NS2_CC = REPO / "ns2/src/ahn_router.cc"
+NS2_TCL = REPO / "ns2/patch/fragments/ns-default.tcl.fragment"
+NS3_CC = REPO / "ns3/model/anthocnet-routing-protocol.cc"
+
+# core field -> identifier per tree. Omitted key = field absent from that tree.
+# ns2_var covers both the ahn_router.cc constructor initializer and (where
+# present) the ns-default.tcl.fragment line, which share the tcl variable name.
+FIELDS = {
+    "alpha": {"ns3": "m_alpha"},
+    "gamma": {"ns3": "m_gamma"},
+    "betaAnts": {"ns2_var": "beta_ants_", "ns3": "m_betaAnts"},
+    "betaData": {"ns2_var": "beta_data_", "ns3": "m_betaData"},
+    "hopTimeSec": {"ns3": "m_hopTime"},
+    "enableMacMetric": {"ns2_var": "enable_mac_metric_", "ns3": "m_enableMacMetric"},
+    "enableProactive": {"ns2_var": "enable_proactive_", "ns3": "m_enableProactive"},
+    "enableDiffusion": {"ns2_var": "enable_diffusion_", "ns3": "m_enableDiffusion"},
+    "enableReactive": {"ns2_var": "enable_reactive_", "ns3": "m_enableReactive"},
+    "enableRepair": {"ns2_var": "enable_repair_", "ns3": "m_enableRepair"},
+    "enableLinkFail": {"ns2_var": "enable_linkfail_", "ns3": "m_enableLinkFail"},
+    "enableDirectedReactive": {
+        "ns2_var": "enable_directed_reactive_",
+        "ns3": "m_enableDirectedReactive",
+    },
+    "proactiveBroadcastProb": {
+        "ns2_var": "proactive_bcast_prob_",
+        "ns3": "m_proactiveBroadcastProb",
+    },
+    "proactiveVirtualMargin": {
+        "ns2_var": "proactive_virtual_margin_",
+        "ns3": "m_proactiveVirtualMargin",
+    },
+    "sessionTtl": {"ns2_var": "session_ttl_", "ns3": "m_sessionTtl"},
+    "helloInterval": {"ns2_macro": "AHN_HELLO_INTERVAL", "ns3": "m_helloInterval"},
+    "proactiveInterval": {
+        "ns2_macro": "AHN_PROACTIVE_INTERVAL",
+        "ns3": "m_proactiveInterval",
+    },
+    "lifeAnt": {"ns2_macro": "AHN_LIFE_ANT"},
+    "networkDiameter": {"ns2_macro": "AHN_NETWORK_DIAMETER"},
+    "linkfailNotifyInterval": {"ns3": "m_linkfailNotifyInterval"},
+    "txFailureThreshold": {
+        "ns2_var": "tx_failure_threshold_",
+        "ns3": "m_txFailureThreshold",
+    },
+    "enableMultipath": {"ns3": "m_enableMultipath"},
+    "antAcceptanceFactor": {"ns3": "m_antAcceptanceFactor"},
+    "antAcceptanceFactorNewHop": {"ns3": "m_antAcceptanceFactorNewHop"},
+    "repairWaitFactor": {"ns2_var": "repair_wait_factor_", "ns3": "m_repairWaitFactor"},
+    "repairTimeout": {"ns2_var": "repair_timeout_", "ns3": "m_repairTimeout"},
+}
+
+
+def norm(literal):
+    """Normalize a C++/tcl literal to a float for comparison."""
+    literal = literal.strip()
+    if literal == "true":
+        return 1.0
+    if literal == "false":
+        return 0.0
+    return float(literal)
+
+
+def parse_config_h(text):
+    # e.g. "double alpha = 0.7;  ///< ..." / "std::size_t maxHistory = 4096;"
+    pat = re.compile(
+        r"^\s*(?:double|bool|int|std::size_t)\s+(\w+)\s*=\s*([-\w.]+)\s*;", re.M
+    )
+    return {name: norm(value) for name, value in pat.findall(text)}
+
+
+def parse_ns2_macros(text):
+    # e.g. "#define AHN_HELLO_INTERVAL      1.0"
+    pat = re.compile(r"^#define\s+(AHN_\w+)\s+([-\d.]+)", re.M)
+    return {name: norm(value) for name, value in pat.findall(text)}
+
+
+def parse_ns2_ctor(text):
+    # Constructor initializers, e.g. "      beta_ants_(1.0)," — restricted to
+    # the identifiers named in FIELDS, so unrelated calls never match.
+    out = {}
+    for spec in FIELDS.values():
+        var = spec.get("ns2_var")
+        if var is None:
+            continue
+        m = re.search(rf"^\s*{re.escape(var)}\(([-\d.]+)\)", text, re.M)
+        if m:
+            out[var] = norm(m.group(1))
+    return out
+
+
+def parse_ns2_tcl(text):
+    # e.g. "Agent/AntHocNet set beta_ants_ 1.0"
+    pat = re.compile(r"^Agent/AntHocNet\s+set\s+(\w+)\s+([-\d.]+)", re.M)
+    return {name: norm(value) for name, value in pat.findall(text)}
+
+
+def parse_ns3_ctor(text):
+    # e.g. "      m_helloInterval(Seconds(1.0))," / "m_alpha(0.7)," /
+    #      "m_enableProactive(true),"
+    pat = re.compile(r"^\s*(m_\w+)\((?:Seconds\()?(true|false|[-\d.]+)\)?\)", re.M)
+    return {name: norm(value) for name, value in pat.findall(text)}
+
+
+def main():
+    core = parse_config_h(CONFIG_H.read_text())
+    ns2_macros = parse_ns2_macros(NS2_H.read_text())
+    ns2_ctor = parse_ns2_ctor(NS2_CC.read_text())
+    ns2_tcl = parse_ns2_tcl(NS2_TCL.read_text())
+    ns3_ctor = parse_ns3_ctor(NS3_CC.read_text())
+
+    errors = []
+    checked = []
+
+    for field, spec in sorted(FIELDS.items()):
+        if field not in core:
+            errors.append(
+                f"{field}: not found in {CONFIG_H.relative_to(REPO)} "
+                "(parser or mapping is stale)"
+            )
+            continue
+        values = [("core", core[field])]
+
+        macro = spec.get("ns2_macro")
+        if macro is not None:
+            if macro in ns2_macros:
+                values.append((f"ns2.h {macro}", ns2_macros[macro]))
+            else:
+                errors.append(f"{field}: macro {macro} not found in ns2/src/ahn_router.h")
+
+        var = spec.get("ns2_var")
+        if var is not None:
+            if var in ns2_ctor:
+                values.append((f"ns2.cc {var}", ns2_ctor[var]))
+            else:
+                errors.append(f"{field}: initializer {var} not found in ns2/src/ahn_router.cc")
+            # Not every bound variable has an ns-default.tcl.fragment line;
+            # compare only when present.
+            if var in ns2_tcl:
+                values.append((f"ns2.tcl {var}", ns2_tcl[var]))
+
+        ns3 = spec.get("ns3")
+        if ns3 is not None:
+            if ns3 in ns3_ctor:
+                values.append((f"ns3 {ns3}", ns3_ctor[ns3]))
+            else:
+                errors.append(
+                    f"{field}: initializer {ns3} not found in "
+                    "ns3/model/anthocnet-routing-protocol.cc"
+                )
+
+        if len({v for _, v in values}) > 1:
+            detail = ", ".join(f"{where}={value:g}" for where, value in values)
+            errors.append(f"{field}: defaults disagree — {detail}")
+        checked.append((field, values))
+
+    print(f"checked {len(checked)} field(s) across trees:")
+    for field, values in checked:
+        trees = ", ".join(where for where, _ in values)
+        print(f"  {field}: {trees}")
+
+    if errors:
+        print(f"\nFAIL: {len(errors)} problem(s):", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+    print("\nOK: all mapped defaults agree across trees")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ns3/tools/check-default-parity.py
+++ b/ns3/tools/check-default-parity.py
@@ -96,14 +96,14 @@ def norm(literal):
 def parse_config_h(text):
     # e.g. "double alpha = 0.7;  ///< ..." / "std::size_t maxHistory = 4096;"
     pat = re.compile(
-        r"^\s*(?:double|bool|int|std::size_t)\s+(\w+)\s*=\s*([-\w.]+)\s*;", re.M
+        r"^\s*(?:double|bool|int|std::size_t)\s+(\w+)\s*=\s*([-\w.]+)\s*;", re.MULTILINE
     )
     return {name: norm(value) for name, value in pat.findall(text)}
 
 
 def parse_ns2_macros(text):
     # e.g. "#define AHN_HELLO_INTERVAL      1.0"
-    pat = re.compile(r"^#define\s+(AHN_\w+)\s+([-\d.]+)", re.M)
+    pat = re.compile(r"^#define\s+(AHN_\w+)\s+([-\d.]+)", re.MULTILINE)
     return {name: norm(value) for name, value in pat.findall(text)}
 
 
@@ -115,7 +115,7 @@ def parse_ns2_ctor(text):
         var = spec.get("ns2_var")
         if var is None:
             continue
-        m = re.search(rf"^\s*{re.escape(var)}\(([-\d.]+)\)", text, re.M)
+        m = re.search(rf"^\s*{re.escape(var)}\(([-\d.]+)\)", text, re.MULTILINE)
         if m:
             out[var] = norm(m.group(1))
     return out
@@ -123,14 +123,14 @@ def parse_ns2_ctor(text):
 
 def parse_ns2_tcl(text):
     # e.g. "Agent/AntHocNet set beta_ants_ 1.0"
-    pat = re.compile(r"^Agent/AntHocNet\s+set\s+(\w+)\s+([-\d.]+)", re.M)
+    pat = re.compile(r"^Agent/AntHocNet\s+set\s+(\w+)\s+([-\d.]+)", re.MULTILINE)
     return {name: norm(value) for name, value in pat.findall(text)}
 
 
 def parse_ns3_ctor(text):
     # e.g. "      m_helloInterval(Seconds(1.0))," / "m_alpha(0.7)," /
     #      "m_enableProactive(true),"
-    pat = re.compile(r"^\s*(m_\w+)\((?:Seconds\()?(true|false|[-\d.]+)\)?\)", re.M)
+    pat = re.compile(r"^\s*(m_\w+)\((?:Seconds\()?(true|false|[-\d.]+)\)?\)", re.MULTILINE)
     return {name: norm(value) for name, value in pat.findall(text)}
 
 


### PR DESCRIPTION
Closes #258. Second of the parallel-agent batch. Converts the #254 failure class — *a default silently changed by a merge that intended something else* — from a two-day benchmark find into a `make test` failure at the offending commit.

## What ships

- **`core/tests/test_config_defaults.cpp`** — default-constructs `Config` and asserts all **36 fields verbatim** in declaration order, each with its provenance comment (`// #88 thesis 3ms`, `// ADR-0012`, `// #177 thesis a1`, …). Suite 24 → 25.
- **`ns3/tools/check-default-parity.py`** (stdlib-only) — maps **26 fields** across `config.h` / NS-2 `AHN_*` macros / NS-2 ctor initializers / `ns-default.tcl.fragment` / ns-3 ctor initializers, prints the mapped list (coverage is visible), exits 1 naming any cross-tree disagreement. Wired into `lint.yml` next to the benchmark-gate self-test. Deliberate exclusion, documented: ns-3 `m_reactiveRetryInterval` (0.25 s) vs core `reactiveRetryInterval` (1.0 s) are different quantities per `configuration.md` §3.3.

## Test of the test — both halves demonstrated

Flip 1: `config.h` `proactiveInterval` 10.0 → 2.0 (**the literal #252 incident**):
```
CHECK_EQ failed: c.proactiveInterval == 10.0 (core/tests/test_config_defaults.cpp:42)
96% tests passed, 1 tests failed out of 25
```
Flip 2: `AHN_PROACTIVE_INTERVAL` alone → 2.0 (single-tree drift):
```
FAIL: proactiveInterval: defaults disagree — core=10, ns2.h AHN_PROACTIVE_INTERVAL=2, ns3 m_proactiveInterval=10
exit=1
```
Both reverted before commit.

## Second commit: ruff 0.16.0 lint fixes (`78a7e01`)

The first CI run failed only the lint leg — and the failure exposed that **the lint leg has been red on `main` since `9473c9b` (PR #253)**: the five CELL probe cases there unpack `levels, out = run_cell(...)` without using `levels` (RUF059), and I merged #253/#257/#261 without catching the red lint leg. The local "ruff clean" claims (this PR's included) were made with ruff 0.15.8, where RUF059/FURB167 don't fire; CI pins 0.16.0.

Fixes in `78a7e01`: `re.M` → `re.MULTILINE` (5× FURB167 in the new parity script), `_levels` in the five probe cases that ignore the list (5× RUF059; `_cell_real`/`_cell_pdr`, which assert on `levels`, untouched). Re-verified with ruff **0.16.0**: full `lint.yml` command clean, self-test 23/23, parity script exit 0.

## Findings from the verification

No value discrepancies — all 36 defaults match `configuration.md` §3.1. Two doc nits recorded, deliberately not fixed here (separate one-liner): §1&#39;s core-layer row still says &#34;31 fields&#34; (§3.1 correctly says 36), and §3.1 orders `proactiveVirtualMargin` before `sessionTtl` against declaration order.

## Verification (re-run on current `main` after the #261 merge)

`make test` 25/25 · parity script `OK: all mapped defaults agree across trees` · ruff 0.16.0 clean on the full lint command.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_