### PR TITLE
fix(bench): stream ##RSS## samples from the paper run — forensics that survive runner death

### DIFF
--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -150,11 +150,32 @@ jobs:
           if [ -x /usr/bin/time ]; then
             timewrap="/usr/bin/time -v -o $GITHUB_WORKSPACE/time-v.log"
           fi
-          # #256 forensics: on failure, also dump time -v — GNU time writes its
-          # report (including "Command terminated by signal 9" and Maximum
-          # resident set size) even when the sim is SIGKILLed, so the OOM's
-          # peak RSS is in that file. All three 900 s SIGKILLs lost it because
-          # nothing printed or uploaded it on the failure path.
+          # #256 forensics, layer 2: run 30574873901 died by losing the RUNNER
+          # (job log 404, artifacts zero, if:always() steps never ran), so
+          # post-mortem files cannot be trusted to exist. The live log stream
+          # survives up to the last flush, so sample memory into stdout every
+          # 60 s: top-RSS process + MemAvailable, greppable as ##RSS##. Pure
+          # /proc + awk — the ns-3 image has no procps. The sampler dies with
+          # the step; its lines are already streamed.
+          (
+            t0=$(date +%s)
+            while sleep 60; do
+              best=0; bestpid=0
+              for f in /proc/[0-9]*/status; do
+                rss=$(awk '/^VmRSS/ {print $2}' "$f" 2>/dev/null)
+                if [ -n "$rss" ] && [ "$rss" -gt "$best" ]; then
+                  best=$rss; bestpid=${f#/proc/}; bestpid=${bestpid%/status}
+                fi
+              done
+              comm=$(cat /proc/$bestpid/comm 2>/dev/null || echo '?')
+              avail=$(awk '/^MemAvailable/ {print $2}' /proc/meminfo)
+              echo "##RSS## t=$(( $(date +%s) - t0 ))s top=$comm pid=$bestpid rss_kb=$best mem_avail_kb=$avail"
+            done
+          ) & sampler_pid=$!
+          # #256 forensics, layer 1 (#267): on failure, also dump time -v —
+          # GNU time writes its report (including "Command terminated by
+          # signal 9" and Maximum resident set size) even when the sim is
+          # SIGKILLed — IF the runner survives to run this branch.
           $timewrap ./ns3 run "$cmd" 2>"$GITHUB_WORKSPACE/ns3-stderr.log" \
             | tee "$GITHUB_WORKSPACE/paper-results.txt" \
             || { echo "--- ns-3 run FAILED; stderr tail ---"; \
@@ -162,7 +183,8 @@ jobs:
                  if [ -s "$GITHUB_WORKSPACE/time-v.log" ]; then \
                    echo "--- /usr/bin/time -v (peak RSS survives a SIGKILL) ---"; \
                    cat "$GITHUB_WORKSPACE/time-v.log"; \
-                 fi; exit 1; }
+                 fi; kill "$sampler_pid" 2>/dev/null; exit 1; }
+          kill "$sampler_pid" 2>/dev/null || true
           if [ -s "$GITHUB_WORKSPACE/ns3-stderr.log" ]; then
             echo "--- ns-3 stderr tail (non-fatal) ---"
             tail -n 20 "$GITHUB_WORKSPACE/ns3-stderr.log"


### PR DESCRIPTION
Refs #256 — forensics layer 2. #267 (layer 1) covers the mode where the ns3 wrapper survives to report the SIGKILL; the fourth kill showed there's a harsher mode it can't reach.

## What the fourth kill taught us

[Run 30574873901](https://github.com/danieljoppi/AntHocNet/actions/runs/30574873901) (main @ `81a59ac`, i.e. *with* #267) died ~98 min into the sim step by **losing the runner itself**: `Run paper scenario` frozen `in_progress`, all later steps `pending`, job logs HTTP 404, zero artifacts. The `if: always()` upload and the failure-branch `cat time-v.log` never executed because there was no runner left to execute them. Post-mortem files cannot be trusted to exist in this mode.

Kill record across identical configs (`time=900 runs=2` × 4 protocols, one process): **52 min, 8 min (`6a479fa`), 45 min (`20c96c1`), 98 min (`81a59ac`)** — the scatter says the trigger is runner memory headroom, not a deterministic sim point; consistent with monotonic growth toward the VM ceiling.

## The change

What survives runner death is the **live log stream**, up to its last flush. The run step now backgrounds a sampler printing every 60 s to step stdout:

```
##RSS## t=<s>s top=<comm> pid=<pid> rss_kb=<VmRSS> mem_avail_kb=<MemAvailable>
```

- Pure `/proc` + `awk` — the ns-3 image has no procps.
- Killed on both success and failure paths; if the runner dies, its lines are already streamed and the growth curve up to seconds before death is in the log.
- Job-log only: `paper-results.txt` is fed by the tee pipeline and stays byte-clean.

## Verification

`yaml.safe_load` parses; `bash -n` on the extracted step script OK; the sampler body executed locally prints the expected line (`##RSS## t=0s top=claude pid=572 rss_kb=478652 mem_avail_kb=15772904`). After merge I'll dispatch the 900 s run once more — whatever dies, we finally get the curve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_