### PR TITLE
feat(ns3): fast ISL failure detection via interface-down + failcell detect/reconverge split

### DIFF
--- a/docs/benchmarks/satellite/isl-grid.md
+++ b/docs/benchmarks/satellite/isl-grid.md
@@ -23,10 +23,33 @@ It is a **static snapshot** grid: no orbital mechanics, no GSL handover, no
 link churn. That makes it the quiet-cell instrument — the regime where the
 [#216](https://github.com/danieljoppi/AntHocNet/issues/216) precomputed
 shortest-path control is expected to win and AntHocNet is expected to lose.
-The adversarial cells that could show the opposite (unpredicted ISL loss,
-asymmetric congestion, handover churn) are #216's scope and **do not exist
-yet**; until they do, results from this page support harness-validation
-claims, not protocol-advantage claims.
+Of the adversarial cells that could show the opposite (unpredicted ISL loss,
+asymmetric congestion, handover churn), only the **first has an instrument**:
+[#260](https://github.com/danieljoppi/AntHocNet/issues/260) added a scripted
+single-ISL break (`--breakLink=r1,c1,r2,c2 --breakAt=<s>`, cut via
+`Ipv4::SetDown` on both endpoint interfaces) that reports a per-run
+`# failcell … tDetect=<s> tReconverge=<s>` line. The remaining cells are
+#216's scope and do not exist yet; until the #216 control row exists, results
+from this page — failcell lines included — support harness-validation claims,
+not protocol-advantage claims.
+
+**Read the failcell numbers honestly.** `tDetect` (break → the protocol's
+first neighbour-loss event for the severed peer, from the `RouteChanged`
+trace; AntHocNet only — the baselines expose no such trace) is ~0 *by
+construction* for a scripted break: the adapter's #260 fast path is the
+`Ipv4` interface-down notification itself, the only failure signal a
+`PointToPointNetDevice` offers (no retry-limit trace; IP drops packets to a
+down interface before any device trace can fire). That models an ISL terminal
+reporting loss-of-light locally within ms. A *silent* failure — the interface
+stays up but frames stop arriving (e.g. a receive-side error model) — is not
+covered by the fast path and still waits the full hello timeout,
+`helloInterval × allowedHelloLoss` = 2 s at defaults; a failure cell built on
+silent loss lower-bounds the protocol, exactly the pre-#260 caveat.
+`tReconverge` (break → the last of the per-flow first deliveries after the
+break) is a **proxy**: the harness does not know which flows crossed the
+broken ISL, so unaffected flows contribute ~one CBR inter-packet gap
+(~125 ms at the 64 B / 4096 bps defaults) and only a value clearly above that
+gap measures re-convergence.
 
 ## Configuration
 
@@ -38,6 +61,7 @@ claims, not protocol-advantage claims.
 | `islRate` | 10Mbps | ISL data rate |
 | `flows` / `cbrBps` | 8 / 4096 | CBR load |
 | `protocols` | anthocnet,aodv,olsr,dsdv | `anthocnet,aodv` is the [#250](https://github.com/danieljoppi/AntHocNet/issues/250) hop-delay discriminator pair |
+| `breakLink` / `breakAt` | off | [#260](https://github.com/danieljoppi/AntHocNet/issues/260) scripted single-ISL break: endpoints `r1,c1,r2,c2` + cut time (s); emits `# failcell` detect/reconverge lines |
 
 ## How to run it
 

--- a/ns3/examples/isl-grid.cc
+++ b/ns3/examples/isl-grid.cc
@@ -19,6 +19,12 @@
  * This is a *scenario*, not a module. It adds no net devices and no mobility;
  * if it ever grows either, it belongs in #195 instead.
  *
+ * Issue #260: one scripted ISL break is supported (--breakLink=r1,c1,r2,c2
+ * --breakAt=<s>), cutting that link's two interfaces via Ipv4::SetDown at
+ * breakAt and reporting the detect/reconverge split as a "# failcell" line —
+ * see the comment at the failcell globals below for exactly what each number
+ * measures (and what the reconverge proxy does NOT measure).
+ *
  * Metrics mirror anthocnet-compare's definitions (PDR, mean and 99th-pct delay,
  * throughput, NRL as routing-control packets over delivered data packets, plus
  * #132 byte-NRL and #57 jitter) so numbers are comparable across the two
@@ -89,6 +95,52 @@ void DiagAntRx(uint8_t type, uint8_t /*dir*/) {
     if (g_diag) g_antRx[type] += 1;
 }
 
+// --- scripted ISL break, detect/reconverge split (#260) ----------------------
+// tDetect: break -> the protocol's first neighbour-loss event for the severed
+// peer at either endpoint, observed via anthocnet's RouteChanged trace source
+// (a removal fires from the core's loseNeighbor). Only anthocnet exposes that
+// trace, so tDetect prints "nan" for the baseline protocols. With the #260
+// interface-down fast path this is ~0 by construction for a SetDown-scripted
+// break; disabling it (EnableMacFailureDetector=false) makes the same number
+// read the detector-A hello timeout instead — the instrumentation measures
+// whichever detector actually fired.
+// tReconverge: break -> the LAST of the per-flow first deliveries after the
+// break, maximised over all flows. This is a PROXY, not path truth: the
+// harness does not know which flows crossed the broken ISL, so an unaffected
+// flow contributes roughly one CBR inter-packet gap (~125 ms at the default
+// 64 B / 4096 bps) and the maximum is dominated by the slowest genuinely
+// re-routed flow. If no flow crossed the broken ISL, the number degenerates to
+// about that gap — read it as an upper bound on re-convergence, meaningful
+// only when it clearly exceeds the inter-packet gap.
+double g_breakAt = 0.0;                  // s; 0 = no scripted break this run
+double g_tDetect = -1.0;                 // s after the break; -1 = never fired
+std::set<uint32_t> g_breakPeerAddrs;     // every Ipv4 address of both endpoints
+std::vector<double> g_flowFirstRxAfter;  // abs time; -1 = nothing after break
+
+void FailcellRouteChanged(uint32_t /*dest*/, uint32_t neighbor, bool added) {
+    if (added || g_tDetect >= 0.0 || g_breakAt <= 0.0) return;
+    const double now = Simulator::Now().GetSeconds();
+    if (now < g_breakAt) return;
+    if (g_breakPeerAddrs.count(neighbor)) g_tDetect = now - g_breakAt;
+}
+
+void FailcellSinkRx(uint32_t flow, Ptr<const Packet>, const Address&) {
+    const double now = Simulator::Now().GetSeconds();
+    if (g_breakAt <= 0.0 || now < g_breakAt) return;
+    if (flow < g_flowFirstRxAfter.size() && g_flowFirstRxAfter[flow] < 0.0) {
+        g_flowFirstRxAfter[flow] = now;
+    }
+}
+
+/// Cut one ISL: both endpoint interfaces go administratively down, which is
+/// the event the adapter's non-wifi fast path (#260) keys on. A p2p device has
+/// no other failure surface — its link never reports down and IP drops packets
+/// to a down interface before any device trace fires.
+void BreakIsl(Ptr<Ipv4> a, uint32_t ifA, Ptr<Ipv4> b, uint32_t ifB) {
+    a->SetDown(ifA);
+    b->SetDown(ifB);
+}
+
 struct Params {
     uint32_t rows;
     uint32_t cols;
@@ -98,6 +150,9 @@ struct Params {
     uint32_t nFlows;
     double   cbrBps;
     bool     torus;
+    double   breakAt;   // #260: 0 = no scripted break
+    uint32_t breakA;    // node index of one break endpoint
+    uint32_t breakB;    // node index of the other
 };
 
 struct Result {
@@ -207,6 +262,10 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_controlBytes = 0;
     g_antTx.clear();
     g_antRx.clear();
+    g_breakAt = P.breakAt;
+    g_tDetect = -1.0;
+    g_breakPeerAddrs.clear();
+    g_flowFirstRxAfter.clear();
 
     const uint32_t nNodes = P.rows * P.cols;
     NodeContainer nodes;
@@ -247,6 +306,45 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             p2p.Install(NodeContainer(nodes.Get(l.first), nodes.Get(l.second)));
         ifs.push_back(address.Assign(devs));
         address.NewNetwork();
+    }
+
+    // #260 scripted break: locate the named ISL among the built links and
+    // schedule both of its interfaces down at breakAt.
+    if (P.breakAt > 0.0) {
+        int breakIdx = -1;
+        for (std::size_t k = 0; k < links.size(); ++k) {
+            if ((links[k].first == P.breakA && links[k].second == P.breakB) ||
+                (links[k].first == P.breakB && links[k].second == P.breakA)) {
+                breakIdx = static_cast<int>(k);
+                break;
+            }
+        }
+        NS_ABORT_MSG_IF(breakIdx < 0, "--breakLink names no built ISL: nodes "
+                        << P.breakA << " and " << P.breakB << " are not adjacent");
+        std::pair<Ptr<Ipv4>, uint32_t> endA = ifs[breakIdx].Get(0);
+        std::pair<Ptr<Ipv4>, uint32_t> endB = ifs[breakIdx].Get(1);
+        Simulator::Schedule(Seconds(P.breakAt), &BreakIsl, endA.first, endA.second,
+                            endB.first, endB.second);
+        // Every address of both endpoint satellites: the core may name the lost
+        // neighbour by its canonical (first-interface) address or by the
+        // link-local one its hellos arrive from, and a removal at either
+        // endpoint identifies the break.
+        for (uint32_t nodeIdx : {P.breakA, P.breakB}) {
+            Ptr<Ipv4> ip = nodes.Get(nodeIdx)->GetObject<Ipv4>();
+            for (uint32_t i = 0; ip && i < ip->GetNInterfaces(); ++i) {
+                for (uint32_t j = 0; j < ip->GetNAddresses(i); ++j) {
+                    g_breakPeerAddrs.insert(ip->GetAddress(i, j).GetLocal().Get());
+                }
+            }
+            // tDetect from the RouteChanged trace at the two endpoints. Only
+            // anthocnet has this trace source; the connect quietly fails for
+            // the baselines and tDetect stays -1 (printed as nan).
+            Ptr<Ipv4RoutingProtocol> rp = ip ? ip->GetRoutingProtocol() : nullptr;
+            if (rp) {
+                rp->TraceConnectWithoutContext(
+                    "RouteChanged", MakeCallback(&FailcellRouteChanged));
+            }
+        }
     }
 
     // Routing overhead, counted at the IP layer exactly as anthocnet-compare
@@ -298,6 +396,16 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         sinks.Add(sink.Install(nodes.Get(dst)));
     }
     sinks.Start(Seconds(0.0));
+
+    // #260: per-flow first delivery after the break, for the tReconverge proxy
+    // (see the failcell comment above for what the maximum over flows means).
+    if (P.breakAt > 0.0) {
+        g_flowFirstRxAfter.assign(sinks.GetN(), -1.0);
+        for (uint32_t f = 0; f < sinks.GetN(); ++f) {
+            sinks.Get(f)->TraceConnectWithoutContext(
+                "Rx", MakeBoundCallback(&FailcellSinkRx, f));
+        }
+    }
 
     if (g_diag && proto == "anthocnet") {
         for (uint32_t i = 0; i < nodes.GetN(); ++i) {
@@ -373,6 +481,8 @@ int main(int argc, char* argv[]) {
     bool torus = true, csv = false;
     std::string islRate = "10Mbps";
     std::string protocols = "anthocnet";
+    std::string breakLink;
+    double breakAt = 0.0;
 
     CommandLine cmd(__FILE__);
     cmd.AddValue("rows", "Orbital planes (grid rows)", rows);
@@ -388,6 +498,10 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("protocols", "Comma-separated list", protocols);
     cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
     cmd.AddValue("diag", "Emit per-run '# diag' lines (ant tallies)", g_diag);
+    cmd.AddValue("breakLink", "Scripted ISL break (#260): endpoints as r1,c1,r2,c2 "
+                              "(must be adjacent); requires --breakAt", breakLink);
+    cmd.AddValue("breakAt", "Time (s) to cut --breakLink's ISL (both interfaces "
+                            "down via Ipv4::SetDown); 0 = no break", breakAt);
     cmd.Parse(argc, argv);
 
     // Same 1 ms delay bin as anthocnet-compare, so delay99 is comparable.
@@ -402,6 +516,34 @@ int main(int argc, char* argv[]) {
     P.nFlows = nFlows;
     P.cbrBps = cbrBps;
     P.torus = torus;
+    P.breakAt = 0.0;
+    P.breakA = P.breakB = 0;
+
+    // #260: parse and validate the scripted break before any run.
+    if (!breakLink.empty() || breakAt > 0.0) {
+        NS_ABORT_MSG_IF(breakLink.empty() || breakAt <= 0.0,
+                        "--breakLink and --breakAt must be given together");
+        NS_ABORT_MSG_IF(breakAt >= simTime, "--breakAt is past --time");
+        std::vector<uint32_t> rc;
+        std::stringstream bs(breakLink);
+        std::string tok;
+        while (std::getline(bs, tok, ',')) {
+            std::stringstream ts(tok);
+            uint32_t v = 0;
+            NS_ABORT_MSG_IF(!(ts >> v), "--breakLink expects r1,c1,r2,c2, got '"
+                            << breakLink << "'");
+            rc.push_back(v);
+        }
+        NS_ABORT_MSG_IF(rc.size() != 4, "--breakLink expects r1,c1,r2,c2, got '"
+                        << breakLink << "'");
+        NS_ABORT_MSG_IF(rc[0] >= rows || rc[2] >= rows || rc[1] >= cols || rc[3] >= cols,
+                        "--breakLink endpoint outside the " << rows << "x" << cols
+                        << " grid");
+        P.breakA = Idx(rc[0], rc[1], P);
+        P.breakB = Idx(rc[2], rc[3], P);
+        NS_ABORT_MSG_IF(P.breakA == P.breakB, "--breakLink endpoints are the same node");
+        P.breakAt = breakAt;
+    }
 
     std::vector<std::string> list;
     std::stringstream ss(protocols);
@@ -441,6 +583,25 @@ int main(int argc, char* argv[]) {
                     std::cout << static_cast<int>(kv.first) << '=' << kv.second << ',';
                 }
                 std::cout << ']' << std::endl;
+            }
+            // #260 detect/reconverge split for the scripted break (definitions
+            // and proxy caveats at the failcell globals above). "nan" = the
+            // event was never observed (no RouteChanged trace on baselines /
+            // no delivery after the break).
+            if (P.breakAt > 0.0) {
+                double tReconv = -1.0;
+                for (double t : g_flowFirstRxAfter) {
+                    if (t >= 0.0) tReconv = std::max(tReconv, t - P.breakAt);
+                }
+                std::cout << std::fixed << std::setprecision(4)
+                          << "# failcell " << list[i] << " seed=" << s
+                          << " breakAt=" << P.breakAt << " tDetect=";
+                if (g_tDetect >= 0.0) std::cout << g_tDetect;
+                else std::cout << "nan";
+                std::cout << " tReconverge=";
+                if (tReconv >= 0.0) std::cout << tReconv;
+                else std::cout << "nan";
+                std::cout << std::endl;
             }
         }
         agg[i].pdr /= runs;

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -573,6 +573,41 @@ void RoutingProtocol::NotifyInterfaceDown(uint32_t interface) {
             break;
         }
     }
+
+    // ADR-0008 detector-D equivalent for non-wifi links (#260). A scripted ISL
+    // break (Ipv4::SetDown, the stock ns-3 way to cut a point-to-point link)
+    // surfaces here and nowhere else: a PointToPointNetDevice has no
+    // retry-limit signal, never reports its link down, and a packet routed at
+    // a down interface is dropped by Ipv4L3Protocol before any device trace
+    // could fire. A real ISL terminal reports loss-of-light locally within
+    // milliseconds, so treating this local event as a definitive transmit
+    // failure is more faithful than waiting for the hello timeout (detector A,
+    // which stays on as the mandatory backstop — e.g. for silent losses this
+    // path never sees). Wifi devices keep their DroppedMpdu path (NotifyTxError,
+    // byte-identical) and are excluded here; both fast paths share the
+    // EnableMacFailureDetector ablation gate.
+    if (!m_enableMacFailureDetector || !m_logic) return;
+    Ptr<NetDevice> dev = m_ipv4->GetNetDevice(interface);
+    if (dev && dev->GetObject<WifiNetDevice>()) return;
+    auto nbIt = m_ifaceNeighbors.find(interface);
+    if (nbIt == m_ifaceNeighbors.end()) return;  // cannot attribute a next hop: no-op
+    const std::set<NodeAddress> lost = nbIt->second;
+    m_ifaceNeighbors.erase(nbIt);
+    for (NodeAddress nb : lost) {
+        // Converge on the shared reportTxFailure seam (prune + LinkFail
+        // notifications), like the wifi path. Its txFailureThreshold debounce
+        // exists to filter transient per-frame collisions (issue #19); an
+        // interface-down is not transient, so it counts as a full failure
+        // streak — drive the seam to its threshold instead of bypassing it,
+        // leaving core/ and the threshold's meaning untouched. No data packet
+        // is in hand, so dataDest stays invalid: no repair ant here, and held
+        // data re-routes through the normal reactive path.
+        std::vector<RouteDecision> decisions = m_logic->reportTxFailure(nb, kInvalidAddress);
+        for (int k = 1; k < m_config.txFailureThreshold && decisions.empty(); ++k) {
+            decisions = m_logic->reportTxFailure(nb, kInvalidAddress);
+        }
+        ExecuteDecisions(decisions, kInvalidAddress);
+    }
 }
 
 void RoutingProtocol::NotifyAddAddress(uint32_t, Ipv4InterfaceAddress) {}
@@ -821,25 +856,32 @@ void RoutingProtocol::RecvAnt(Ptr<Socket> socket) {
     // interface, which is precisely the case ResolveNextHop needs help with.
     if (incoming.type == AntType::Hello && incoming.src != kInvalidAddress) {
         const Ipv4Address canonical = ToIpv4(incoming.src);
-        if (canonical != sender) {
-            // A hello arrives on the subnet-broadcast socket; check the unicast
-            // map too so the mapping is still learned if that ever changes.
-            bool known = false;
-            Ipv4InterfaceAddress ifaceAddr;
-            auto bit = m_socketSubnetBroadcast.find(socket);
-            if (bit != m_socketSubnetBroadcast.end()) {
-                ifaceAddr = bit->second;
+        // A hello arrives on the subnet-broadcast socket; check the unicast
+        // map too so the mapping is still learned if that ever changes.
+        bool known = false;
+        Ipv4InterfaceAddress ifaceAddr;
+        auto bit = m_socketSubnetBroadcast.find(socket);
+        if (bit != m_socketSubnetBroadcast.end()) {
+            ifaceAddr = bit->second;
+            known = true;
+        } else {
+            auto uit = m_socketAddresses.find(socket);
+            if (uit != m_socketAddresses.end()) {
+                ifaceAddr = uit->second;
                 known = true;
-            } else {
-                auto uit = m_socketAddresses.find(socket);
-                if (uit != m_socketAddresses.end()) {
-                    ifaceAddr = uit->second;
-                    known = true;
-                }
             }
-            const int32_t i =
-                known ? m_ipv4->GetInterfaceForAddress(ifaceAddr.GetLocal()) : -1;
-            if (i >= 0) {
+        }
+        const int32_t i =
+            known ? m_ipv4->GetInterfaceForAddress(ifaceAddr.GetLocal()) : -1;
+        if (i >= 0) {
+            // #260: record both names the core may hold this neighbour under
+            // (learnNeighbor sees the link-local prevHop on every ant and the
+            // canonical src on hellos) so the non-wifi interface-down fast
+            // path can attribute which next hops a link break severed.
+            std::set<NodeAddress>& nbs = m_ifaceNeighbors[static_cast<uint32_t>(i)];
+            nbs.insert(ToCore(sender));
+            nbs.insert(incoming.src);
+            if (canonical != sender) {
                 PeerRoute pr;
                 pr.iface = static_cast<uint32_t>(i);
                 pr.linkLocal = sender;

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -260,6 +260,14 @@ private:
     /// the two differ, so it stays empty on every single-interface topology.
     std::map<Ipv4Address, PeerRoute> m_peerRoutes;
 
+    /// Issue #260: every core name a neighbour was heard under, per interface —
+    /// both the link-local sender (what learnNeighbor records as prevHop) and
+    /// the canonical `msg.src` a hello carries. Consulted only by the non-wifi
+    /// interface-down fast path in NotifyInterfaceDown so an ISL break can
+    /// attribute which next hop(s) it severed; an interface that never heard a
+    /// hello has no entry, and that path is then a no-op.
+    std::map<uint32_t, std::set<::anthocnet::core::NodeAddress>> m_ifaceNeighbors;
+
     ::anthocnet::core::Config m_config;
     Ns3Clock m_clock;
     Ns3Rng m_rng;


### PR DESCRIPTION
Closes #260. Last of the parallel-agent batch. Detector-D equivalent for point-to-point ISLs, plus the scripted-break instrumentation the #216 failure cell needs to attribute a lost race to *detection* vs *reconvergence* (the #192 detect+reconverge race framing).

## Investigation result first

The isl-grid harness had **no break mechanism at all**, so this PR defines one — and the failure signal follows from that choice. Stock ns-3 gives `PointToPointNetDevice` no usable TX-side failure trace for a scripted break: no public API takes a p2p link down (`IsLinkUp()` stays true forever, so `MacTxDrop` can never fire), and `PhyTxDrop` only fires on `TransmitStart` failure. The one stock idiom is `Ipv4::SetDown` (ns-3's own dynamic-global-routing example) — after which `Ipv4L3Protocol` drops outbound packets *before* the device, so no device trace can observe the failure, but the protocol synchronously receives `NotifyInterfaceDown`. **The ticket's PhyTxDrop sketch is a dead end; the interface-down notification is the right signal** — and the higher-fidelity model: a real ISL terminal reports loss-of-light locally within milliseconds.

## Adapter (`anthocnet-routing-protocol.{h,cc}`)

- New `m_ifaceNeighbors`: per receiving interface, every core name a hello neighbour is known under (link-local `prevHop` + canonical `msg.src`). The `m_peerRoutes` population is byte-for-byte the same logic, un-nested.
- `NotifyInterfaceDown` fast path: **skipped for wifi devices** (their DroppedMpdu detector D untouched), gated on the same `EnableMacFailureDetector` ablation switch, no-op when the interface has no recorded neighbours. Converges on the existing `m_logic->reportTxFailure` seam, driven **to the threshold rather than bypassing it** — an interface-down is not a transient collision, but core/ and the threshold's meaning stay untouched. No repair ant is forged (`dataDest = kInvalidAddress`); held data re-routes via the normal reactive path.
- Detector A (hello timeout) remains the backstop for silent failures where the interface stays up.

## Harness (`isl-grid.cc`)

- `--breakLink=r1,c1,r2,c2 --breakAt=<s>`: validates the ISL exists, schedules `Ipv4::SetDown` on both endpoints.
- Per run: `# failcell <proto> seed= breakAt= tDetect= tReconverge=`. `tDetect` = break → first neighbour-loss for the severed peer via the existing `RouteChanged` trace (AntHocNet only; baselines print nan). `tReconverge` = break → last per-flow first delivery after the break, documented honestly as a proxy with a ~125 ms floor (CBR inter-packet gap at defaults).

## Docs

`isl-grid.md` gains the failcell knob row and an honesty paragraph: `tDetect ≈ 0` is *by construction* for scripted breaks; silent failures still wait the 2 s hello timeout; the tReconverge proxy's floor.

## Review surface & verification

Core/ untouched (`make test` 25/25 locally after rebase onto #264's main). Wifi-path invariance: `NotifyTxError`, trace connections, `MapMacToCore` unchanged. **CI is the compile gate** — the dev environment cannot build ns-3, per AGENTS.md adapter workflow. The three stock APIs used that don't already appear in this repo, worth a reviewer's eye: `Ipv4::SetDown`, `Ipv4InterfaceContainer::Get` (pair return), `Ipv4::GetNAddresses`/`GetAddress(i,j)`.

Refs #192, #216, ADR-0008.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_