### PR TITLE
fix(bench): keep OOM forensics — print and upload time -v + stderr on a failed benchmark run

### DIFF
--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -150,19 +150,35 @@ jobs:
           if [ -x /usr/bin/time ]; then
             timewrap="/usr/bin/time -v -o $GITHUB_WORKSPACE/time-v.log"
           fi
+          # #256 forensics: on failure, also dump time -v — GNU time writes its
+          # report (including "Command terminated by signal 9" and Maximum
+          # resident set size) even when the sim is SIGKILLed, so the OOM's
+          # peak RSS is in that file. All three 900 s SIGKILLs lost it because
+          # nothing printed or uploaded it on the failure path.
           $timewrap ./ns3 run "$cmd" 2>"$GITHUB_WORKSPACE/ns3-stderr.log" \
             | tee "$GITHUB_WORKSPACE/paper-results.txt" \
             || { echo "--- ns-3 run FAILED; stderr tail ---"; \
-                 tail -n 60 "$GITHUB_WORKSPACE/ns3-stderr.log"; exit 1; }
+                 tail -n 60 "$GITHUB_WORKSPACE/ns3-stderr.log"; \
+                 if [ -s "$GITHUB_WORKSPACE/time-v.log" ]; then \
+                   echo "--- /usr/bin/time -v (peak RSS survives a SIGKILL) ---"; \
+                   cat "$GITHUB_WORKSPACE/time-v.log"; \
+                 fi; exit 1; }
           if [ -s "$GITHUB_WORKSPACE/ns3-stderr.log" ]; then
             echo "--- ns-3 stderr tail (non-fatal) ---"
             tail -n 20 "$GITHUB_WORKSPACE/ns3-stderr.log"
           fi
       - name: Upload results
+        # if: always() + stderr/time-v in the artifact — a failed run is
+        # exactly when the forensics are needed (#256), and skipping upload on
+        # failure discarded them three times.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: paper-benchmark
-          path: paper-results.txt
+          path: |
+            paper-results.txt
+            ns3-stderr.log
+            time-v.log
           retention-days: 7
       - name: Compact result block (cheap to fetch via get_job_logs tail)
         # Re-emit each protocol row as a single greppable line as the LAST log

--- a/.github/workflows/satellite-benchmark.yml
+++ b/.github/workflows/satellite-benchmark.yml
@@ -138,6 +138,10 @@ jobs:
             tail -n 20 "$GITHUB_WORKSPACE/ns3-stderr.log"
           fi
       - name: Upload results
+        # if: always(): a failed run is exactly when the stderr + time -v
+        # forensics are needed (#256's lesson — three SIGKILLed paper runs
+        # lost their peak-RSS evidence to a skipped upload).
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: satellite-benchmark


### PR DESCRIPTION
Refs #256 (stays open — this is the instrumentation its forensics need, not the fix).

## The finding that forced this

The 900 s paper-benchmark rerun ([run 30567236436](https://github.com/danieljoppi/AntHocNet/actions/runs/30567236436)) died with SIGKILL again — **third time** — ~45 min in. Two consequences:

1. **#256's working hypothesis is falsified.** This run executed on main @ `20c96c1`, i.e. *with* the #255 `proactiveInterval=10` restore, so the OOM is **not** a #254 symptom. Kill depths so far: 52 min and 8 min on `6a479fa`, 45 min on `20c96c1` — all at `time=900 runs=2` × 4 protocols in one process.
2. **The evidence died with the runner, three times.** `/usr/bin/time -v` (the #131 wrap) *had written its report* — GNU time reports `Command terminated by signal 9` plus `Maximum resident set size` even when the child is killed — but: the run step's failure branch never printed it, the `##PERF##` parse lives in a later step skipped on failure, and the artifact upload is (a) also skipped on failure and (b) only carried `paper-results.txt` anyway.

## The change

- **paper-benchmark.yml** — the failure branch now cats `time-v.log` (peak RSS of the killed tree) after the stderr tail; `Upload results` gains `if: always()` and carries `paper-results.txt` + `ns3-stderr.log` + `time-v.log`.
- **satellite-benchmark.yml** — same `if: always()` on its upload (it already carried all three files but had the identical skip-on-failure hole).

Verified: both files parse (`yaml.safe_load`); nothing besides the failure path and the upload condition changed. After merge I'll re-dispatch the 900 s run to finally capture the peak-RSS number for #256.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_