### PR TITLE
fix(core): receptions refresh the 1-hop pheromone at the metric's unloaded 1-hop value — not the legacy constant 1.0 (#279)

### DIFF
--- a/core/src/ant_router_logic.cpp
+++ b/core/src/ant_router_logic.cpp
@@ -25,8 +25,21 @@ void AntRouterLogic::learnNeighbor(NodeAddress neighbor) {
     if (neighbor == address_ || neighbor == kInvalidAddress) return;
     const bool isNew = lastSeen_.find(neighbor) == lastSeen_.end();
     table_.addNeighbor(neighbor);
-    // Seed an equal-weight regular entry, as the legacy recvAHN did.
-    engine_.updateRegular(table_, neighbor, neighbor, 1.0);
+    // A reception is direct evidence of a live 1-hop path, so it refreshes the
+    // (neighbor, neighbor) entry — at the metric's UNLOADED 1-HOP value, not
+    // the legacy constant 1.0 (#279). The constant gamma-blended the entry
+    // ~100x below its backward-ant value on every packet, corrupting every
+    // 1-hop hello advert (measured: hub pinned at 0.78 vs 74.24 refreshed).
+    // But the per-reception refresh itself is load-bearing: seeding only new
+    // neighbours let 1-hop entries evaporate between backward-ant refreshes,
+    // and the resulting route flaps collapsed the ISL field into a reactive
+    // discovery storm (NRL 37 -> 10801; A/B recorded on the issue). So:
+    // refresh every reception, in the same units backward ants deposit.
+    LinkObservation obs;
+    obs.hops = 1;
+    obs.pathTime = config_.hopTimeSec;
+    obs.hopTime = config_.hopTimeSec;
+    engine_.updateRegular(table_, neighbor, neighbor, metric_->pheromone(obs));
     lastSeen_[neighbor] = clock_.now();  // liveness: any reception refreshes it
     txFailures_.erase(neighbor);         // a reception clears the tx-failure streak (#19)
     if (isNew && observer_) observer_->onRouteChanged(neighbor, neighbor, true);

--- a/core/tests/test_router_logic.cpp
+++ b/core/tests/test_router_logic.cpp
@@ -200,5 +200,36 @@ int main() {
         CHECK(forwarded[0].action == RouteAction::Broadcast);
     }
 
+    // --- #279: receptions refresh the 1-hop entry at the metric's unloaded
+    // 1-hop value, not the legacy constant 1.0. The constant pinned the entry
+    // ~100x below its backward-ant value (corrupting every 1-hop hello
+    // advert); dropping the refresh entirely let 1-hop entries evaporate and
+    // collapsed the ISL field into a reactive storm (A/B on the issue). The
+    // fixed point of repeated receptions must be the same tau a backward ant
+    // would deposit for an unloaded 1-hop path.
+    {
+        FakeClock clock;
+        ScriptedRng rng({0.5});
+        AntRouterLogic router(/*addr*/ 1, cfg, clock, rng);
+        // tau(1 hop, unloaded) = ((T_hop + 1*T_hop)/2)^-1 = 1/T_hop.
+        const double tau1 = 1.0 / cfg.hopTimeSec;
+
+        // A brand-new neighbour seeds at reinforce(0, tau1) = 0.3*tau1 —
+        // metric-scale from the first packet, not the old 0.3.
+        router.learnNeighbor(5);
+        CHECK_NEAR(router.table().getPheromoneRegular(5, 5), 0.3 * tau1, 1e-6);
+
+        // Repeated receptions converge to tau1 (the old code converged to 1.0,
+        // ~100x low at the default 3 ms T_hop).
+        for (int i = 0; i < 60; ++i) router.learnNeighbor(5);
+        CHECK_NEAR(router.table().getPheromoneRegular(5, 5), tau1, 1e-3);
+
+        // A backward-ant value is gamma-blended toward tau1, never toward 1.0:
+        // one reception moves 2*tau1 to 0.7*2*tau1 + 0.3*tau1 = 1.7*tau1.
+        router.table().setPheromoneRegular(5, 5, 2.0 * tau1);
+        router.learnNeighbor(5);
+        CHECK_NEAR(router.table().getPheromoneRegular(5, 5), 1.7 * tau1, 1e-6);
+    }
+
     return RUN_TESTS();
 }


### PR DESCRIPTION
`learnNeighbor` re-applied `updateRegular(neighbor, neighbor, 1.0)` on **every** reception, faithfully mirroring the legacy `recvAHN`. `updateRegular` is a γ-blend (`0.7·old + 0.3·new`), so with hellos arriving every second the 1-hop regular entry could never hold the value backward ants deposit — measured on the #180 probe's star hub: pinned at 0.776–0.778 between refreshes vs 74.24 refreshed, **~100× low**. Since `createHelloAnt` advertises `bestRegular(dest)`, every 1-hop hello advert was depressed by the same factor and every hub-relay topology inherited a corrupted virtual table (star-9 median v/r 0.1969 while line/grid sat at ~1.0 on the #262 clock).

## Why not seed-once (the issue's primary suggestion)

Tried first and **refuted by the pre-merge A/B** (full record on #279): seeding only new neighbours lets 1-hop entries evaporate between backward-ant refreshes (`α^Δt` reaches `minPheromone` in ~30–60 s), so next-hop-to-neighbour routes flap and every flap fires reactive discovery. Measured collapse:

- ISL corridor field: PDR 100 → **16.2**, NRL 37.4 → **10801** (reactive antTx ~500k/300 s vs ~100)
- 900 s paper field: PDR 95.4 → 92.2, delay 62.4 → 84.9, NRL 43.0 → 61.4, reconv drops 1.14 % → 6.96 %

The per-reception refresh was load-bearing; only its **value** was wrong.

## The fix

A reception is direct evidence of a live, working 1-hop path, so it now refreshes the `(neighbor, neighbor)` entry **in the same units backward ants deposit**: the metric's unloaded 1-hop value — `LinkObservation{hops=1, pathTime=T_hop, hopTime=T_hop}` through the `ILinkMetric` seam (item 16), i.e. τ = `((T_hop+T_hop)/2)⁻¹ = 1/T_hop` (333.3 at the 3 ms default) for `ClassicMetric` — instead of the constant 1.0. Fixed point of repeated receptions = the unloaded 1-hop deposit; a congestion-elevated backward-ant value γ-decays toward the unloaded value rather than toward 1.0. Liveness (`lastSeen_`), the tx-failure reset (#19) and `addNeighbor` are untouched.

## Verification

- core `make test` **25/25** — the new #279 case pins: new-neighbour seed at `0.3/T_hop` (metric scale from the first packet); repeated receptions converge to `1/T_hop`, not 1.0; a 2×-elevated value blends to 1.7×, never toward 1.0.
- `exp_uniformity_probe`: star-9 median v/r **0.1969 → 1.9569** (the ~100× 1-hop advert depression is gone); line 0.9028 / grid 1.0041 — #262's degree-independence preserved.
- **ns-3 A/B vs `main` on identical seeds** (both regimes, this fix's arm `3864b4f`):
  - 900 s paper field: PDR 95.1 vs 95.4, delay 57.7 vs 62.4, NRL 41.66 vs 42.99, NRLbytes 93.8 vs 100.5 — neutral-to-favourable, within ~1σ (runs 30724403991 vs 30724134366).
  - ISL corridor, metric OFF: mean probe delay **32.1 vs 76.3** — substantially better (run 30724398291).
  - ISL corridor, metric ON: 64.7 vs 46.8 — one seed-flip apart on a 5-seed cell whose per-seed outcome is already known to be bimodal (#216); NRL/PDR byte-comparable (37.4/100 %) (run 30724392567).

Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_