### PR TITLE
feat(core): the ILinkState congestion queries name the next hop — the stamp moves to where the interface is known (#206)

### DIFF
--- a/core/include/anthocnet/core/ant_router_logic.h
+++ b/core/include/anthocnet/core/ant_router_logic.h
@@ -145,8 +145,11 @@ public:
 
     /// Append this node to a forward ant's visited stack, recording this hop's
     /// cost (congestion-aware MAC estimate when enabled, else wall-clock delta).
-    /// Bounded by Config::maxPathLength.
-    void stampForward(AntMessage& ant) const;
+    /// `nextHop` is the interface the ant leaves by, so the congestion signal
+    /// is read for the queue it will actually wait in; kInvalidAddress when
+    /// there is no single one (broadcast, or this node is the destination) —
+    /// the ILinkState then aggregates (#206). Bounded by Config::maxPathLength.
+    void stampForward(AntMessage& ant, NodeAddress nextHop) const;
 
     /// Advance a backward ant by one hop: move this node from the visited stack
     /// onto `history` and return the next hop (path management only; the deposit
@@ -193,9 +196,10 @@ private:
     void computeBackAntState(AntMessage& ant) const;
 
     /// This node's contribution to a forward ant's path-time estimate: the
-    /// congestion-aware MAC cost (Q_mac+1)*T̂_mac when enabled and available,
-    /// else the ant's wall-clock transit delta since the previous stamp.
-    double localHopCost(const AntMessage& ant) const;
+    /// congestion-aware MAC cost (Q_mac+1)*T̂_mac toward `nextHop` when enabled
+    /// and available, else the ant's wall-clock transit delta since the
+    /// previous stamp.
+    double localHopCost(const AntMessage& ant, NodeAddress nextHop) const;
 
     NodeAddress     address_;
     Config          config_;

--- a/core/include/anthocnet/core/ports.h
+++ b/core/include/anthocnet/core/ports.h
@@ -55,19 +55,28 @@ public:
 /// MAC, so it measures; the core turns these into a per-hop cost. Optional —
 /// when no ILinkState is injected (or the feature is gated off) the core falls
 /// back to the forward ant's wall-clock transit time, i.e. unchanged behaviour.
+/// Both queries name the next hop the cost is being computed *for* (#206): a
+/// multi-interface node (a satellite with one queue per ISL) has no single
+/// "the queue", and the useful congestion signal is per-next-hop.
+/// `nextHop == kInvalidAddress` means the caller has no single outgoing
+/// interface — the ant is being broadcast on every interface, or this node is
+/// the path's terminal — and the adapter should aggregate across interfaces.
+/// Single-interface adapters (one wifi radio) may ignore the parameter: there
+/// per-next-hop degenerates to per-node for free.
 class ILinkState {
 public:
     virtual ~ILinkState() = default;
-    /// Packets currently queued for transmission at this node's interface (those
-    /// a newly-enqueued packet would wait behind). Returns >= 0; negative is
+    /// Packets currently queued for transmission toward `nextHop` (those a
+    /// newly-enqueued packet would wait behind). Returns >= 0; negative is
     /// treated as 0.
-    virtual int macQueueLength() const = 0;
-    /// Smoothed per-packet MAC service time (seconds): a running average of the
-    /// time from a packet reaching the head of the interface queue to a
-    /// successful transmission, including contention/retransmission. Returns
-    /// <= 0 when no sample has been observed yet (the core then uses the
-    /// unloaded reference hop time for that hop).
-    virtual Time macServiceTime() const = 0;
+    virtual int macQueueLength(NodeAddress nextHop) const = 0;
+    /// Smoothed per-packet MAC service time (seconds) toward `nextHop`: a
+    /// running average of the time from a packet reaching the head of the
+    /// interface queue to a successful transmission, including
+    /// contention/retransmission — and excluding propagation, which is real
+    /// delay but not congestion. Returns <= 0 when no sample has been observed
+    /// yet (the core then uses the unloaded reference hop time for that hop).
+    virtual Time macServiceTime(NodeAddress nextHop) const = 0;
 };
 
 /// Optional observer the core notifies of routing events (item 15). It only

--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -472,12 +472,12 @@ NodeAddress AntRouterLogic::randomDestination() {
     return table_.randomDestination(rng_);
 }
 
-void AntRouterLogic::stampForward(AntMessage& ant) const {
+void AntRouterLogic::stampForward(AntMessage& ant, NodeAddress nextHop) const {
     if (ant.visited.size() >= config_.maxPathLength) return;
-    ant.visited.push_back({address_, localHopCost(ant)});
+    ant.visited.push_back({address_, localHopCost(ant, nextHop)});
 }
 
-double AntRouterLogic::localHopCost(const AntMessage& ant) const {
+double AntRouterLogic::localHopCost(const AntMessage& ant, NodeAddress nextHop) const {
     // Congestion-aware per-hop cost (item 10/A2, [1] §3.2): when the MAC metric
     // is enabled and a link-state signal is available, this node contributes its
     // *expected time to send one packet given its current queue* — (Q_mac+1) *
@@ -491,9 +491,9 @@ double AntRouterLogic::localHopCost(const AntMessage& ant) const {
     // implementation time, so it is isolated here and flagged for a maintainer
     // cross-check. Any correction is a one-line change in this function.
     if (config_.enableMacMetric && linkState_) {
-        const double tmac = linkState_->macServiceTime();
+        const double tmac = linkState_->macServiceTime(nextHop);
         if (tmac > 0.0) {
-            const int q = linkState_->macQueueLength();
+            const int q = linkState_->macQueueLength(nextHop);
             return (static_cast<double>(q > 0 ? q : 0) + 1.0) * tmac;
         }
         return config_.hopTimeSec;  // no MAC sample yet: unloaded reference hop
@@ -623,10 +623,19 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
         if (ant.visited.size() >= config_.maxPathLength) {
             return {RouteDecision::drop()};
         }
-        stampForward(ant);
+
+        // The stamp happens where the outgoing interface is known (#206): the
+        // unicast branch stamps with its chosen next hop so the congestion
+        // signal reads the queue the ant will actually wait in; the broadcast
+        // and destination branches have no single outgoing interface and stamp
+        // kInvalidAddress (ILinkState aggregates). A looped-back own ant is
+        // dropped unstamped — its stamp never reached the wire anyway.
 
         if (ant.dst == address_) {
-            // Destination reached: spawn the backward ant and send it home.
+            // Destination reached: stamp our own contribution — the backward
+            // ant's path time includes the destination's load — then spawn it
+            // and send it home.
+            stampForward(ant, kInvalidAddress);
             AntMessage back = createBackAnt(ant);
             NodeAddress next = advanceBackAnt(back);
             if (next == kInvalidAddress) return {RouteDecision::drop()};
@@ -657,6 +666,7 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
                                             config_.reactiveMaxBroadcasts)) {
                 return {RouteDecision::drop()};
             }
+            stampForward(ant, kInvalidAddress);  // flood: every interface at once
             return {broadcastForward(ant)};  // bounded per type (drop at budget 0)
         }
         // A proactive ant with a route is normally unicast, but with a small
@@ -666,8 +676,10 @@ std::vector<RouteDecision> AntRouterLogic::onReceiveAnt(const AntMessage& incomi
         // a routable ant.
         if (proactive && config_.enableProactive && ant.broadcastBudget != 0 &&
             rng_.uniform() < config_.proactiveBroadcastProb) {
+            stampForward(ant, kInvalidAddress);
             return {broadcastForward(ant)};
         }
+        stampForward(ant, next);
         return {sendAnt(RouteAction::Unicast, next, ant)};
     }
 

--- a/core/tests/test_backant_metric.cpp
+++ b/core/tests/test_backant_metric.cpp
@@ -69,9 +69,9 @@ int main() {
         clock.set(0.0);
         AntMessage fwd = router.createForwardAnt(AntType::Reactive, 9);  // visited=[{0,0}]
         clock.set(0.02);
-        router.stampForward(fwd);  // delta 0.02
+        router.stampForward(fwd, kInvalidAddress);  // delta 0.02
         clock.set(0.05);
-        router.stampForward(fwd);  // delta 0.03 (cumulative 0.05 - prior 0.02)
+        router.stampForward(fwd, kInvalidAddress);  // delta 0.03 (cumulative 0.05 - prior 0.02)
         CHECK_EQ(fwd.visited.size(), static_cast<std::size_t>(3));
         CHECK_NEAR(fwd.visited[1].time, 0.02, 1e-9);
         CHECK_NEAR(fwd.visited[2].time, 0.03, 1e-9);

--- a/core/tests/test_mac_metric.cpp
+++ b/core/tests/test_mac_metric.cpp
@@ -15,12 +15,22 @@ using anthocnet::test::ScriptedRng;
 
 namespace {
 
-// Scriptable MAC signals for the node under test.
+// Scriptable MAC signals for the node under test. Records every next hop the
+// core queries so the per-next-hop contract (#206) is pinnable: unicast stamps
+// must name the chosen next hop, broadcast/destination stamps must pass
+// kInvalidAddress (= "no single outgoing interface, aggregate").
 struct FakeLinkState : ILinkState {
     int    q    = 0;
     double tmac = 0.0;
-    int  macQueueLength() const override { return q; }
-    Time macServiceTime() const override { return tmac; }
+    mutable std::vector<NodeAddress> queried;
+    int macQueueLength(NodeAddress nextHop) const override {
+        queried.push_back(nextHop);
+        return q;
+    }
+    Time macServiceTime(NodeAddress nextHop) const override {
+        queried.push_back(nextHop);
+        return tmac;
+    }
 };
 
 // An in-transit forward ant that has just left `src` heading to `dst`.
@@ -48,7 +58,7 @@ int main() {
         AntRouterLogic r(/*addr*/ 1, cfg, clock, rng);
         AntMessage a = inTransit(/*src*/ 0, /*dst*/ 9);
         clock.advance(0.3);
-        r.stampForward(a);
+        r.stampForward(a, /*nextHop*/ 5);
         CHECK_EQ(a.visited.size(), static_cast<std::size_t>(2));
         CHECK_NEAR(a.visited.back().time, 0.3, 1e-9);
     }
@@ -65,7 +75,7 @@ int main() {
         AntRouterLogic r(1, cfg, clock, rng, /*metric*/ nullptr, &ls);
         AntMessage a = inTransit(0, 9);
         clock.advance(5.0);  // large wall-clock: must not leak into the cost
-        r.stampForward(a);
+        r.stampForward(a, /*nextHop*/ 5);
         CHECK_NEAR(a.visited.back().time, (3 + 1) * 0.02, 1e-9);  // 0.08
     }
 
@@ -80,7 +90,7 @@ int main() {
         ls.tmac = 0.02;
         AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
         AntMessage a = inTransit(0, 9);
-        r.stampForward(a);
+        r.stampForward(a, /*nextHop*/ 5);
         CHECK_NEAR(a.visited.back().time, 0.02, 1e-9);
     }
 
@@ -96,7 +106,7 @@ int main() {
         ls.tmac = 0.0;  // no sample observed
         AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
         AntMessage a = inTransit(0, 9);
-        r.stampForward(a);
+        r.stampForward(a, /*nextHop*/ 5);
         CHECK_NEAR(a.visited.back().time, cfg.hopTimeSec, 1e-9);
     }
 
@@ -111,7 +121,7 @@ int main() {
         ls.tmac = 0.02;
         AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
         AntMessage a = inTransit(0, 9);
-        r.stampForward(a);
+        r.stampForward(a, /*nextHop*/ 5);
         CHECK_NEAR(a.visited.back().time, 0.02, 1e-9);  // (0+1)*0.02
     }
 
@@ -130,7 +140,7 @@ int main() {
             ls.tmac = tmac;
             AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
             AntMessage a = inTransit(0, 9);
-            r.stampForward(a);
+            r.stampForward(a, /*nextHop*/ 5);
             double t = 0.0;
             for (const AntHop& h : a.visited) t += h.time;
             return t;
@@ -149,6 +159,73 @@ int main() {
         oBusy.hopTime = cfg.hopTimeSec;
         oBusy.pathTime = busy;
         CHECK(m.pheromone(oBusy) < m.pheromone(oIdle));
+    }
+
+    // 7. Per-next-hop contract through the real receive path (#206): the stamp
+    //    happens where the outgoing interface is known, so the congestion
+    //    signal is read for the queue the ant will actually wait in.
+    {
+        Config cfg;
+        cfg.enableMacMetric = true;
+
+        // 7a. Unicast: a routed forward ant stamps with its chosen next hop.
+        {
+            FakeClock clock;
+            ScriptedRng rng({0.99});  // stay on the unicast branch (no proactive broadcast)
+            FakeLinkState ls;
+            ls.q = 2;
+            ls.tmac = 0.02;
+            AntRouterLogic r(/*addr*/ 1, cfg, clock, rng, nullptr, &ls);
+            r.table().setPheromoneRegular(/*dest*/ 9, /*neighbor*/ 5, 0.9);
+            AntMessage a = inTransit(/*src*/ 3, /*dst*/ 9);
+            auto decisions = r.onReceiveAnt(a, /*prevHop*/ 3);
+            CHECK_EQ(decisions.size(), static_cast<std::size_t>(1));
+            CHECK(decisions[0].action == RouteAction::Unicast);
+            CHECK_EQ(decisions[0].nextHop, 5);
+            CHECK(!ls.queried.empty());
+            for (NodeAddress qh : ls.queried) CHECK_EQ(qh, 5);
+            CHECK_NEAR(decisions[0].message.visited.back().time, (2 + 1) * 0.02, 1e-9);
+        }
+
+        // 7b. Broadcast (no route): no single outgoing interface — the stamp
+        //     queries kInvalidAddress, the aggregate-across-interfaces contract.
+        {
+            FakeClock clock;
+            ScriptedRng rng({0.99});
+            FakeLinkState ls;
+            ls.q = 2;
+            ls.tmac = 0.02;
+            AntRouterLogic r(1, cfg, clock, rng, nullptr, &ls);
+            AntMessage a = inTransit(3, 9);  // no pheromone for 9 anywhere
+            auto decisions = r.onReceiveAnt(a, 3);
+            CHECK_EQ(decisions.size(), static_cast<std::size_t>(1));
+            CHECK(decisions[0].action == RouteAction::Broadcast);
+            CHECK(!ls.queried.empty());
+            for (NodeAddress qh : ls.queried) CHECK_EQ(qh, kInvalidAddress);
+        }
+
+        // 7c. Destination: the terminal node still contributes its own cost to
+        //     the backward ant's path time (aggregate — it forwards nowhere).
+        {
+            FakeClock clock;
+            ScriptedRng rng({0.99});
+            FakeLinkState ls;
+            ls.q = 2;
+            ls.tmac = 0.02;
+            AntRouterLogic r(/*addr*/ 9, cfg, clock, rng, nullptr, &ls);
+            AntMessage a = inTransit(3, /*dst*/ 9);
+            a.visited = {{3, 0.0}, {4, 0.01}};
+            auto decisions = r.onReceiveAnt(a, /*prevHop*/ 4);
+            CHECK_EQ(decisions.size(), static_cast<std::size_t>(1));
+            CHECK(decisions[0].action == RouteAction::Unicast);  // backward ant home
+            CHECK(!ls.queried.empty());
+            for (NodeAddress qh : ls.queried) CHECK_EQ(qh, kInvalidAddress);
+            // The destination's own stamp is on the retraced path: after
+            // advanceBackAnt moved node 9 onto history, its cost is there.
+            CHECK_EQ(decisions[0].message.history.size(), static_cast<std::size_t>(1));
+            CHECK_EQ(decisions[0].message.history.back().node, 9);
+            CHECK_NEAR(decisions[0].message.history.back().time, (2 + 1) * 0.02, 1e-9);
+        }
     }
 
     return RUN_TESTS();

--- a/ns2/src/ahn_router.cc
+++ b/ns2/src/ahn_router.cc
@@ -165,14 +165,16 @@ int AntHocNetAgent::command(int argc, const char* const* argv) {
 
 // --- item 10/A2: MAC congestion signals (core::ILinkState) ------------------
 
-int AntHocNetAgent::macQueueLength() const {
+int AntHocNetAgent::macQueueLength(anthocnet::core::NodeAddress /*nextHop*/) const {
     // Packets backlogged in the interface queue between LL and MAC — those a
     // newly-forwarded packet would wait behind. Without the "if-queue" handle
     // the backlog reads 0, so the metric degrades to the unloaded hop time.
+    // One interface queue per mobilenode: the per-next-hop parameter (#206)
+    // is ignored.
     return ifqueue_ ? ifqueue_->length() : 0;
 }
 
-anthocnet::core::Time AntHocNetAgent::macServiceTime() const {
+anthocnet::core::Time AntHocNetAgent::macServiceTime(anthocnet::core::NodeAddress /*nextHop*/) const {
     // Nominal per-packet MAC service time, matching the NS-3 adapter's current
     // pass: the congestion signal is the *measured queue occupancy*
     // (macQueueLength), so per-hop cost = (Q+1)*hopTime. A measured tx-time

--- a/ns2/src/ahn_router.h
+++ b/ns2/src/ahn_router.h
@@ -77,9 +77,11 @@ public:
 
     void linkFailed(Packet* p);
 
-    // core::ILinkState (item 10/A2)
-    int macQueueLength() const override;
-    anthocnet::core::Time macServiceTime() const override;
+    // core::ILinkState (item 10/A2). NS-2's mobilenode has one interface
+    // queue, so this is the degenerate single-interface case and the
+    // per-next-hop parameter (#206) is ignored.
+    int macQueueLength(anthocnet::core::NodeAddress nextHop) const override;
+    anthocnet::core::Time macServiceTime(anthocnet::core::NodeAddress nextHop) const override;
 
 protected:
     // packet paths

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -354,11 +354,13 @@ void RoutingProtocol::onRouteChanged(::anthocnet::core::NodeAddress dest,
 
 // --- item 10/A2: MAC congestion signals (core::ILinkState) ------------------
 
-int RoutingProtocol::macQueueLength() const {
+int RoutingProtocol::macQueueLength(NodeAddress /*nextHop*/) const {
     // Packets currently backlogged at the wifi MAC across all access categories
     // — the queue a newly-forwarded packet would wait behind. Summed over the
     // per-AC txop queues (unified since ns-3.36, the CI-matrix floor). Returns 0
     // on non-wifi devices, so the metric degrades to the unloaded hop time.
+    // Single radio: every next hop shares this one MAC queue, so the
+    // per-next-hop parameter (#206) is ignored here.
     if (!m_wifiMac) return 0;
     uint32_t total = 0;
     // AC_BE_NQOS is essential: a non-QoS mac (AdhocWifiMac, the MANET default)
@@ -372,7 +374,7 @@ int RoutingProtocol::macQueueLength() const {
     return static_cast<int>(total);
 }
 
-::anthocnet::core::Time RoutingProtocol::macServiceTime() const {
+::anthocnet::core::Time RoutingProtocol::macServiceTime(NodeAddress /*nextHop*/) const {
     // Measured per-packet MAC service time (issue #68): EWMA of inter-ack
     // spacing sampled while the MAC queue stayed backlogged, so contention and
     // retransmissions are included but queue wait is not — (Q+1)*T̂_mac must
@@ -397,7 +399,7 @@ void RoutingProtocol::NotifyAckedMpdu(Ptr<const AHN_WIFI_MPDU>) {
         }
     }
     m_lastAckTime = now;
-    m_backlogAtLastAck = macQueueLength() > 0;
+    m_backlogAtLastAck = macQueueLength(kInvalidAddress) > 0;
 }
 
 // --- lifecycle --------------------------------------------------------------

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -82,9 +82,12 @@ public:
 
     // core::ILinkState (item 10/A2): supply MAC congestion signals for the
     // congestion-aware per-hop metric. Only meaningful when EnableMacMetric is
-    // set; the core queries these while stamping a forward ant.
-    int macQueueLength() const override;
-    ::anthocnet::core::Time macServiceTime() const override;
+    // set; the core queries these while stamping a forward ant, naming the
+    // next hop the cost is for (#206). This wifi implementation is the
+    // degenerate single-interface case — one radio, one MAC, one queue — so
+    // the parameter is ignored and per-next-hop collapses to per-node.
+    int macQueueLength(::anthocnet::core::NodeAddress nextHop) const override;
+    ::anthocnet::core::Time macServiceTime(::anthocnet::core::NodeAddress nextHop) const override;
 
     // Ipv4RoutingProtocol
     Ptr<Ipv4Route> RouteOutput(Ptr<Packet> p, const Ipv4Header& header,


### PR DESCRIPTION
Step 1 of the #206 plan (owner decision 2026-07-31: general `ILinkState` abstraction, regime-selected at build/configuration; control-flow **option C** from the recorded blocker analysis). Behaviour on wifi and NS-2 is **byte-identical**; this PR makes the seam *correct* so the p2p/ISL implementation (step 2, next PR) has something true to implement.

## Interface (`ports.h`)

`ILinkState::macQueueLength` and `::macServiceTime` now take the `NodeAddress` next hop the cost is being computed **for**. Contract, written into the port: `nextHop == kInvalidAddress` means the caller has no single outgoing interface — the ant is being broadcast on every interface, or this node is the path's terminal — and the adapter should aggregate across interfaces. Single-interface adapters may ignore the parameter (per-next-hop degenerates to per-node for free).

Why per-next-hop, not per-node: the A2 metric exists to choose *between* next hops. On a satellite with one queue per ISL, a node-wide signal raises the cost of every candidate equally and steers identically to no metric at all — silently.

`macServiceTime` takes the hop too: heterogeneous links have per-link serialisation times, and the contract now states **propagation is excluded** — real delay, but not congestion (an ISL's 3–18 ms would otherwise swamp the signal's dynamic range).

## Control flow (`ant_router_logic.cpp`)

The A2 cost used to be stamped *before* next-hop selection — at the moment of sampling there was nothing to sample for (the blocker recorded on the issue). The stamp moves to the branches where the outgoing interface is known:

| branch | stamp |
|---|---|
| unicast | `stampForward(ant, next)` — reads the queue the ant will actually wait in |
| broadcast (flood / proactive exploration) | `stampForward(ant, kInvalidAddress)` — the ant genuinely goes out every interface |
| destination | `stampForward(ant, kInvalidAddress)` — keeps the terminal node's own contribution in the backward ant's path time |
| looped-back own ant | dropped unstamped (its stamp never reached the wire before either) |

**Wire-identical in every case**: no serialized bytes change, and the wall-clock fallback cost is computed at the same sim time (the move is within one synchronous call). No `kWireVersion` bump.

## Adapters

- **ns-3**: wifi impl ignores the parameter (one radio, one MAC queue — documented as the degenerate case); `NotifyAckedMpdu`'s backlog probe passes `kInvalidAddress`.
- **NS-2**: same — one interface queue per mobilenode.

## Tests

- `test_mac_metric.cpp`: `FakeLinkState` records every queried next hop; new case 7 pins the contract through the real receive path — 7a unicast stamps with the chosen hop (and the `(Q+1)·T̂` cost lands in `visited`), 7b broadcast queries `kInvalidAddress`, 7c the destination stamps aggregate and its cost rides the backward ant's `history`.
- `test_backant_metric.cpp`: call sites updated (wall-clock fallback, hop-agnostic).

## Verification

- core `make test`: **25/25** (invariant checker: rule 1 PASS, core-test rule PASS; docs WARN acknowledged — the ADR/docs update recording the regime-selection decision lands with step 3 per the plan on the issue).

Refs #206 (steps 2–3 follow in the next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_