### PR TITLE
feat(ns3): per-interface transmit-queue congestion reader for the p2p/ISL regime + ADR-0017 (#206)

### DIFF
--- a/docs/adr/0017-linkstate-is-per-next-hop-and-regime-selected.md
+++ b/docs/adr/0017-linkstate-is-per-next-hop-and-regime-selected.md
@@ -1,0 +1,114 @@
+# ADR-0017: The congestion signal is per-next-hop, and its implementation is selected by what the build instantiates
+
+- **Status:** Accepted — owner decision recorded on
+  [#206](https://github.com/danieljoppi/AntHocNet/issues/206) (2026-07-31);
+  shipped by the #206 step-1/step-2 PRs
+- **Date:** 2026-08-01
+
+## Context
+
+The item-10/A2 congestion-aware metric ([1] §3.2, #55/#67) makes a forward ant
+record each node's expected send time from queue occupancy, so path cost
+reflects sustained load. The NS-3 adapter sourced that signal exclusively from
+the wifi MAC (`if (!m_wifiMac) return 0;`): on any other device the signal was
+0 and `EnableMacMetric` silently inert.
+
+That mattered because the satellite track's defensible research claim is
+**congestion adaptivity** — LEO topology is deterministic and precomputable,
+congestion is not (#202's prior-art survey found the whole ACO-on-LEO field
+converged on exactly this framing). An ISL is a `PointToPointNetDevice`; a
+congestion metric that returns 0 on every ISL removes the mechanism the claim
+rests on, and made #216's "congestion the precomputed control cannot see" cell
+meaningless rather than negative.
+
+Two design questions had to be settled before generalising the source:
+
+1. **Per-interface vs per-node.** `m_wifiMac` is one MAC; a satellite has one
+   queue per ISL, and the A2 metric exists to choose *between* next hops. A
+   node-wide signal raises the cost of every candidate equally — on a
+   four-ISL satellite it steers identically to no metric at all, silently.
+2. **Where to sample.** The A2 cost was stamped into the ant *before*
+   next-hop selection: at the moment of sampling there was nothing to sample
+   for. Invisible on wifi (one queue), fatal on multi-interface nodes.
+
+## Decision
+
+1. **`ILinkState` queries name the next hop.** `macQueueLength(nextHop)` /
+   `macServiceTime(nextHop)`, with the contract in `ports.h`:
+   `nextHop == kInvalidAddress` means "no single outgoing interface —
+   aggregate across interfaces". Wifi is the degenerate case (one radio, one
+   queue) and ignores the parameter, byte-identical to before.
+2. **The stamp moves to where the interface is known** (option C on #206):
+   the unicast branch stamps with its chosen next hop; broadcast and
+   destination branches stamp `kInvalidAddress` — a flooding ant genuinely
+   goes out every interface, so its cost genuinely is node-wide, and the
+   terminal node keeps its own contribution in the backward ant's path time.
+3. **Units: congestion is queue depth × service time, propagation excluded.**
+   An ISL's 3–18 ms propagation is real delay (the wall-clock transit path
+   already prices it) but it is constant and load-independent; folding it into
+   `T̂` would swamp the signal's dynamic range and produce a metric that
+   measures distance — which the deterministic control already optimises. The
+   non-wifi service time is therefore sampled as **inter-dequeue spacing while
+   the transmit queue stays backlogged** (the transmitter-side analogue of the
+   wifi inter-ack EWMA, #68), which excludes propagation by construction — the
+   sender never waits for it.
+4. **One core, regime-selected readers — chosen by what the build
+   instantiates.** The core consumes `ILinkState` and never learns what a
+   device is (golden rule 1). The adapter carries two readers: the wifi MAC
+   reader (MANET regime) and the per-device transmit-queue reader (p2p/ISL
+   regime, via the generic `TxQueue` attribute that `PointToPointNetDevice`,
+   `CsmaNetDevice` and `SimpleNetDevice` all expose — no device-specific
+   module dependency). Which reader a node uses is decided by the devices its
+   build's scenario instantiated: wifi devices select the MAC reader, queue-
+   bearing devices select the queue reader; wifi is preferred where both
+   exist. This is the owner's stated architecture — *the networking-type
+   decision is relayed in the configuration build; the protocol implementation
+   shares the same algorithm, but the MANET and satellite build compilations
+   differ* — and it extends [ADR-0015](0015-satellite-substrate-lives-in-the-image.md)'s
+   axis (one protocol build, regime-specific images/substrates) to the
+   congestion signal. It is **not** a runtime protocol switch and not a second
+   core.
+
+## Alternatives considered
+
+- **Per-node signal, generalised source only.** Non-functional on
+  multi-interface nodes, not merely imprecise — see Context. Worse, it *looks*
+  fixed: it changes the signature, passes CI, and leaves the ISL case
+  measuring the wrong thing. Rejected on #206 ("option B").
+- **Keep stamp-before-selection, aggregate always.** Same failure with less
+  code churn. Rejected for the same reason.
+- **A runtime attribute selecting the reader.** Adds a knob whose correct
+  value is always derivable from the device type; a wrong setting silently
+  zeroes the signal — the exact failure class #206 fixes. Rejected.
+- **Deriving p2p service time from the `DataRate` attribute.** Deterministic
+  and propagation-free, but wrong for heterogeneous packet sizes (ants are
+  ~64 B, data ~1000 B) and unavailable on devices without the attribute; the
+  measured EWMA handles both and mirrors the shipped wifi design. Rejected as
+  the primary source (it remains a sanity cross-check in review).
+
+## Consequences
+
+- `EnableMacMetric` now produces a real, per-next-hop signal on p2p/ISL and
+  `SimpleNetDevice` topologies; the #216 congestion cell (asymmetric load over
+  equal-length paths) is unblocked and is the acceptance measurement for the
+  satellite claim.
+- Core control flow changed on the forward-ant hot path (stamp after
+  selection). Pinned by core tests (per-next-hop unicast stamp, aggregate
+  broadcast/destination stamps, destination's own contribution) and an ns-3
+  suite case asserting the signal *discriminates* between a loaded and an idle
+  next hop on a multi-interface relay.
+- Wire format untouched; no `kWireVersion` bump (stamps are computed at the
+  same simulation time as before — costs are byte-identical on wifi).
+- The NS-2 adapter keeps its single interface queue (degenerate case, #69
+  remains the sibling gap for a measured NS-2 service time).
+- `m_txQueues` cleanup rides `NotifyInterfaceDown`, so a dead ISL's residual
+  backlog cannot inflate the aggregate signal (#260's fast path already fires
+  there).
+
+## References
+
+[#206](https://github.com/danieljoppi/AntHocNet/issues/206) (decisions and
+blocker analysis), #194/#202/#216 (the satellite claim this enables), #55/#67/#68
+(A2 metric as shipped), #260 (interface-down fast path), ADR-0015 (the
+one-build-per-regime axis this extends), `core/include/anthocnet/core/ports.h`,
+`ns3/model/anthocnet-routing-protocol.cc`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,6 +241,16 @@ against — the thesis audit confirmed it has no evaporation term at all (§3.1,
 per-hop cost to the paper's congestion-aware A2 formula; it is off by default
 purely because no benchmark has yet justified flipping it.
 
+Where the A2 signal comes from is **regime-selected by the devices the build
+instantiates** (ADR-0017, #206): wifi devices feed it from the MAC queue +
+inter-ack service EWMA (the MANET benchmark build), point-to-point/ISL and
+other queue-bearing devices from the per-interface transmit queue +
+inter-dequeue EWMA (the satellite build). The signal is per-next-hop — on a
+multi-interface satellite each ISL reports its own backlog — and propagation
+is deliberately excluded from the service time: an ISL's constant 3–18 ms is
+distance, not congestion. There is no knob to select the reader; the device
+type decides, wifi preferred where both exist.
+
 ### Reactive setup — `reactiveMaxBroadcasts`, `enableMultipath`, `antAcceptanceFactor`, `reactiveRetryInterval`, `maxPathLength`
 
 How routes are discovered. `reactiveMaxBroadcasts` bounds how often **one

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -5,6 +5,7 @@
 #include "ns3/node.h"
 #include "ns3/boolean.h"
 #include "ns3/double.h"
+#include "ns3/pointer.h"
 #include "ns3/uinteger.h"
 #include "ns3/inet-socket-address.h"
 #include "ns3/udp-socket-factory.h"
@@ -354,33 +355,106 @@ void RoutingProtocol::onRouteChanged(::anthocnet::core::NodeAddress dest,
 
 // --- item 10/A2: MAC congestion signals (core::ILinkState) ------------------
 
-int RoutingProtocol::macQueueLength(NodeAddress /*nextHop*/) const {
-    // Packets currently backlogged at the wifi MAC across all access categories
-    // — the queue a newly-forwarded packet would wait behind. Summed over the
-    // per-AC txop queues (unified since ns-3.36, the CI-matrix floor). Returns 0
-    // on non-wifi devices, so the metric degrades to the unloaded hop time.
-    // Single radio: every next hop shares this one MAC queue, so the
-    // per-next-hop parameter (#206) is ignored here.
-    if (!m_wifiMac) return 0;
-    uint32_t total = 0;
-    // AC_BE_NQOS is essential: a non-QoS mac (AdhocWifiMac, the MANET default)
-    // keeps its single DCF queue under AC_BE_NQOS, not AC_BE — without it
-    // GetTxopQueue returns nullptr and the backlog always reads 0, so the whole
-    // A2 signal was silently absent (issue #73).
-    for (AcIndex ac : {AC_BE_NQOS, AC_BE, AC_BK, AC_VI, AC_VO}) {
-        Ptr<WifiMacQueue> q = m_wifiMac->GetTxopQueue(ac);
-        if (q) total += q->GetNPackets();
+int RoutingProtocol::macQueueLength(NodeAddress nextHop) const {
+    // Wifi regime: packets backlogged at the wifi MAC across all access
+    // categories — the queue a newly-forwarded packet would wait behind.
+    // Summed over the per-AC txop queues (unified since ns-3.36, the CI-matrix
+    // floor). Single radio: every next hop shares this one MAC queue, so the
+    // per-next-hop parameter (#206) is ignored — and preferred where it
+    // exists, keeping pre-#206 wifi behaviour byte-identical.
+    if (m_wifiMac) {
+        uint32_t total = 0;
+        // AC_BE_NQOS is essential: a non-QoS mac (AdhocWifiMac, the MANET
+        // default) keeps its single DCF queue under AC_BE_NQOS, not AC_BE —
+        // without it GetTxopQueue returns nullptr and the backlog always reads
+        // 0, so the whole A2 signal was silently absent (issue #73).
+        for (AcIndex ac : {AC_BE_NQOS, AC_BE, AC_BK, AC_VI, AC_VO}) {
+            Ptr<WifiMacQueue> q = m_wifiMac->GetTxopQueue(ac);
+            if (q) total += q->GetNPackets();
+        }
+        return static_cast<int>(total);
     }
-    return static_cast<int>(total);
+    // p2p/ISL regime (#206): the backlog lives in the per-interface device
+    // transmit queue. A named next hop reads the one queue the packet would
+    // wait in; kInvalidAddress means no single outgoing interface (broadcast,
+    // or the path's terminal) — aggregate across them, per the ILinkState
+    // contract.
+    if (m_txQueues.empty()) return 0;
+    if (nextHop == kInvalidAddress) {
+        uint32_t total = 0;
+        for (const auto& kv : m_txQueues) {
+            if (kv.second.queue) total += kv.second.queue->GetNPackets();
+        }
+        return static_cast<int>(total);
+    }
+    if (m_socketAddresses.empty()) return 0;  // ResolveNextHop needs an iface
+    Ipv4Address gateway;
+    Ptr<NetDevice> dev;
+    uint32_t iface = 0;
+    ResolveNextHop(nextHop, gateway, dev, iface);
+    const auto it = m_txQueues.find(iface);
+    if (it == m_txQueues.end() || !it->second.queue) return 0;
+    return static_cast<int>(it->second.queue->GetNPackets());
 }
 
-::anthocnet::core::Time RoutingProtocol::macServiceTime(NodeAddress /*nextHop*/) const {
-    // Measured per-packet MAC service time (issue #68): EWMA of inter-ack
-    // spacing sampled while the MAC queue stayed backlogged, so contention and
-    // retransmissions are included but queue wait is not — (Q+1)*T̂_mac must
-    // not double-count the queue. 0 until the first sample; the core then
-    // falls back to the unloaded reference hop time (ILinkState contract).
-    return m_macServiceEwmaSec;
+::anthocnet::core::Time RoutingProtocol::macServiceTime(NodeAddress nextHop) const {
+    // Wifi regime (issue #68): EWMA of inter-ack spacing sampled while the MAC
+    // queue stayed backlogged, so contention and retransmissions are included
+    // but queue wait is not — (Q+1)*T̂_mac must not double-count the queue.
+    // 0 until the first sample; the core then falls back to the unloaded
+    // reference hop time (ILinkState contract).
+    if (m_wifiMac || m_txQueues.empty()) return m_macServiceEwmaSec;
+    // p2p/ISL regime (#206): per-interface inter-dequeue EWMA — serialisation
+    // only, never propagation (an ISL's 3-18 ms is real delay but not
+    // congestion; folding it in would swamp the signal's dynamic range).
+    if (nextHop != kInvalidAddress) {
+        if (m_socketAddresses.empty()) return 0.0;
+        Ipv4Address gateway;
+        Ptr<NetDevice> dev;
+        uint32_t iface = 0;
+        ResolveNextHop(nextHop, gateway, dev, iface);
+        const auto it = m_txQueues.find(iface);
+        return it != m_txQueues.end() ? it->second.ewmaSec : 0.0;
+    }
+    // Aggregate (broadcast / terminal): mean of the sampled interfaces, 0 (=
+    // fall back to the unloaded reference) when none has a sample yet.
+    double sum = 0.0;
+    int n = 0;
+    for (const auto& kv : m_txQueues) {
+        if (kv.second.ewmaSec > 0.0) {
+            sum += kv.second.ewmaSec;
+            ++n;
+        }
+    }
+    return n > 0 ? sum / n : 0.0;
+}
+
+void RoutingProtocol::TxDequeueTrace(RoutingProtocol* self, uint32_t interface,
+                                     Ptr<const Packet> p) {
+    self->NotifyTxDequeue(interface, p);
+}
+
+void RoutingProtocol::NotifyTxDequeue(uint32_t interface, Ptr<const Packet>) {
+    // A valid pure-service sample is the spacing between two consecutive
+    // dequeues during which the queue never emptied — the device pulls the
+    // next packet the moment the previous one finishes serialising, so that
+    // spacing IS the per-packet service time (and never includes propagation:
+    // the sender does not wait for it). Mirrors NotifyAckedMpdu.
+    auto it = m_txQueues.find(interface);
+    if (it == m_txQueues.end()) return;
+    TxQueueState& st = it->second;
+    const Time now = Simulator::Now();
+    if (st.backlogAtLastDequeue && st.lastDequeue.IsStrictlyPositive()) {
+        const double sample = (now - st.lastDequeue).GetSeconds();
+        if (sample > 0.0) {
+            st.ewmaSec = st.ewmaSec > 0.0
+                             ? m_macServiceAlpha * st.ewmaSec +
+                                   (1.0 - m_macServiceAlpha) * sample
+                             : sample;
+        }
+    }
+    st.lastDequeue = now;
+    st.backlogAtLastDequeue = st.queue && st.queue->GetNPackets() > 0;
 }
 
 void RoutingProtocol::NotifyAckedMpdu(Ptr<const AHN_WIFI_MPDU>) {
@@ -558,6 +632,27 @@ void RoutingProtocol::NotifyInterfaceUp(uint32_t interface) {
         }
     }
 
+    // #206 step 2: non-wifi devices (the p2p/ISL regime) carry their backlog
+    // in the per-device transmit queue instead. Grab it through the generic
+    // "TxQueue" attribute — PointToPointNetDevice, CsmaNetDevice and
+    // SimpleNetDevice all expose one, so no device-specific module dependency
+    // — and sample the service time from its "Dequeue" trace. Which regime a
+    // node runs is decided by what the build's scenario instantiated: wifi
+    // devices select the MAC reader above, queue-bearing devices select this
+    // one. A device with neither (loopback) contributes no signal.
+    if (!wifi && dev) {
+        PointerValue txq;
+        if (dev->GetAttributeFailSafe("TxQueue", txq)) {
+            Ptr<Queue<Packet>> q = txq.Get<Queue<Packet>>();
+            if (q) {
+                m_txQueues[interface].queue = q;
+                q->TraceConnectWithoutContext(
+                    "Dequeue",
+                    MakeBoundCallback(&RoutingProtocol::TxDequeueTrace, this, interface));
+            }
+        }
+    }
+
     Start();
 }
 
@@ -575,6 +670,10 @@ void RoutingProtocol::NotifyInterfaceDown(uint32_t interface) {
             break;
         }
     }
+
+    // #206: stop reading a dead ISL's transmit queue — its residual backlog
+    // must not keep inflating the aggregate congestion signal.
+    m_txQueues.erase(interface);
 
     // ADR-0008 detector-D equivalent for non-wifi links (#260). A scripted ISL
     // break (Ipv4::SetDown, the stock ns-3 way to cut a point-to-point link)

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -16,6 +16,7 @@
 #include "ns3/timer.h"
 #include "ns3/traced-callback.h"
 #include "ns3/mac48-address.h"
+#include "ns3/queue.h"
 #include "ns3/wifi-mac.h"
 
 // ns-3 renamed WifiMacQueueItem -> WifiMpdu (and wifi-mac-queue-item.h ->
@@ -322,8 +323,27 @@ private:
     bool m_enableMacMetric;  ///< item 10/A2 congestion-aware per-hop metric
 
     // WifiMac handle for the item-10/A2 queue-occupancy signal (null on non-wifi
-    // devices, where the metric falls back to the unloaded reference hop time).
+    // devices, where the p2p/ISL transmit-queue reader below takes over, #206).
     Ptr<WifiMac> m_wifiMac;
+
+    // #206 step 2: per-interface transmit-queue congestion for non-wifi
+    // devices — the p2p/ISL regime, where each interface is one ISL with its
+    // own queue and the useful signal is per-next-hop. `queue` is the device's
+    // "TxQueue" (PointToPointNetDevice, CsmaNetDevice and SimpleNetDevice all
+    // expose the attribute); the EWMA samples inter-dequeue spacing while the
+    // queue stays backlogged — the transmitter-side analogue of the wifi
+    // inter-ack EWMA (#68), which excludes propagation by construction (the
+    // sender never waits for it). Smoothing shares MacServiceAlpha.
+    struct TxQueueState {
+        Ptr<Queue<Packet>> queue;
+        double ewmaSec = 0.0;             ///< 0 = no sample yet (core falls back)
+        Time   lastDequeue;               ///< previous Dequeue timestamp
+        bool   backlogAtLastDequeue = false;
+    };
+    std::map<uint32_t, TxQueueState> m_txQueues;  ///< iface index -> queue state
+    void NotifyTxDequeue(uint32_t interface, Ptr<const Packet> p);
+    static void TxDequeueTrace(RoutingProtocol* self, uint32_t interface,
+                               Ptr<const Packet> p);
 
     // L3 forwarding callbacks cached from RouteInput (Ipv4L3Protocol passes the
     // same bound callbacks on every call). NotifyTxError needs them to re-inject

--- a/ns3/test/anthocnet-test-suite.cc
+++ b/ns3/test/anthocnet-test-suite.cc
@@ -30,6 +30,7 @@
 #include "ns3/position-allocator.h"
 #include "ns3/vector.h"
 #include "ns3/double.h"
+#include "ns3/data-rate.h"
 #include "ns3/ipv4.h"
 
 #include "ns3/anthocnet-packet.h"
@@ -227,6 +228,127 @@ private:
     uint32_t m_rxBytes;
 };
 
+// #206 — the per-next-hop congestion signal on non-wifi devices.
+//
+// The same multi-interface relay shape as the #203 test (one SimpleNetDevice
+// per link, so node 1 has one transmit queue per neighbour), with the relay's
+// egress toward node 2 slowed to 32 kb/s so a data burst backlogs that queue
+// while the queue toward node 0 stays idle. The ILinkState surface must then
+// DISCRIMINATE: a positive backlog and a sampled service time toward the
+// loaded next hop, (near-)nothing toward the idle one, and an aggregate at
+// least as large as any single queue. A node-wide signal cannot pass this —
+// it would read the same value for both hops, which is exactly the silent
+// failure #206 exists to prevent.
+class PerHopCongestionSignalTestCase : public TestCase
+{
+public:
+    PerHopCongestionSignalTestCase()
+        : TestCase("Per-next-hop congestion signal on non-wifi devices (#206)"),
+          m_qLoaded(0), m_qIdle(0), m_qAggregate(0), m_tLoaded(0.0), m_tIdle(0.0) {}
+
+    void DoRun() override {
+        using ns3::anthocnet::RoutingProtocol;
+        RngSeedManager::SetSeed(1);
+        RngSeedManager::SetRun(1);
+
+        NodeContainer nodes;
+        nodes.Create(3);
+
+        NodeContainer leftPair(nodes.Get(0), nodes.Get(1));
+        NodeContainer rightPair(nodes.Get(1), nodes.Get(2));
+        SimpleNetDeviceHelper devHelper;
+        NetDeviceContainer leftDevs = devHelper.Install(leftPair, CreateObject<SimpleChannel>());
+        NetDeviceContainer rightDevs = devHelper.Install(rightPair, CreateObject<SimpleChannel>());
+
+        // Slow the relay's egress toward node 2. The left link keeps the
+        // default infinite rate, so its queue drains instantly and stays idle.
+        Ptr<SimpleNetDevice> relayRight = DynamicCast<SimpleNetDevice>(rightDevs.Get(0));
+        relayRight->SetAttribute("DataRate", DataRateValue(DataRate("32kbps")));
+
+        AntHocNetHelper anthocnet;
+        InternetStackHelper internet;
+        internet.SetRoutingHelper(anthocnet);
+        internet.Install(nodes);
+
+        Ipv4AddressHelper address;
+        address.SetBase("10.1.1.0", "255.255.255.0");
+        Ipv4InterfaceContainer leftIfs = address.Assign(leftDevs);
+        address.SetBase("10.1.2.0", "255.255.255.0");
+        Ipv4InterfaceContainer rightIfs = address.Assign(rightDevs);
+
+        const uint16_t port = 9;
+        Ptr<Socket> rx = Socket::CreateSocket(nodes.Get(2), UdpSocketFactory::GetTypeId());
+        rx->Bind(InetSocketAddress(Ipv4Address::GetAny(), port));
+        rx->SetRecvCallback(MakeCallback(&PerHopCongestionSignalTestCase::Drain, this));
+
+        // A sustained 1000-byte burst from node 0: at 32 kb/s the relay drains
+        // ~4 pkt/s, so sending 40/s from t=10 guarantees a deep backlog toward
+        // node 2 at the probe time.
+        Ptr<Socket> tx = Socket::CreateSocket(nodes.Get(0), UdpSocketFactory::GetTypeId());
+        tx->Connect(InetSocketAddress(rightIfs.GetAddress(1), port));
+        for (double t = 10.0; t < 14.0; t += 0.025) {
+            Simulator::Schedule(Seconds(t), &PerHopCongestionSignalTestCase::Send, this, tx);
+        }
+
+        Simulator::Schedule(Seconds(13.0), &PerHopCongestionSignalTestCase::Probe, this,
+                            nodes.Get(1),
+                            RoutingProtocol::ToCore(rightIfs.GetAddress(1)),
+                            RoutingProtocol::ToCore(leftIfs.GetAddress(0)));
+
+        Simulator::Stop(Seconds(15.0));
+        Simulator::Run();
+        Simulator::Destroy();
+
+        NS_TEST_ASSERT_MSG_GT(m_qLoaded, 0,
+                              "no backlog read toward the loaded next hop");
+        // The instant-drain queue can momentarily hold the packet being
+        // serialised within a timestep; anything beyond that is a real backlog
+        // and breaks the discrimination this test pins.
+        NS_TEST_ASSERT_MSG_LT(m_qIdle, 2,
+                              "backlog read toward the idle next hop");
+        NS_TEST_ASSERT_MSG_GT(m_qLoaded, m_qIdle,
+                              "signal does not discriminate between next hops");
+        NS_TEST_ASSERT_MSG_GT_OR_EQ(m_qAggregate, m_qLoaded,
+                                    "aggregate smaller than a single queue");
+        // Service time toward the loaded hop: sampled (positive) and at the
+        // serialisation scale — 1000 B at 32 kb/s is 0.25 s; ants are smaller.
+        // A value near an ISL's propagation delay would mean the decomposition
+        // folded propagation in, which it must not.
+        NS_TEST_ASSERT_MSG_GT(m_tLoaded, 0.0,
+                              "no service-time sample toward the loaded next hop");
+        NS_TEST_ASSERT_MSG_LT(m_tLoaded, 1.0,
+                              "service time off the serialisation scale");
+        NS_TEST_ASSERT_MSG_EQ(m_tIdle, 0.0,
+                              "service-time sample on the never-backlogged link");
+    }
+
+private:
+    void Send(Ptr<Socket> s) { s->Send(Create<Packet>(1000)); }
+    void Drain(Ptr<Socket> s) {
+        Ptr<Packet> p;
+        while ((p = s->Recv())) {
+        }
+    }
+    void Probe(Ptr<Node> relay, ::anthocnet::core::NodeAddress towardLoaded,
+               ::anthocnet::core::NodeAddress towardIdle) {
+        Ptr<ns3::anthocnet::RoutingProtocol> rp =
+            relay->GetObject<ns3::anthocnet::RoutingProtocol>();
+        NS_TEST_ASSERT_MSG_EQ((rp != nullptr), true, "relay has no AntHocNet protocol");
+        if (!rp) return;
+        m_qLoaded    = rp->macQueueLength(towardLoaded);
+        m_qIdle      = rp->macQueueLength(towardIdle);
+        m_qAggregate = rp->macQueueLength(::anthocnet::core::kInvalidAddress);
+        m_tLoaded    = rp->macServiceTime(towardLoaded);
+        m_tIdle      = rp->macServiceTime(towardIdle);
+    }
+
+    int m_qLoaded;
+    int m_qIdle;
+    int m_qAggregate;
+    double m_tLoaded;
+    double m_tIdle;
+};
+
 // B3 — address mapping never aliases the core's kInvalidAddress sentinel.
 class AddressMappingTestCase : public TestCase
 {
@@ -373,6 +495,7 @@ public:
         AddTestCase(new AddressMappingTestCase(), AHN_TEST_QUICK);
         AddTestCase(new AntHocNetDeliveryTestCase(), AHN_TEST_QUICK);
         AddTestCase(new MultiInterfaceDeliveryTestCase(), AHN_TEST_QUICK);
+        AddTestCase(new PerHopCongestionSignalTestCase(), AHN_TEST_QUICK);
         AddTestCase(new RepairAntOnLinkBreakTestCase(), AHN_TEST_QUICK);
     }
 };


### PR DESCRIPTION
Steps 2–3 of the #206 plan, on top of the merged step-1 interface change (#276): the non-wifi `ILinkState` implementation, the regime-selection record (**ADR-0017**), and docs. With this, `EnableMacMetric` produces a real, per-next-hop congestion signal on every ISL — the mechanism the satellite track's claim rests on (#202), unblocking the #216 congestion cell.

## The reader (`ns3/model/anthocnet-routing-protocol.{h,cc}`)

Non-wifi devices carry their backlog in the per-device transmit queue, one per interface — on a satellite, one per ISL. The adapter now:

- grabs each non-wifi device's queue at `NotifyInterfaceUp` through the generic **`TxQueue` attribute** (`PointToPointNetDevice`, `CsmaNetDevice` and `SimpleNetDevice` all expose one — no device-specific module dependency),
- samples the per-packet service time from the queue's `Dequeue` trace as **inter-dequeue spacing while the queue stays backlogged** — the transmitter-side analogue of the wifi inter-ack EWMA (#68), sharing `MacServiceAlpha`. This **excludes propagation by construction** (the sender never waits for it), which is the units decomposition #206 requires: an ISL's constant 3–18 ms is distance, not congestion, and folding it in would swamp the signal's dynamic range,
- answers `macQueueLength`/`macServiceTime` **per next hop** by resolving the hop to its interface via the existing `ResolveNextHop` (#203); `kInvalidAddress` aggregates across interfaces (sum of backlogs; mean of sampled service EWMAs) per the `ports.h` contract,
- keeps **wifi preferred where present** (regime dispatch on `m_wifiMac` — MANET behaviour byte-identical),
- erases a downed interface's queue state in `NotifyInterfaceDown` so a dead ISL's residual backlog cannot inflate the aggregate (#260's fast path already fires there).

## Test (`ns3/test/anthocnet-test-suite.cc`)

New suite case **"Per-next-hop congestion signal on non-wifi devices (#206)"**: the #203 multi-interface relay shape with the egress toward node 2 slowed to 32 kb/s and a sustained 1000 B burst. Asserts the signal **discriminates** — positive backlog and sampled service time toward the loaded hop, (near-)nothing toward the idle hop, aggregate ≥ any single queue, service time on the serialisation scale (< 1 s; a propagation-contaminated value would sit near the link delay), exactly 0 on the never-backlogged link. A node-wide signal cannot pass this case — it reads the same value for both hops, the silent failure #206 exists to prevent. Runs in the six-version CI matrix.

## Record (docs)

- **`docs/adr/0017-linkstate-is-per-next-hop-and-regime-selected.md`**: the two #206 decisions (per-next-hop signal; reader selected by what the build instantiates — the owner's *"networking type is relayed in the configuration build"*, extending ADR-0015's one-build-per-regime axis), the units decomposition, alternatives rejected (per-node signal; a runtime selector knob; `DataRate`-derived service time), consequences.
- **`docs/configuration.md`**: `enableMacMetric` section documents the regime-selected signal source and the propagation exclusion.

## Acceptance state

- ✅ non-zero, correctly-scaled signal on `PointToPointNetDevice`-shaped and `SimpleNetDevice` topologies (suite case);
- ✅ wifi behaviour byte-identical (step 1, #276);
- ✅ core `ILinkState` shape change covered by core tests (step 1, #276);
- ⏭️ the asymmetric-load congestion scenario (traffic shifting off the loaded path) is the **#216 congestion cell** this unblocks — a benchmark run in the satellite suite, not a unit test.

Refs #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_