### PR TITLE
fix(bench): cap sim address space at 13 GiB so an OOM dies gracefully, not with the runner

### DIFF
--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -172,6 +172,16 @@ jobs:
               echo "##RSS## t=$(( $(date +%s) - t0 ))s top=$comm pid=$bestpid rss_kb=$best mem_avail_kb=$avail"
             done
           ) & sampler_pid=$!
+          # #256 forensics, layer 3: cap the sim's address space BELOW the
+          # runner's ceiling so it dies by bad_alloc (graceful: wrapper
+          # reports, job finalizes, logs/artifacts survive) instead of by
+          # taking the whole runner down (runs 30574873901 and 30584510356:
+          # frozen steps, logs 404 server-side, artifacts zero — even the
+          # streamed ##RSS## lines were unretrievable because the log blob
+          # never finalized). 13 GiB leaves ~3 GiB for OS+runner agent on
+          # the 16 GiB ubuntu-latest VM. ulimit -v is per-process inherited,
+          # so it caps the sim binary itself, not just the wrapper.
+          ulimit -v 13631488 || echo "ulimit -v failed (non-fatal)"
           # #256 forensics, layer 1 (#267): on failure, also dump time -v —
           # GNU time writes its report (including "Command terminated by
           # signal 9" and Maximum resident set size) even when the sim is


### PR DESCRIPTION
Refs #256 — forensics layer 3, and the one that makes layers 1–2 actually reachable.

## Why layer 2 wasn't enough

Fifth 900 s kill ([run 30584510356](https://github.com/danieljoppi/AntHocNet/actions/runs/30584510356), main @ `6707fce` *with* the #268 sampler, ~78 min into the sim step) repeated the runner-lost mode — and exposed that it defeats even streamed forensics: when the runner dies, **the job log blob never finalizes server-side**. `get_job_logs` returns HTTP 404 after completion (verified on both runner-lost runs, 30574873901 and 30584510356); the streamed `##RSS##` lines exist only inside a run-level ZIP on `results-receiver.actions.githubusercontent.com`, which this environment's network policy blocks. So the curve was captured and is still unreadable.

## The change

Remove the runner-death mode instead of instrumenting around it: `ulimit -v 13631488` (13 GiB) in the run step before the sim. The limit is inherited per-process, so it caps the sim binary itself. At 13 GiB the allocator fails → `std::bad_alloc` → abort **with the wrapper and runner alive**: the job fails but *finalizes*, so the `##RSS##` curve (#268), the `time -v` report (#267), the stderr tail (with the bad_alloc message) and the `if: always()` artifact all become retrievable. 13 GiB leaves ~3 GiB headroom for OS + runner agent on the 16 GiB `ubuntu-latest` VM, comfortably above any legitimate paper-scenario footprint (300 s runs complete far below it).

Kill record, all `time=900 runs=2` × 4 protocols: 52 min, 8 min (`6a479fa`), 45 min (`20c96c1`), 98 min (`81a59ac`), 78 min (`6707fce`). Modes: 3× sim SIGKILL with surviving wrapper, 2× runner lost.

## Verification

`yaml.safe_load` parses; `bash -n` on the extracted step script OK. After merge: dispatch #6 — whichever way it ends, the growth curve and peak number finally land in a retrievable log.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_