### PR TITLE
feat(core): virtual pheromone ages on the regular table's time-proportional clock (#262)

### DIFF
--- a/core/include/anthocnet/core/pheromone_engine.h
+++ b/core/include/anthocnet/core/pheromone_engine.h
@@ -29,11 +29,14 @@ public:
     void updateRegular(PheromoneTable& table, NodeAddress dest,
                        NodeAddress neighbor, double phUpdate) const;
 
-    /// Time-proportional aging of every regular link by alpha^(dt/interval),
-    /// pruning links below minPheromone. Driven by the maintenance tick.
+    /// Time-proportional aging of every regular AND virtual link by
+    /// alpha^(dt/interval), pruning links below minPheromone. Driven by the
+    /// maintenance tick. One clock for both tables (#262) keeps them
+    /// commensurable for virtual-vs-regular comparisons.
     void evaporateAll(PheromoneTable& table, double dtSeconds) const;
 
-    /// Evaporate all virtual links then reinforce those advertised by a hello.
+    /// Reinforce the virtual links advertised by a hello. Aging is handled by
+    /// evaporateAll, same as the regular table (#262).
     void updateVirtual(PheromoneTable& table, const AntMessage& hello) const;
 
     /// Prune a vanished neighbour from both tables.
@@ -41,7 +44,6 @@ public:
 
     /// True if any neighbour still holds usable pheromone for this dest.
     bool hasRegularDestination(const PheromoneTable& table, NodeAddress dest) const;
-    bool hasVirtualDestination(const PheromoneTable& table, NodeAddress dest) const;
 
 private:
     void cleanNeighbor(PheromoneTable& table, NodeAddress neighbor, bool regular) const;

--- a/core/src/pheromone_engine.cpp
+++ b/core/src/pheromone_engine.cpp
@@ -1,7 +1,6 @@
 #include "anthocnet/core/pheromone_engine.h"
 
 #include <cmath>
-#include <set>
 #include <vector>
 
 namespace anthocnet {
@@ -18,13 +17,6 @@ double PheromoneEngine::reinforce(double phValue, double phUpdate) const {
 bool PheromoneEngine::hasRegularDestination(const PheromoneTable& table, NodeAddress dest) const {
     for (NodeAddress neighbor : table.neighbors()) {
         if (table.getPheromoneRegular(dest, neighbor) > config_.minPheromone) return true;
-    }
-    return false;
-}
-
-bool PheromoneEngine::hasVirtualDestination(const PheromoneTable& table, NodeAddress dest) const {
-    for (NodeAddress neighbor : table.neighbors()) {
-        if (table.getPheromoneVirtual(dest, neighbor) > config_.minPheromone) return true;
     }
     return false;
 }
@@ -60,39 +52,36 @@ void PheromoneEngine::evaporateAll(PheromoneTable& table, double dtSeconds) cons
             }
         }
     }
+
+    // Virtual pheromone ages here too, on the identical clock (#262). The
+    // thesis defines no virtual aging at all — per-hello replacement plus
+    // eviction on neighbour loss — so any decay is our extension, and it must
+    // at least be commensurable with the regular table: every virtual-vs-
+    // regular comparison (the #180/#252 emission gate included) assumes the
+    // two are in the same units. The old per-hello whole-table decay aged at
+    // alpha^degree per second, a rate set by topology, not time.
+    const std::vector<NodeAddress> vdests(table.virtualDestinations().begin(),
+                                          table.virtualDestinations().end());
+    for (NodeAddress dest : vdests) {
+        const std::vector<NodeAddress> neighbors(table.neighbors().begin(),
+                                                 table.neighbors().end());
+        for (NodeAddress n : neighbors) {
+            const double ph = table.getPheromoneVirtual(dest, n);
+            if (ph <= 0.0) continue;
+            const double aged = ph * factor;
+            if (aged < config_.minPheromone) {
+                table.removePheromoneVirtual(dest, n);
+            } else {
+                table.setPheromoneVirtual(dest, n, aged);
+            }
+        }
+    }
 }
 
 void PheromoneEngine::updateVirtual(PheromoneTable& table, const AntMessage& hello) const {
     // Diffusion gated off (ADR-0007): keep the virtual table empty so proactive
     // selection degenerates to the regular-only sum.
     if (!config_.enableProactive || !config_.enableDiffusion) return;
-
-    std::set<NodeAddress> destsRem;
-
-    // Evaporate every virtual link; prune those that fall below the floor.
-    const std::vector<NodeAddress> dests(table.virtualDestinations().begin(),
-                                         table.virtualDestinations().end());
-    for (NodeAddress dest : dests) {
-        const std::vector<NodeAddress> neighbors(table.neighbors().begin(),
-                                                 table.neighbors().end());
-        for (NodeAddress neighbor : neighbors) {
-            double phValue = table.getPheromoneVirtual(dest, neighbor);
-            if (phValue < config_.minPheromone) {
-                table.removePheromoneVirtual(dest, neighbor);
-                if (!hasVirtualDestination(table, dest)) destsRem.insert(dest);
-            } else {
-                table.setPheromoneVirtual(dest, neighbor, evaporate(phValue));
-            }
-        }
-    }
-
-    for (NodeAddress dest : destsRem) {
-        const std::vector<NodeAddress> neighbors(table.neighbors().begin(),
-                                                 table.neighbors().end());
-        for (NodeAddress neighbor : neighbors) {
-            table.removePheromoneVirtual(dest, neighbor);
-        }
-    }
 
     // Reinforce the destinations this hello advertised, via its sender. The
     // advert is the neighbour's best pheromone (an inverse cost) to advert.node;

--- a/core/tests/test_pheromone_engine.cpp
+++ b/core/tests/test_pheromone_engine.cpp
@@ -49,6 +49,37 @@ int main() {
     CHECK(table.getPheromoneRegular(9, 1) > cfg.minPheromone);
     CHECK(table.getPheromoneRegular(9, 2) < cfg.minPheromone);
 
+    // Virtual pheromone ages on the SAME time-proportional clock as regular
+    // (#262): evaporateAll applies alpha^(dt/interval) to both tables, and
+    // updateVirtual only reinforces — receiving a hello must not age anything.
+    // This pins the commensurability the #180/#252 emission gate assumes.
+    {
+        PheromoneTable t;
+        t.addNeighbor(1);
+        t.setPheromoneRegular(9, 1, 0.4);
+        t.setPheromoneVirtual(9, 1, 0.4);
+        engine.evaporateAll(t, cfg.evaporationInterval);
+        CHECK_NEAR(t.getPheromoneRegular(9, 1), 0.4 * 0.7, 1e-9);
+        CHECK_NEAR(t.getPheromoneVirtual(9, 1), 0.4 * 0.7, 1e-9);  // same factor
+
+        // A hello advertising some other destination leaves the existing
+        // virtual entry byte-identical (the old per-hello whole-table decay
+        // would have multiplied it by alpha here).
+        const double before = t.getPheromoneVirtual(9, 1);
+        AntMessage hello;
+        hello.type = AntType::Hello;
+        hello.src = 1;
+        hello.helloDests.push_back({7, 0.5});
+        engine.updateVirtual(t, hello);
+        CHECK_NEAR(t.getPheromoneVirtual(9, 1), before, 1e-12);
+        CHECK(t.getPheromoneVirtual(7, 1) > 0.0);  // advert reinforced
+
+        // Unrefreshed virtual entries decay below minPheromone and are pruned
+        // by evaporateAll, matching regular-table eviction.
+        for (int i = 0; i < 60; ++i) engine.evaporateAll(t, cfg.evaporationInterval);
+        CHECK_NEAR(t.getPheromoneVirtual(9, 1), 0.0, 1e-12);
+    }
+
     // cleanNeighbor wipes a vanished neighbour from the table.
     PheromoneTable t2;
     t2.setPheromoneRegular(9, 3, 0.8);

--- a/docs/adr/0012-evaporation-is-a-secondary-safety-net.md
+++ b/docs/adr/0012-evaporation-is-a-secondary-safety-net.md
@@ -64,6 +64,22 @@ and hellos are periodic, so that path is effectively periodic and roughly matche
 the Bellman-Ford-style diffusion refresh; it may be aligned onto the same tick for
 consistency but is not the deviation this ADR fixes.
 
+> **Update (2026-08-01, #262):** the alignment anticipated above is done. The
+> per-hello whole-table decay was *not* effectively periodic — it fired once per
+> **received** hello, so the virtual table aged at `α^degree` per second, a rate
+> set by topology, not time. The thesis itself defines **no** virtual aging at
+> all (per-hello replacement semantics §4.2.3 plus eviction on neighbour loss
+> §4.2.5), so any decay is our extension — and the #262 three-arm A/B showed
+> the fast accidental clock had been acting as a proactive throttle (removing
+> it costs +7–13 % NRL at any proactive rate, with no PDR gain). Virtual aging
+> now lives in `evaporateAll` on the identical `α^(Δt/interval)` factor as
+> regular, making the two tables **commensurable** — the property every
+> virtual-vs-regular comparison (the #180/#252 emission gate included)
+> silently assumed. The NRL cost is moot under the #248 MANET guidance
+> (proactive off); the satellite regime, which keeps proactive, needs the
+> clock correct. Full evidence on
+> [#262](https://github.com/danieljoppi/AntHocNet/issues/262).
+
 ## Alternatives considered
 
 - **Event-driven on reinforcement (status quo).** Indefensible on any reading:


### PR DESCRIPTION
Lands **arm C** of the #262 three-arm A/B — the owner's pick after the revised recommendation on the issue.

## What changes

Virtual-table aging moves out of `updateVirtual` — where a whole-table ×α decay ran once per **received** hello, i.e. `α^degree` per second, a rate set by topology, not time — and into `evaporateAll`, on the identical `factor = α^(Δt/evaporationInterval)` the regular table uses (ADR-0012's single-sourced aging). Entries that fall below `minPheromone` are removed there, matching regular-table eviction. `updateVirtual` now only reinforces the advertised links.

- `core/src/pheromone_engine.cpp` — per-hello decay block removed from `updateVirtual`; virtual aging loop added to `evaporateAll` on the shared `factor`. `hasVirtualDestination()` removed: its only caller was the deleted block (`#include <set>` likewise). Note `hasRegularDestination()` was **already** caller-less before this change; left in place per the surgical-change rule.
- `core/include/anthocnet/core/pheromone_engine.h` — doc comments updated; `hasVirtualDestination` declaration dropped.
- `core/tests/test_pheromone_engine.cpp` — new block **pinning the clock**: (a) `evaporateAll` ages a virtual entry by exactly the regular factor (0.4 → 0.4·0.7 on both tables, same Δt); (b) receiving a hello leaves non-advertised virtual entries byte-identical (the old code would have multiplied by α here); (c) unrefreshed virtual entries decay below `minPheromone` and are pruned by `evaporateAll`. No prior test pinned either clock — both A/B arms passed 25/25 unchanged, which is itself why this test now exists.
- `docs/adr/0012-evaporation-is-a-secondary-safety-net.md` — the "may be aligned onto the same tick for consistency" paragraph gets an update note recording that the alignment is done, why, and the measured cost.

## Why

The thesis defines **no** virtual aging at all: per-hello replacement semantics (§4.2.3) plus eviction on neighbour loss (§4.2.5). Any decay is our extension, so it must at least be **commensurable** with the regular table — every virtual-vs-regular comparison (the #180/#252 emission gate included) silently assumed the two tables were in the same units, and under the old clock they were not.

Measured on the paper field (900 s, #262 A/B): removing the fast accidental clock increases proactive liveness → **+7–13 % NRL at any proactive rate, no PDR gain** — the old per-hello decay had been acting as an accidental proactive throttle. That cost is moot under the #248 MANET guidance (proactive off beats every rate on every axis), and the satellite regime — which keeps proactive — needs the clock correct for the #180 gate re-derivation. C@20s falsified the slower-rate-compensates variant. Full evidence and arm definitions on #262; the landed diff is `a4d2888`'s experiment change with production comments.

## Verification

- core `make test`: **25/25** including the new clock pins (run on the post-#274 base).
- The identical code already went through full CI as experiment commit `a4d2888` during the A/B.

Closes #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_