### PR TITLE
feat(bench): adopt the dedicated diversity cell — floor-relative gate at the churn-free window

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -52,6 +52,16 @@ MAX_PATH_LENGTH = 100
 # AntHocNet diversity figure means anything.
 SINGLE_PATH_PROTOS = ("aodv", "olsr", "dsdv")
 SINGLE_PATH_DIV_MAX = 1.10
+# The dedicated diversity-measurement cell (#230, run 30650903707): window
+# <= DIV_CELL_WINDOW_S is the calibrated churn-free window, where a raised
+# offered rate feeds the cells and the single-path baselines legitimately sit
+# ABOVE 1.10 (a route break at 8 pkt/s lands packets on both routes within one
+# short window — floor measured at aodv=1.133). In that cell diversity is read
+# as EXCESS over the in-run single-path floor, so the absolute bound relaxes to
+# a sanity ceiling: a baseline above DIV_CELL_SANITY_MAX means the window is
+# not churn-free at this rate and the cell is unreadable.
+DIV_CELL_WINDOW_S = 2.0
+DIV_CELL_SANITY_MAX = 1.50
 
 ROW = re.compile(r"^\s*(?:##BENCH##\s+)?([a-z][\w-]*)((?:\s+[-\d.]+|\s+inf)+)\s*$")
 
@@ -79,7 +89,8 @@ ISL_RUN = re.compile(r"^\s*##RUN##\s+(\d+)\s+([a-z][\w-]*)"
 DIAG_LINE = re.compile(r"^\s*#\s+(paths|energy|drops|reorder)\s+([a-z][\w-]*)\s+(.+)$")
 DIAG_KEYS = {
     "paths":   {"hopsMean": "hops", "hopsMax": "hops_max", "divUsed": "div",
-                "divMax": "div_max", "entropyBits": "entropy"},
+                "divMax": "div_max", "entropyBits": "entropy",
+                "windowS": "div_window"},
     # energy(J)/J-per-pkt live at table positions 10/11, which the 9-number
     # ##BENCH## block does not carry; the '# energy' line adds the residual
     # bounds. 'pdr' on the '# drops' line is deliberately unmapped — the
@@ -325,6 +336,7 @@ def parse_results(path):
                    "hops_max": r.get("path_hops_max"),
                    "div": r.get("path_div_used"),
                    "div_max": r.get("path_div_max"),
+                   "div_window": r.get("path_div_window_s"),
                    "entropy": r.get("path_entropy_bits"),
                    "jain": r.get("jain_pkts")}
         return
@@ -549,6 +561,7 @@ def cmd_results(a):
             # whenever PDR is non-zero.
             hops, hops_max = num("hops"), num("hops_max")
             div, div_max = num("div"), num("div_max")
+            div_window = num("div_window")
             entropy, jain = num("entropy"), num("jain")
             if hops is not None:
                 if hops < 0.0:
@@ -581,15 +594,29 @@ def cmd_results(a):
                                    "carried destination uses at least one "
                                    "next hop")
                 elif (r["proto"] in SINGLE_PATH_PROTOS
+                        and div_window is not None
+                        and div_window <= DIV_CELL_WINDOW_S
+                        and div > DIV_CELL_SANITY_MAX):
+                    report("FAIL", f"{tag}: path diversity {div} > "
+                                   f"{DIV_CELL_SANITY_MAX} for a single-path "
+                                   "protocol even at the churn-free window "
+                                   f"(<= {DIV_CELL_WINDOW_S} s) — the window "
+                                   "is not churn-free at this offered rate, "
+                                   "so the diversity cell is unreadable "
+                                   "(#230)")
+                elif (r["proto"] in SINGLE_PATH_PROTOS
+                        and (div_window is None
+                             or div_window > DIV_CELL_WINDOW_S)
                         and div > SINGLE_PATH_DIV_MAX):
                     report("FAIL", f"{tag}: path diversity {div} > "
                                    f"{SINGLE_PATH_DIV_MAX} for a single-path "
                                    "protocol — path_div_window_s is longer than "
                                    "the route lifetime, so route replacement is "
                                    "being counted as concurrent multipath; "
-                                   "recalibrate the window (#230) before "
-                                   "reading any path_div_* or path_entropy_bits "
-                                   "figure, including AntHocNet's")
+                                   "diversity is only readable from the "
+                                   "dedicated cell (cbrBps=4096, "
+                                   "pathWindowS=2), as excess over the "
+                                   "single-path floor (#230)")
             if div_max is not None and div is not None and div_max and div_max < div:
                 report("FAIL", f"{tag}: max path diversity {div_max} < mean "
                                f"path diversity {div}")

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -423,6 +423,35 @@ def _cell_pdr_authoritative():
            f"'# drops' pdr leaked into the row: {levels} vs {base}\n{out}")
 
 
+# --- #230 dedicated diversity cell (cbrBps=4096, pathWindowS=2) --------------
+# Real readings from run 30650903707: at the churn-free 2 s window with the
+# raised rate, the single-path floor sits legitimately above the 1.10 absolute
+# bound (aodv 1.133 — a route break at 8 pkt/s lands packets on both routes
+# within one short window), so the absolute rule must NOT fire there; only the
+# 1.50 sanity ceiling may.
+DIVCELL = """\
+##BENCH## anthocnet 94.8 62.0 900.0 6.10 40.00 95.00 3.5 361.0 47.9
+##BENCH## aodv 90.1 33.0 480.0 5.60 53.00 47.00 4.0 inf 28.2
+# paths anthocnet divUsed=1.229 divMax=7.0 entropyBits=0.163 windowS=2.0 hopsMean=2.77 hopsMax=64.0
+# paths aodv divUsed=1.133 divMax=6.0 entropyBits=0.093 windowS=2.0 hopsMean=2.17 hopsMax=63.0
+"""
+
+
+@case("#230 diversity cell: baseline above 1.10 at windowS<=2 stays quiet")
+def _divcell_floor_allowed():
+    _levels, out = run_cell(DIVCELL)
+    expect("path diversity" not in out, "divcell-quiet",
+           f"absolute 1.10 rule fired inside the diversity cell\n{out}")
+
+
+@case("#230 diversity cell: baseline above the 1.50 sanity ceiling fires")
+def _divcell_sanity_fires():
+    _levels, out = run_cell(DIVCELL.replace("aodv divUsed=1.133",
+                                            "aodv divUsed=1.633"))
+    expect("not churn-free at this offered rate" in out, "divcell-sanity",
+           f"planted 1.633 above the sanity ceiling not flagged\n{out}")
+
+
 # --- #259 satellite (isl-grid) input: CSV schema + human mode + rules --------
 #
 # The CSV fixture is a realistic 4x4 torus at the anchor knobs: 16 satellites,

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -353,15 +353,39 @@ not a blank column.
 > dominate. The two bounds cross, which is why the sweep has no solution.
 >
 > `kDefaultPathWindowS` is therefore **left at 10 s** — no other value is
-> better, and moving it would imply the problem was solved. The fix is to raise
-> the offered rate for diversity measurement or to count concurrent next hops
-> per packet-pair rather than per time window;
-> [#230](https://github.com/danieljoppi/AntHocNet/issues/230) tracks it.
-> `scenario_check.py` now flags **every** window at 1 pkt/s — FAIL below the
-> 2-packet floor, WARN at it, WARN/FAIL past the churn bound — and `preflight`
-> refuses the dispatch before a run is spent. Until it closes, read
-> `path_hops_*` and `jain_pkts` (unaffected) and treat the diversity and
-> entropy columns as not yet measuring what they claim.
+> better at the paper's 1 pkt/s, and moving it would imply the problem was
+> solved. A 900 s re-sweep (w ∈ {2,4,6,10}, runs 30649042555/30649049794/
+> 30649059276/30599510462) reproduced the table above point for point.
+>
+> **Resolution (#230, owner-approved): a dedicated diversity-measurement
+> cell.** Raising the offered rate feeds the cells instead of shrinking the
+> window past the churn bound: at `--cbrBps=4096 --pathWindowS=2` (8 pkt/s →
+> 16 packets per cell; run 30650903707, 900 s) AntHocNet separates from every
+> baseline — `divUsed` **1.229** vs aodv 1.133 / olsr 1.090 / dsdv 1.046,
+> `entropyBits` 0.163 vs ≤ 0.093, `divMax` 7 vs ≤ 6. Concurrent spreading is
+> real and was sample-starved at 1 pkt/s.
+>
+> Rules for using the cell:
+>
+> 1. **All `path_div_*`/`path_entropy_bits` claims come from this cell only**
+>    (`cbrBps=4096`, `pathWindowS=2`), which is its own load regime (8× the
+>    paper rate) and must be labeled as such — never mixed into the headline
+>    paper cell, whose diversity columns remain unquotable.
+> 2. **Report diversity as excess over the in-run single-path floor**, not as
+>    an absolute: at 8 pkt/s even a churn-free window catches AODV's route
+>    replacement landing packets on two routes inside one window (measured
+>    floor 1.133), so the honest figure is AntHocNet − AODV in the same run
+>    (today: **+0.096 used-paths, +0.070 entropy bits**). No (rate, window)
+>    pair drives the floor to 1.0 while keeping the cells fed.
+> 3. `scenario_check.py` enforces the split: the absolute 1.10 single-path
+>    bound applies whenever `path_div_window_s > 2`; at the cell's window it
+>    relaxes to a 1.50 sanity ceiling (a baseline above that means the window
+>    is not churn-free at the offered rate and the cell is unreadable).
+>
+> The per-packet-pair concurrency counter remains the clean long-term
+> instrument that would retire the floor comparison; #230 keeps it as the
+> follow-up. `path_hops_*` and `jain_pkts` are unaffected by all of this and
+> readable from any cell.
 
 - **Reactive protocols read one hop high on route-discovery packets.** A
   protocol with no route yet bounces the packet through the loopback device to


### PR DESCRIPTION
Owner-approved resolution of #230's path-diversity deadlock (refs #217). Evidence chain on the issue; summary:

1. **900 s window re-sweep** (w ∈ {2,4,6,10}) reproduced the documented dead end point for point: largest baseline-clean window is 2 s, and at 2 s *everyone* reads ~1.000 — sample-starved at 1 pkt/s. Shrinking alone buys a clean gate over an empty metric.
2. **The traffic arm** ([run 30650903707](https://github.com/danieljoppi/AntHocNet/actions/runs/30650903707): `cbrBps=4096, pathWindowS=2`, 900 s) separates AntHocNet from every baseline: `divUsed` **1.229** vs 1.133/1.090/1.046, entropy 0.163 vs ≤0.093. Concurrent spreading is real — it was starved, not absent. Wrinkle: the single-path floor itself rises with rate (AODV 1.133 > 1.10 even churn-free), so the sound reading is **excess over the in-run AODV floor** (+0.096 used-paths, +0.070 entropy bits) — no absolute threshold works at the cell.

## What lands

- **`scenario_check.py`**: `windowS` (text) / `path_div_window_s` (CSV) parse into the row. The single-path rule splits: window > 2 s keeps the absolute 1.10 FAIL (message now points at the dedicated cell); window ≤ 2 s relaxes to a **1.50 sanity ceiling** (baseline above it ⇒ window not churn-free at the offered rate ⇒ cell unreadable). Headline campaigns (windowS=10) validate exactly as before — re-verified on the run-30599510462 block (still 3 FAILs) and the run-30650903707 cell block (passes).
- **`test_scenario_check.py`**: DIVCELL fixture from the real run; two cases (floor-above-1.10 quiet at w=2; planted 1.633 fires). **33 cases pass.**
- **`metrics.md`**: the caveat block gains the resolution — cell definition (its own 8× load regime, never mixed into the headline cell, whose diversity columns stay unquotable), floor-relative reporting rule, gate behavior, per-packet-pair counter kept as the long-term follow-up. `kDefaultPathWindowS` stays 10 s; no harness code changes.

ruff 0.16.0 clean on the lint.yml file set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_