### PR TITLE
feat(skills): satellite results pipeline — validate, parse and commit isl-grid output

### DIFF
--- a/.claude/skills/benchmark-results/bench_parse.py
+++ b/.claude/skills/benchmark-results/bench_parse.py
@@ -48,9 +48,31 @@ PERF = re.compile(r"##PERF##.*")
 
 
 def parse_cell(text):
-    """Return {proto: {metric: float}} from one run's output text."""
+    """Return {proto: {metric: float}} from one run's output text.
+
+    isl-grid's human table and ##RUN## rows (#259) already parse via ROW/RUN
+    (the first six fields are position-identical to anthocnet-compare's);
+    its --csv rows are mapped by header name below, so a satellite cell A/Bs
+    exactly like a MANET one (#244 directed arm, #250 discriminator).
+    """
     rows = {}
+    isl_cols = None
     for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("protocol,runs,rows,cols,"):  # isl-grid --csv header
+            isl_cols = s.split(",")
+            continue
+        if isl_cols and "," in s:
+            d = dict(zip(isl_cols, s.split(",")))
+            try:
+                rows[d["protocol"]] = {
+                    "pdr": float(d["pdr_pct"]), "delay": float(d["delay_ms"]),
+                    "delay99": float(d["delay99_ms"]),
+                    "thrput": float(d["throughput_kbps"]),
+                    "nrl": float(d["nrl"])}
+            except (KeyError, ValueError):
+                pass
+            continue
         m = BENCH.search(line) or ROW.match(line)
         parts = (m.group(1).split() if m and m.re is BENCH
                  else (m.groups() if m else None))

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -18,10 +18,14 @@ Usage:
         # overrides. Exit 1 on any FAIL-level degeneracy.
 
     scenario_check.py results FILE [FILE ...] [--anchor single-hop|broch-low-mobility]
-        # FILE = a saved ##BENCH## cell / results-table text, or a classified
-        # campaign CSV (sniffed by header). --anchor additionally enforces
-        # the ns3/tools/anchors.yml floor on AODV rows (#59, single source
-        # of thresholds). Exit 1 on any FAIL.
+        # FILE = a saved ##BENCH## cell / results-table text, a classified
+        # campaign CSV (sniffed by header), or isl-grid output (#259): its
+        # --csv schema (sniffed by the 'protocol,runs,rows,cols,...' header)
+        # or the human satellite-results.txt ('+Grid' summary + ##RUN## rows
+        # + table). --anchor additionally enforces the ns3/tools/anchors.yml
+        # floor on AODV rows (#59, single source of thresholds); the
+        # satellite floors fire automatically when the input identifies the
+        # topology. Exit 1 on any FAIL.
 """
 import argparse
 import csv
@@ -50,6 +54,19 @@ SINGLE_PATH_PROTOS = ("aodv", "olsr", "dsdv")
 SINGLE_PATH_DIV_MAX = 1.10
 
 ROW = re.compile(r"^\s*(?:##BENCH##\s+)?([a-z][\w-]*)((?:\s+[-\d.]+|\s+inf)+)\s*$")
+
+# #259: isl-grid human-mode output. The '+Grid' summary line carries the
+# topology context the per-row rules need (node/link count identifies the
+# single-ISL anchor topology; the ISL delay is the propagation floor), and its
+# presence disambiguates the whole file — the isl-grid table shares ROW's shape
+# but orders columns pdr/delay/delay99/thrput/nrl/nrlbytes/jitter, so the MANET
+# mapping would silently bind jitter to nrl_bytes.
+ISL_GRID = re.compile(r"^\+Grid \w+ \d+x\d+ = (\d+) satellites, (\d+) ISLs"
+                      r".* @ ([\d.]+) ms", re.MULTILINE)
+# Per-run line: '##RUN## <seed> <proto> <pdr> <delay> <delay99> <thrput> <nrl>
+# <nrlBytes> <jitter>'.
+ISL_RUN = re.compile(r"^\s*##RUN##\s+(\d+)\s+([a-z][\w-]*)"
+                     r"((?:\s+[-\d.]+|\s+inf)+)\s*$")
 
 # Diagnostic lines of a saved cell ('# paths anthocnet divUsed=1.104 ...').
 # anthocnet-compare prints one per (family, protocol) after the table; they are
@@ -87,13 +104,16 @@ def report(level, msg):
     print(f"{level}: {msg}")
 
 
-def anchor_floor(anchor):
-    key = ANCHOR_KEY[anchor]
+def yml_floor(key):
     with open(ANCHORS_YML) as fh:
         for line in fh:
             if line.split(":")[0].strip() == key:
                 return float(line.split(":")[1].split("#")[0])
     sys.exit(f"FAIL: {key} not found in {ANCHORS_YML}")
+
+
+def anchor_floor(anchor):
+    return yml_floor(ANCHOR_KEY[anchor])
 
 
 def cmd_preflight(a):
@@ -230,6 +250,52 @@ def parse_results(path):
     with open(path) as fh:
         text = fh.read()
     first = text.lstrip().splitlines()[0] if text.strip() else ""
+    # #259: isl-grid --csv. One row per protocol; rows/cols/nodes/links/
+    # isl_delay_ms are topology context the satellite rules read, mapped under
+    # sat_*/isl_delay keys so they can never collide with a MANET column.
+    if first.startswith("protocol,runs,rows,cols,"):
+        for r in csv.DictReader(text.splitlines()):
+            yield {"where": f"isl-grid {r.get('rows')}x{r.get('cols')}",
+                   "proto": r.get("protocol"),
+                   "pdr": r.get("pdr_pct"), "delay": r.get("delay_ms"),
+                   "delay99": r.get("delay99_ms"), "nrl": r.get("nrl"),
+                   "jitter": r.get("jitter_ms"),
+                   "isl_delay": r.get("isl_delay_ms"),
+                   "sat_nodes": r.get("nodes"), "sat_links": r.get("links")}
+        return
+    # #259: isl-grid human mode (the satellite-results.txt artifact). The
+    # '+Grid' summary identifies the format and supplies the topology context;
+    # ##RUN## per-seed rows and the aggregate table rows both map into the
+    # standard row dict — note jitter sits at position 6 here (position 5 is
+    # nrl_bytes), which is why this input must not fall through to the MANET
+    # ROW mapping below. '# diag' ant-tally lines are deliberately not parsed:
+    # no results-mode rule reads them.
+    grid = ISL_GRID.search(text)
+    if grid:
+        ctx = {"isl_delay": grid.group(3), "sat_nodes": grid.group(1),
+               "sat_links": grid.group(2)}
+        base = os.path.basename(path)
+        for line in text.splitlines():
+            m = ISL_RUN.match(line)
+            if m:
+                seed, proto = m.group(1), m.group(2)
+                nums = m.group(3).split()
+                if len(nums) >= 7:
+                    yield {"where": f"{base} run{seed}", "proto": proto,
+                           "pdr": nums[0], "delay": nums[1],
+                           "delay99": nums[2], "nrl": nums[4],
+                           "jitter": nums[6], **ctx}
+                continue
+            m = ROW.match(line)
+            if not m:
+                continue
+            proto, nums = m.group(1), m.group(2).split()
+            if proto in ("protocol",) or len(nums) < 7:
+                continue
+            yield {"where": base, "proto": proto,
+                   "pdr": nums[0], "delay": nums[1], "delay99": nums[2],
+                   "nrl": nums[4], "jitter": nums[6], **ctx}
+        return
     if first.startswith("kind,") or ",protocol," in first:
         for r in csv.DictReader(text.splitlines()):
             yield {"where": f"{r.get('group')}={r.get('x')}",
@@ -541,6 +607,52 @@ def cmd_results(a):
                     report("FAIL", f"{tag}: Jain's fairness index 0 with PDR "
                                    f"{pdr} — packets delivered but no per-flow "
                                    "counts")
+            # #259 satellite (isl-grid) rules. Present only when the input
+            # carried the topology context (the --csv columns or the '+Grid'
+            # summary line); MANET inputs never set isl_delay, so nothing here
+            # can fire on them.
+            isl = num("isl_delay")
+            if isl is not None and isl > 0:
+                # Propagation floor. Soundness: flows connect distinct
+                # satellites and every ISL is a point-to-point link with a
+                # fixed one-way delay of isl_delay_ms, so every delivered
+                # packet crosses >= 1 ISL and pays >= isl_delay_ms of pure
+                # propagation before serialisation/queueing; the mean over
+                # delivered packets inherits the bound. A mean below it is a
+                # harness/instrumentation bug (wrong clock, wrong counting
+                # point), never a fast protocol — the satellite counterpart of
+                # "path length < 1 hop". No stronger floor is derivable from
+                # the columns present: flow endpoints (and hence per-flow hop
+                # counts) are not in the output, so every flow could legally be
+                # between adjacent satellites (h=1). The h*d hop-delay identity
+                # with its sat_hop_delay_slack_ms band stays a dispatch-time
+                # gate (check-sat-anchors.sh), where h is known.
+                if delay is not None and pdr and delay < isl:
+                    report("FAIL", f"{tag}: mean delay {delay} ms below the "
+                                   f"one-ISL propagation floor {isl} ms — "
+                                   "every delivered packet crosses >= 1 ISL, "
+                                   "so this is a harness/instrumentation bug, "
+                                   "not a fast protocol (#259)")
+                # Single-ISL anchor, applied to a fetched result (#259): a
+                # 2-node/1-link row identifies the sat-single-isl anchor
+                # topology from the input itself, so the anchors.yml floor
+                # fires without an --anchor flag. Soundness: one lossless p2p
+                # link, static, no contention — physics says PDR 100; the
+                # floor's own margin (99.0) tolerates only route-setup loss at
+                # t=0. Scoped to AODV rows because that is the protocol the
+                # anchor is calibrated for (see anchors.yml), mirroring the
+                # --anchor floors above.
+                nsat, nisl = num("sat_nodes"), num("sat_links")
+                if (nsat == 2 and nisl == 1 and r["proto"] == "aodv"
+                        and pdr is not None):
+                    sfloor = yml_floor("sat_single_isl_pdr_min")
+                    if pdr < sfloor:
+                        report("FAIL", f"{tag}: single-ISL anchor floor "
+                                       f"sat_single_isl_pdr_min {sfloor} "
+                                       f"violated (AODV PDR {pdr}) — a p2p "
+                                       "link is lossless, so the substrate or "
+                                       "route setup is broken; do not trust "
+                                       "these numbers (#259)")
             if floor is not None and r["proto"] == "aodv" and pdr is not None:
                 if pdr < floor:
                     report("FAIL", f"{tag}: anchor '{a.anchor}' floor "

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -423,6 +423,133 @@ def _cell_pdr_authoritative():
            f"'# drops' pdr leaked into the row: {levels} vs {base}\n{out}")
 
 
+# --- #259 satellite (isl-grid) input: CSV schema + human mode + rules --------
+#
+# The CSV fixture is a realistic 4x4 torus at the anchor knobs: 16 satellites,
+# 32 ISLs, islDelayMs=5, 8 flows. delay 10.4 ms is the measured hop-delay
+# identity reading (h=2, d=5 ms: 10.39 ms, CI run 30190452648, anchors.yml).
+
+ISL_CLEAN = {
+    "protocol": "anthocnet", "runs": "3", "rows": "4", "cols": "4",
+    "nodes": "16", "links": "32", "isl_delay_ms": "5.0", "flows": "8",
+    "pdr_pct": "100.0", "delay_ms": "10.4", "delay99_ms": "10.9",
+    "throughput_kbps": "32.28", "nrl": "1.401", "nrl_bytes": "0.988",
+    "jitter_ms": "0.15",
+}
+
+
+def run_isl(**overrides):
+    """Check one isl-grid --csv row (ISL_CLEAN + overrides)."""
+    row = dict(ISL_CLEAN, **overrides)
+    return run_cell(",".join(row) + "\n"
+                    + ",".join(str(v) for v in row.values()) + "\n")
+
+
+# The human-mode fixture mirrors what satellite-benchmark.yml's
+# satellite-results.txt artifact holds: ##RUN## per-seed rows, '# diag' ant
+# tallies (deliberately unparsed), the '+Grid' summary and the aggregate table
+# — whose column order (…thrput nrl nrlbytes jitter) differs from the MANET
+# table, the trap the dedicated branch exists for.
+
+ISL_CELL = """\
+##RUN## 1 anthocnet 100.00 10.40 10.90 32.28 1.40 0.99 0.15
+##RUN## 2 anthocnet 100.00 10.41 10.92 32.29 1.41 0.99 0.15
+# diag anthocnet seed=1 ctrlTx=1234 antTx[1=100,2=50,] antRx[1=98,2=49,]
+##RUN## 1 aodv 100.00 10.30 10.60 32.28 0.60 0.35 0.10
+##RUN## 2 aodv 100.00 10.31 10.61 32.28 0.60 0.35 0.10
++Grid torus 4x4 = 16 satellites, 32 ISLs (mean degree 4.00) @ 5.00 ms 10Mbps, 8 flows, 60.00 s, mean of 2 run(s)
+
+protocol          PDR%  delay(ms)  delay99(ms)  thrput(kbps)     NRL   NRLbytes  jitter(ms)
+-------------------------------------------------------------------------------------------
+anthocnet        100.0       10.4         10.9         32.28    1.40       0.99        0.15
+aodv             100.0       10.3         10.6         32.28    0.60       0.35        0.10
+"""
+
+
+@case("#259 clean isl-grid CSV row reports nothing")
+def _isl_clean():
+    levels, out = run_isl()
+    expect(levels == [], "isl-clean", f"expected no reports, got {levels}\n{out}")
+    expect("checked 1 rows" in out, "isl-clean",
+           f"CSV row not parsed\n{out}")
+
+
+@case("#259 mean delay below the one-ISL propagation floor FAILs")
+def _isl_floor_fires():
+    levels, out = run_isl(delay_ms="3.2", delay99_ms="3.4")
+    expect("FAIL" in levels, "isl-floor-fires",
+           f"delay 3.2 < islDelayMs 5.0 did not FAIL\n{out}")
+    expect("propagation floor" in out, "isl-floor-fires",
+           f"FAIL did not name the floor\n{out}")
+
+
+@case("#259 propagation floor skips a dead cell (delay 0, PDR 0)")
+def _isl_floor_dead_cell():
+    # Nothing delivered => the mean-of-none prints 0.0; the dead-cell WARN
+    # owns that reading, the physics floor must not pile a FAIL on top.
+    levels, out = run_isl(pdr_pct="0.0", delay_ms="0.0", delay99_ms="0.0",
+                          throughput_kbps="0.00", jitter_ms="0.00")
+    expect("FAIL" not in levels, "isl-floor-dead",
+           f"floor fired on a dead cell\n{out}")
+    expect("WARN" in levels, "isl-floor-dead",
+           f"dead cell not WARNed\n{out}")
+
+
+@case("#259 single-ISL AODV row below sat_single_isl_pdr_min FAILs")
+def _isl_anchor_fires():
+    levels, out = run_isl(protocol="aodv", rows="1", cols="2", nodes="2",
+                          links="1", delay_ms="5.2", delay99_ms="5.4",
+                          pdr_pct="97.0")
+    expect("FAIL" in levels, "isl-anchor-fires",
+           f"AODV 97.0 on one lossless ISL did not FAIL\n{out}")
+    expect("sat_single_isl_pdr_min" in out, "isl-anchor-fires",
+           f"FAIL did not name the anchor key\n{out}")
+
+
+@case("#259 single-ISL anchor stays quiet at 100.0 and off-anchor topologies")
+def _isl_anchor_quiet():
+    levels, out = run_isl(protocol="aodv", rows="1", cols="2", nodes="2",
+                          links="1", delay_ms="5.2", delay99_ms="5.4",
+                          pdr_pct="100.0")
+    expect(levels == [], "isl-anchor-quiet",
+           f"fired on a perfect single-ISL row\n{out}")
+    # 97.0 on the 4x4 grid is congestion territory, not the anchor topology;
+    # firing there would make the gate cry wolf on every loaded run.
+    levels, out = run_isl(protocol="aodv", pdr_pct="97.0")
+    expect(levels == [], "isl-anchor-quiet",
+           f"anchor fired off the 2-node/1-link topology\n{out}")
+
+
+@case("#259 human satellite-results.txt parses runs+table and stays quiet")
+def _isl_cell_clean():
+    levels, out = run_cell(ISL_CELL)
+    expect(levels == [], "isl-cell-clean",
+           f"clean human-mode output reported {levels}\n{out}")
+    # 4 ##RUN## rows + 2 table rows; the '# diag' line must bind to nothing.
+    expect("checked 6 rows" in out, "isl-cell-clean",
+           f"wrong row count from human mode\n{out}")
+
+
+@case("#259 planted sub-floor delay on a ##RUN## line fires")
+def _isl_cell_floor_fires():
+    _levels, out = run_cell(ISL_CELL.replace("##RUN## 2 aodv 100.00 10.31",
+                                            "##RUN## 2 aodv 100.00 3.10"))
+    expect("propagation floor" in out and "run2/aodv" in out,
+           "isl-cell-floor", f"per-run sub-floor delay not flagged\n{out}")
+
+
+@case("#259 table jitter binds to column 7, not to NRLbytes")
+def _isl_cell_jitter_position():
+    # Corrupt only the table's last column (jitter). Under the MANET mapping
+    # position 5 (NRLbytes) would be read as jitter and this would stay
+    # silent — the mis-binding the dedicated isl-grid branch prevents.
+    _levels, out = run_cell(ISL_CELL.replace(
+        "aodv             100.0       10.3         10.6         32.28    0.60       0.35        0.10",
+        "aodv             100.0       10.3         10.6         32.28    0.60       0.35       -0.10"))
+    expect("negative jitter" in out, "isl-cell-jitter",
+           f"negative jitter in the last table column not flagged\n{out}")
+
+
 def main():
     for name, fn in CASES:
         fn()

--- a/.github/workflows/rescue-artifacts.yml
+++ b/.github/workflows/rescue-artifacts.yml
@@ -6,12 +6,19 @@ name: Rescue run artifacts into docs (manual)
 # `scenario-matrix` artifact of each given run and commits its scenarios.csv
 # into docs/benchmarks/campaign/ so the data survives expiry. Runs in seconds;
 # it does NOT dispatch any simulation.
+#
+# #259 extends the same rescue to the satellite suite: the `satellite-benchmark`
+# artifact's satellite-results.txt (human table + ##RUN## rows, not a CSV)
+# lands as docs/benchmarks/campaign/<runid>-sat.txt.
 on:
   workflow_dispatch:
     inputs:
       run_ids:
         description: 'Comma-separated workflow run IDs whose scenario-matrix artifact to rescue'
         default: '30031902395,30031904151'
+      sat_run_ids:
+        description: 'Comma-separated workflow run IDs whose satellite-benchmark artifact to rescue (#259); clear run_ids when rescuing only satellite runs'
+        default: ''
 
 permissions:
   contents: write
@@ -19,12 +26,13 @@ permissions:
 
 jobs:
   rescue:
-    name: rescue scenario-matrix CSVs
+    name: rescue campaign result artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Download artifacts and stage CSVs
+        if: github.event.inputs.run_ids != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -53,7 +61,35 @@ jobs:
             cp "$dir/scenarios.csv" "docs/benchmarks/campaign/${id}-${label}.csv"
           done
           rm -rf rescue-tmp
-      - name: Commit rescued CSVs
+      - name: Download satellite artifacts and stage results (#259)
+        if: github.event.inputs.sat_run_ids != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p docs/benchmarks/campaign
+          IFS=',' read -ra IDS <<< "${{ github.event.inputs.sat_run_ids }}"
+          for id in "${IDS[@]}"; do
+            id="$(echo "$id" | tr -d ' ')"
+            # satellite-benchmark uploads a results *text* (human table +
+            # ##RUN## per-seed rows), not a CSV; the -sat.txt suffix tells
+            # readers and scenario_check.py the format on sight.
+            label="sat"
+            dir="rescue-tmp/$id"
+            gh run download "$id" -R "$GITHUB_REPOSITORY" -n satellite-benchmark -D "$dir"
+            if [ ! -f "$dir/satellite-results.txt" ]; then
+              echo "FAIL: no satellite-results.txt in artifact of run $id"; exit 1
+            fi
+            runs=$(grep -c '##RUN##' "$dir/satellite-results.txt" || true)
+            if [ "$runs" -lt 1 ]; then
+              echo "FAIL: satellite-results.txt of run $id has no ##RUN## result rows (#28 empty-table class)"; exit 1
+            fi
+            echo "run $id ($label): $runs per-run result rows"
+            cp "$dir/satellite-results.txt" "docs/benchmarks/campaign/${id}-${label}.txt"
+          done
+          rm -rf rescue-tmp
+      - name: Commit rescued results
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -61,6 +97,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "nothing new to commit"
           else
-            git commit -m "benchmarks: rescue campaign sweep CSVs from expiring artifacts (#122) [skip ci]"
+            git commit -m "benchmarks: rescue campaign results from expiring artifacts (#122, #259) [skip ci]"
             git push origin "HEAD:${{ github.ref_name }}"
           fi

--- a/docs/benchmarks/satellite/isl-grid.md
+++ b/docs/benchmarks/satellite/isl-grid.md
@@ -73,11 +73,38 @@ excess tracked in [#250](https://github.com/danieljoppi/AntHocNet/issues/250)
 
 ## Results
 
-**No committed results yet.** This suite has no per-merge refresh (the MANET
-quick taxonomy keeps that job); satellite numbers are produced by manual
-dispatch and should be recorded here (and on the driving issue, per ADR-0013)
-when a campaign-grade run exists. Do not quote the CI smoke numbers — they are
-delivery gates at tiny scale, not measurements.
+**No committed results yet**, but the pipeline that lands and gates them is
+real ([#259](https://github.com/danieljoppi/AntHocNet/issues/259)) — the same
+dispatch → rescue → validate → parse loop the MANET suite runs, so no
+satellite number is ever eyeball-only:
+
+1. **Dispatch** `satellite-benchmark.yml` (above). The results file
+   (`satellite-results.txt`: `##RUN##` per-seed rows plus the summary table)
+   is uploaded as the `satellite-benchmark` artifact (30-day retention).
+2. **Rescue** it past expiry with the `rescue-artifacts` workflow
+   (`sat_run_ids` input); it is committed as
+   `docs/benchmarks/campaign/<runid>-sat.txt`.
+3. **Validate** before reading:
+   `python3 .claude/skills/benchmark-results/scenario_check.py results FILE`
+   understands both the `--csv` schema and the human
+   `##RUN##`/table output, runs the generic plausibility rules (PDR bounds,
+   delay99 ≥ mean, negatives, dead cells) and adds the satellite invariants —
+   mean delay at or above the one-ISL propagation floor (`isl_delay_ms`), and
+   the `sat_single_isl_pdr_min` floor from
+   [`ns3/tools/anchors.yml`](../../../ns3/tools/anchors.yml) on any AODV row
+   whose topology is the 2-node/1-link anchor. A FAIL is a harness bug: do
+   not compare, publish, or quote the numbers.
+4. **Parse / A/B** with
+   `python3 .claude/skills/benchmark-results/bench_parse.py OFF ON` — both
+   the text output and `--csv` rows are accepted; the
+   [#244](https://github.com/danieljoppi/AntHocNet/issues/244) directed-arm
+   and [#250](https://github.com/danieljoppi/AntHocNet/issues/250) comparisons
+   are exactly this. Record the verdict + run IDs on the driving issue
+   (ADR-0013).
+
+This suite has no per-merge refresh (the MANET quick taxonomy keeps that
+job). Do not quote the CI smoke numbers — they are delivery gates at tiny
+scale, not measurements.
 
 What the suite is waiting on, in dependency order:
 


### PR DESCRIPTION
Closes #259. Third of the parallel-agent batch. Closes the gap between "the satellite workflow ran" (#257) and "a satellite number may be quoted": validation gate, A/B parsing, and rescue/commit path now exist for the isl-grid suite, mirroring what #253 built for MANET cells.

## What ships

- **`scenario_check.py results` understands both isl-grid formats** — the `--csv` schema (header-sniffed) and the human `satellite-results.txt` (`+Grid` summary + `##RUN##` rows + aggregate table). Generic rules (PDR range, delay99 ≥ mean, negatives, #28 dead-cell WARN) fire unchanged; topology context rides along under non-colliding `sat_*` keys. **Fixes a latent mis-binding**: the isl-grid table's column order differs from the MANET table, so the generic ROW mapping would silently have read NRLbytes as jitter — now pinned by a dedicated branch and a test that plants a negative jitter in the last column.
- **Two satellite-specific rules**, each with its soundness argument in a comment:
  - *Propagation floor (FAIL)*: mean delay < `isl_delay_ms` is physically impossible on a p2p ISL mesh — it flags a harness/clock bug, never a fast protocol. Deliberately no stronger floor: flow endpoints (hence hop counts) are not in the output, so h=1 must stay legal. The h×d identity remains a dispatch-time gate (`check-sat-anchors.sh`) where h is known.
  - *Single-ISL anchor (FAIL)*: a 2-node/1-link AODV row self-identifies the anchor topology, so `sat_single_isl_pdr_min` (99.0) fires without an `--anchor` flag; floor read live from `anchors.yml` via the new `yml_floor()` helper (no duplication).
- **`bench_parse.py`**: `parse_cell()` maps isl-grid `--csv` rows by header name into the standard `{pdr,delay,delay99,thrput,nrl}` shape — satellite cells now A/B exactly like MANET ones (what the #244 directed arm and the #250 discriminator need).
- **`rescue-artifacts.yml`**: new `sat_run_ids` input rescuing the `satellite-benchmark` artifact as `docs/benchmarks/campaign/<runid>-sat.txt`, with a `##RUN##`-count sanity guard (#28 class); the MANET step gains an `if:` skip so satellite-only rescues don't fail on expired MANET artifacts.
- **`docs/benchmarks/satellite/isl-grid.md`**: Results stub now documents the real pipeline (dispatch → rescue → validate → parse/A-B). The "no committed results / waiting on #216" statements stay — still true.

## Tests

`test_scenario_check.py` 23 → **31 cases** (two per rule + clean fixtures, realistic readings from CI run 30190452648): clean CSV/human fixtures quiet; sub-floor delay fires; single-ISL 97.0 fires and names the anchors.yml key while 97.0 on the 4×4 stays quiet (congestion territory, not the anchor); the column-7 jitter-binding proof.

## Verification

- Self-test **31/31**; `make test` untouched (no core/ changes); parity script OK.
- **Real-world check**: the actual output of satellite-benchmark run [30567234126](https://github.com/danieljoppi/AntHocNet/actions/runs/30567234126) (the #250 discriminator) through the new validator: `checked 12 rows / verdict: OK (0 fail, 0 warn)` — retroactively validating the numbers recorded on #250.
- ruff **0.16.0** (the CI pin) clean on the full `lint.yml` command. Three 0.16.0 findings in the agent's original commit (1 FURB167, 2 RUF059 — same classes `78a7e01` cleared repo-wide) fixed before push, noted in the commit-message addendum.

Not parsed, by choice: `# diag` ant-tally lines (no results-mode rule reads them) and any hop-count inference (endpoints absent from output — inventing hops would make the floor unsound).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_