### PR TITLE
fix(bench): the corridor background transmits at constant duty — the OnOff default off-phase zeroed the congestion signal every other second

### DIFF
--- a/docs/benchmarks/satellite/isl-grid.md
+++ b/docs/benchmarks/satellite/isl-grid.md
@@ -84,7 +84,10 @@ since [#206](https://github.com/danieljoppi/AntHocNet/issues/206) gave
 there are exactly two shortest paths, each `cols/2` hops — **east**
 `(0,0)→(0,1)→…→(0,cols/2)` and **west** `(0,0)→(0,cols−1)→…→(0,cols/2)`;
 any path leaving row 0 is ≥ 2 hops longer. A background OnOff flow
-`(0,1)→(0,2)` (1000 B packets, rate `corridorLoad`, UDP port 10) loads the
+`(0,1)→(0,2)` (1000 B packets, rate `corridorLoad`, UDP port 10, **constant
+duty** — the OnOff default of 1 s on/1 s off would oscillate the queue
+empty→full→empty every 2 s, and an ant sampling the off-phase reads zero
+backlog; the first dispatches measured exactly that) loads the
 east corridor's second link from `corridorLoadAt` onward — after discovery
 has settled on the quiet net, so a reactive baseline has already committed a
 route. Hop count cannot distinguish the corridors; only a congestion signal

--- a/ns3/examples/isl-grid.cc
+++ b/ns3/examples/isl-grid.cc
@@ -502,6 +502,14 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                          InetSocketAddress(nodeAddr[Idx(0, 2, P)], kLoadPort));
         load.SetAttribute("DataRate", StringValue(P.corridorLoad));
         load.SetAttribute("PacketSize", UintegerValue(1000));
+        // Constant duty: the OnOff DEFAULT is 1 s on / 1 s off, under which a
+        // 12 Mbps load on a 10 Mbps ISL oscillates the queue empty->full->empty
+        // every 2 s — an ant sampling in the off-phase reads zero backlog, and
+        // the first cell-1 dispatches measured exactly that (mac-metric arm
+        // shifted only 2/5 seeds; see #216). Sustained congestion IS the cell,
+        // so the background transmits continuously at corridorLoad.
+        load.SetAttribute("OnTime", StringValue("ns3::ConstantRandomVariable[Constant=1]"));
+        load.SetAttribute("OffTime", StringValue("ns3::ConstantRandomVariable[Constant=0]"));
         load.SetAttribute("StartTime", TimeValue(Seconds(P.corridorLoadAt)));
         load.SetAttribute("StopTime", TimeValue(Seconds(P.simTime - 1.0)));
         apps.Add(load.Install(nodes.Get(Idx(0, 1, P))));


### PR DESCRIPTION
The first #216 cell-1 dispatches (runs [30720782823](https://github.com/danieljoppi/AntHocNet/actions/runs/30720782823) / [30720786720](https://github.com/danieljoppi/AntHocNet/actions/runs/30720786720), main `3e8f44a`) exposed a design hole in the cell: the background load app left the ns-3 OnOff **defaults** in place — `OnTime=1s, OffTime=1s` — so "12Mbps" offered load was 12 Mbps at **50 % duty**. On the 10 Mbps ISL each 1 s burst overflows the 100-packet DropTail mid-burst, and the following 1 s off-phase drains it **empty**: the queue oscillates 0 → full → 0 every 2 s. An ant sampling during the off-phase reads zero backlog, so the A2 per-next-hop signal flickers with the duty cycle instead of reporting sustained congestion.

Measured consequence (full record going to #216): the `EnableMacMetric=true` arm shifted the probe off the loaded corridor in only **2/5 seeds** — no better than the metric-off control (3/5, via its wall-clock-transit side channel) — while the cell's *instrument* worked exactly as designed: aodv/dsdv pinned east `1136/0/0` every seed at 35–89 ms probe delay vs ~15–17 ms on the clean corridor; olsr 4/5 east with one tie-break escape.

Sustained congestion *is* what cell 1 exists to offer, so the background now sets `OnTime=Constant(1)` / `OffTime=Constant(0)` and transmits continuously at `corridorLoad`. The probe and standard flows keep the shared defaults deliberately — they are the measured traffic and must stay comparable with every other isl-grid number.

`docs/benchmarks/satellite/isl-grid.md`: the cell section states the constant-duty choice and why.

After merge: re-dispatch the two arms with `protocols=anthocnet` (metric ON) and `protocols=anthocnet,aodv,olsr` (blind controls — dsdv excluded per #281, the stock-ns-3 crash these dispatches also surfaced, independent of this change).

Refs #216, #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_