### PR TITLE
docs: open-source front door + accuracy audit — fix count/default drift, add docs map, ADR index, CI reproducibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ onto *your* NS-2 / NS-3 tree.
 core/   simulator-agnostic C++ (no NS-2/NS-3 headers) + unit tests
 ns2/    NS-2 Agent adapter + idempotent anchor-based source patch
 ns3/    native ns3::Ipv4RoutingProtocol contrib module
-docs/   architecture.md, porting-notes.md, adr/
+docs/   architecture.md, porting-notes.md, adr/ — full map in docs/README.md
 ```
 
 ## Build & verify
@@ -165,4 +165,4 @@ results.
 | **Understand why satellite ≠ MANET** (before assuming a MANET intuition transfers) | [`docs/network-regimes.md`](docs/network-regimes.md) — the inversion in one line: MANET hides the *topology* and gives you the traffic; a constellation gives you the topology and hides the *traffic*. Diagrams, and a difference table where every row traces to a defect, parameter or control in this repo |
 | Cut a release | run the `Release` workflow (Commitizen); see `CONTRIBUTING.md`. **Post-release the Zenodo DOI is a manual human step** — `zenodo.org` is proxy-blocked (403) and the DOI is minted async after publish, so an agent must ask the maintainer for it (never invent one) then update the README badge + `CITATION.cff` in a `docs:` PR |
 | Tune defaults | `core/include/anthocnet/core/config.h` |
-| **Look up a parameter's default, its provenance, or how to calibrate it** | [`docs/configuration.md`](docs/configuration.md) — all 30 `Config` fields with a `source` column ([1] §/thesis/repo choice/**unknown**), the ns-3 attribute + NS-2 bind for each, the sweep→A/B→noise loop, and the checklist for adding a parameter. The `unknown` rows in §3.2 are the next #88/#169 candidates |
+| **Look up a parameter's default, its provenance, or how to calibrate it** | [`docs/configuration.md`](docs/configuration.md) — all 36 `Config` fields with a `source` column ([1] §/thesis/repo choice/**unknown**), the ns-3 attribute + NS-2 bind for each, the sweep→A/B→noise loop, and the checklist for adding a parameter. The `unknown` rows in §3.2 are the next #88/#169 candidates |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -86,6 +86,7 @@ CONTEXT.md                ← this file
 AGENTS.md                 ← build/verify/conventions for AI agents
 Makefile                  ← make test | install-ns2 | install-ns3 | clean
 docs/
+  README.md               ← docs map (every page, grouped by task)
   architecture.md         ← design + decision flow
   configuration.md        ← every tunable, its default's provenance, how to calibrate
   porting-notes.md        ← bugs fixed, NS-2 patch anchors, wire format, caveats
@@ -174,7 +175,8 @@ These were latent in the original NS-2 module and are fixed in `core/`:
   reconvergence holds drop at the cap instead of the 3 s `QueueTimeout`)
   mean delay reaches parity with AODV on two-ray for near-noise PDR cost
   (#103). The residual disk-model gap is the CONTEXT-§8 channel penalty plus
-  the still-unverified `T_hop` (#88), not an algorithmic deviation. NS-3 only;
+  `T_hop` (#88 — since corrected to the thesis's 3 ms; tail impact pending
+  re-measurement), not an algorithmic deviation. NS-3 only;
   the NS-2 adapter has no equivalent cap yet.
 
 ## 9. Glossary
@@ -196,7 +198,7 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 | Forward / backward / hello / repair ant | path collector / pheromone depositor / neighbour-discovery + gossip / link-failure local search. |
 | Neighbour liveness | a neighbour is "gone" via either missed hellos (core timer, primary) or a failed unicast (MAC signal, fast-path); both call `loseNeighbor`. `INeighborProvider` is advisory, never authoritative for removal (ADR-0008). |
 | Stochastic data routing | data is forwarded by a per-packet pheromone-weighted draw, **excluding the prev hop** (loop safety; only-option fallback). Per-flow stickiness (a bounded `(src,dst)→hop` cache) is config-gated, default off (ADR-0010). |
-| Multipath reactive setup | a later reactive forward ant of an already-seen `(src,seq)` generation is still forwarded when both its hops and travel time are within `antAcceptanceFactor` (1.5) of the generation's best, laying down several good paths ([1] §3.1). Requires its **linkfail churn bound**: losing a best hop that leaves a usable alternate is absorbed, not flooded — without it multipath *regressed* PDR on the ns-3 disk-model harness. Config-gated (`enableMultipath`, default on; #96). |
+| Multipath reactive setup | a later reactive forward ant of an already-seen `(src,seq)` generation is still forwarded when both its hops and travel time are within `antAcceptanceFactor` of the generation's best (thesis two-factor band since #177: `a1 = 0.9`, `a2 = 2.0` for a new first hop; [1] §3.1 stated a single 1.5), laying down several good paths. Requires its **linkfail churn bound**: losing a best hop that leaves a usable alternate is absorbed, not flooded — without it multipath *regressed* PDR on the ns-3 disk-model harness. Config-gated (`enableMultipath`, default on; #96). |
 | `NodeAddress` | core address type (`int32_t`), = a node's primary interface IP, treated opaquely; `kInvalidAddress` = -1 = "no route / no specific next hop". Broadcast is a `RouteAction`, **never** a `NodeAddress` (ADR-0011). |
 
 ## 10. Open questions for future work
@@ -241,9 +243,11 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 - Are the `Config` defaults (`alpha`/`betaAnts`/`betaData`/`gamma`, intervals, `maxPathLength`,
   `maxHistory`) the right operating point, or should they be tuned per
   simulator? (See #23 convergence, #26 fidelity.) **Now partly answered:**
-  [`docs/configuration.md`](docs/configuration.md) tabulates all 30 fields with
-  the *provenance* of each default. Eleven have none — §3.2 lists them as the
-  standing worklist, `alpha` first (ADR-0012 changed its meaning and said it
-  "must be re-tuned"; no re-tune is on record). Two defaults have already been
+  [`docs/configuration.md`](docs/configuration.md) tabulates all 36 fields with
+  the *provenance* of each default. Four have none — §3.2 lists them as the
+  standing worklist (the #182 thesis audit shrank it from eleven: five more
+  turned out *positively absent* from the sources, i.e. `repo choice` with
+  nothing to calibrate against — `alpha` among them, still untuned after
+  ADR-0012 said it "must be re-tuned"). Two defaults have already been
   found wrong this way (#88 `T_hop`, #169 `reactiveMaxBroadcasts`), so treat an
   un-sourced number as a suspect rather than a setting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,15 @@ release, so a paper reproducing them should cite that release's DOI.
   wire format changed.
 - Picking up work? The backlog lives in GitHub issues (each ticket carries
   evidence, a fix sketch, and acceptance criteria).
+- **A change to protocol behaviour needs an A/B benchmark verdict**, not a
+  plausibility argument — the sweep → A/B → noise-verdict loop is
+  [`docs/configuration.md` §5](docs/configuration.md#5-how-to-calibrate-a-parameter).
+  Record the verdict and run IDs on the relevant issue.
+- **Bugs and findings become GitHub issues** — including partial findings and
+  dead ends. The discipline (and the label taxonomy: one type label, area
+  label(s), a priority) is
+  [ADR-0013](docs/adr/0013-track-bugs-and-findings-as-issues.md); it is what
+  keeps investigations recoverable across sessions.
 
 ## Reporting issues
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ onto *your own* NS-2 or NS-3 tree:
 core/   simulator-agnostic C++ (no NS-2/NS-3 dependency) + unit tests
 ns2/    thin Agent adapter + anchor-based source patch installer
 ns3/    native Ipv4RoutingProtocol module
-docs/   architecture and porting notes
+docs/   architecture, configuration, benchmarks, fidelity, ADRs — map in docs/README.md
 ```
 
 ## Why one core, two adapters
@@ -156,6 +156,7 @@ History of the work is in the per-phase commits; design rationale is in
 
 | Document | Purpose |
 |----------|---------|
+| [docs/README.md](docs/README.md) | **The docs map** — every page in `docs/`, grouped by what you are trying to do. |
 | [docs/ant-colony-routing.md](docs/ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet, and how they map to the code. Start here for the *idea*. |
 | [docs/architecture.md](docs/architecture.md) | Design, the core/adapter split, and the decision flow. |
 | [docs/porting-notes.md](docs/porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, wire format, version caveats. |
@@ -163,7 +164,9 @@ History of the work is in the per-phase commits; design rationale is in
 | [docs/benchmarks.md](docs/benchmarks.md) | Results index → [metrics](docs/benchmarks/metrics.md), [methodology](docs/benchmarks/methodology.md), per-scenario and per-sweep pages. |
 | [docs/fidelity.md](docs/fidelity.md) | What v1.0 reproduces from the 2004 paper and where it deliberately deviates. |
 | [docs/wire-format.md](docs/wire-format.md) | Canonical on-wire ant layout, version byte, and diff vs. the original and the papers. |
-| [docs/adr/](docs/adr) | Architecture Decision Records — the "why" behind the structure. |
+| [docs/publications/](docs/publications/README.md) | Source-of-truth digests of the 2004 paper and 2007 thesis — what every fidelity claim is checked against. |
+| [docs/network-regimes.md](docs/network-regimes.md) | Why MANET and satellite/ISL routing are different problems (the satellite research track's ground rules). |
+| [docs/adr/](docs/adr/README.md) | Architecture Decision Records 0001–0018, indexed — the "why" behind the structure. |
 | [paper/](paper/) | JOSS software-paper draft (`paper.md`/`paper.bib`), for submission against this repo. |
 | [CONTEXT.md](CONTEXT.md) | Project orientation: domain background, repo map, current state, glossary, open questions. |
 | [AGENTS.md](AGENTS.md) | Build/verify/conventions and invariants for contributors and AI agents. |
@@ -183,8 +186,29 @@ pre-built **Docker images** on GHCR (see [docker/README.md](docker/README.md)).
 To cite this implementation, use the “Cite this repository” button (from
 [CITATION.cff](CITATION.cff)). Once the repo is linked to
 [Zenodo](https://zenodo.org), each release is archived with a DOI, which is then
-added to `CITATION.cff`. Please also cite the original AntHocNet paper
-(Di Caro, Ducatelle & Gambardella, PPSN VIII, 2004) referenced there.
+added to `CITATION.cff`. Please also cite the sources this implements:
+
+- G. Di Caro, F. Ducatelle, L. M. Gambardella, *AntHocNet: an Ant-Based Hybrid
+  Routing Algorithm for Mobile Ad Hoc Networks*, PPSN VIII, LNCS 3242,
+  pp. 461–470, Springer, 2004 — the algorithm ([digest](docs/publications/papers/2004-ppsn-anthocnet.md)).
+- F. Ducatelle, *Adaptive Routing in Ad Hoc Wireless Multi-hop Networks*, PhD
+  thesis, Università della Svizzera Italiana / IDSIA, 2007 — the designated
+  primary source for parameters the paper leaves unspecified
+  ([status](docs/publications/thesis/README.md)).
+
+What this implementation reproduces from those sources — and every deliberate
+deviation — is stated in [docs/fidelity.md](docs/fidelity.md).
+
+## Contributing
+
+[CONTRIBUTING.md](CONTRIBUTING.md) has the build/test steps per component, the
+code style, and the Conventional-Commit PR-title rules; [AGENTS.md](AGENTS.md)
+has the golden rules (invariants) and verification workflow. Bugs and findings
+are tracked as GitHub issues with a label taxonomy
+([ADR-0013](docs/adr/0013-track-bugs-and-findings-as-issues.md)); changes to
+protocol behaviour are expected to carry an A/B benchmark verdict
+([docs/configuration.md §5](docs/configuration.md#5-how-to-calibrate-a-parameter)).
+Security reports: [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# Documentation map
+
+Where to find things in `docs/`. Repo-level orientation is one directory up:
+[`README.md`](../README.md) (front door), [`CONTEXT.md`](../CONTEXT.md)
+(project orientation + glossary), [`AGENTS.md`](../AGENTS.md) (build/verify,
+golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Understand the protocol
+
+| Page | What it is |
+|---|---|
+| [ant-colony-routing.md](ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet. Start here for the *idea*. |
+| [architecture.md](architecture.md) | The core/adapter split, ports, and the decision flow. |
+| [network-regimes.md](network-regimes.md) | Why MANET and satellite/ISL are different routing problems — read before transferring an intuition between them. |
+
+## Build, port, extend
+
+| Page | What it is |
+|---|---|
+| [porting-notes.md](porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, version caveats. |
+| [wire-format.md](wire-format.md) | Canonical on-wire ant layout and the `kWireVersion` rules (golden rule 4). |
+| [configuration.md](configuration.md) | Every tunable, its default's **provenance**, the ns-3/NS-2 surface for it, and the calibration loop. |
+| [cross-validation.md](cross-validation.md) | NS-2 vs NS-3 behaviour re-validation (not bit-for-bit parity). |
+
+## Measure & reproduce
+
+| Page | What it is |
+|---|---|
+| [benchmarks.md](benchmarks.md) | Results index: per-merge taxonomy table + links to every scenario/sweep page. |
+| [benchmarks/metrics.md](benchmarks/metrics.md) | What PDR, delay99, NRL etc. mean, and their caveats. |
+| [benchmarks/methodology.md](benchmarks/methodology.md) | Reproduce commands (local and CI dispatch), build profiles, validation anchors, determinism gate. |
+| [benchmarks/README.md](benchmarks/README.md) | How the figures/tables are generated and regenerated. |
+| [benchmarks/satellite/isl-grid.md](benchmarks/satellite/isl-grid.md) | The satellite/ISL suite: harness, analytic anchors, dispatch. |
+
+## Research provenance & fidelity
+
+| Page | What it is |
+|---|---|
+| [fidelity.md](fidelity.md) | What this implementation reproduces from the 2004 paper, and every deliberate deviation — the claims page. |
+| [publications/](publications/README.md) | Source-of-truth digests of the 2004 PPSN paper and the 2007 Ducatelle thesis (no vendored PDFs). |
+| [satellite-routing-prior-art.md](satellite-routing-prior-art.md) | ACO-on-constellations survey behind the satellite track (#192). |
+
+## Decisions & process
+
+| Page | What it is |
+|---|---|
+| [adr/](adr/README.md) | Architecture Decision Records 0001–0018, indexed with one-line summaries. |
+| [handoffs/](handoffs/) | Dated cross-session investigation handoffs (see ADR-0013 for the issue-first discipline). |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,36 @@
+# Architecture Decision Records
+
+The "why" behind the repository's structure and the protocol's deliberate
+deviations, one decision per file ([ADR-0001](0001-record-architecture-decisions.md)
+explains the practice). All ADRs below are **Accepted**; where one has been
+partly superseded or updated, the note says so — the ADR itself carries the
+detail.
+
+| ADR | Decision |
+|---|---|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions as ADRs in `docs/adr/`. |
+| [0002](0002-one-core-two-adapters.md) | One simulator-agnostic algorithm core; thin per-simulator adapters (NS-2, NS-3). The repo's load-bearing invariant. |
+| [0003](0003-pure-core-returns-route-decisions.md) | The core is pure: it returns `RouteDecision`s and performs no I/O; adapters execute them. |
+| [0004](0004-pod-ant-messages-and-codec.md) | Ants are POD value types (`AntMessage`) with a single canonical wire codec — no header-resident pointers. |
+| [0005](0005-ns2-idempotent-anchor-patch.md) | NS-2 installation is an idempotent, anchor-based source patch — never a forked simulator tree or line-numbered diff. |
+| [0006](0006-on-wire-protocol-version.md) | A 1-byte on-wire protocol version (`kWireVersion`), no negotiation — golden rule 4's foundation. |
+| [0007](0007-proactive-diffusion-gated.md) | Keep virtual pheromone / proactive diffusion, but config-gate it so the ablation is runnable. *Partly superseded on one point by ADR-0016.* |
+| [0008](0008-neighbour-liveness-two-detectors.md) | Neighbour liveness via two detectors (hello timeout + MAC transmit-failure fast path); `INeighborProvider` is advisory. |
+| [0009](0009-backward-ants-carry-path-not-state.md) | The wire carries path observations, not computed state — backward ants carry the path, nodes compute pheromone locally. |
+| [0010](0010-data-forwarding-prevhop-excluded-stochastic.md) | Data forwarding is prev-hop-excluded stochastic; per-flow stickiness is gated and default off. |
+| [0011](0011-nodeaddress-is-ip-broadcast-is-an-action.md) | `NodeAddress` is the node's IP, treated opaquely; broadcast is a `RouteAction`, never an address. |
+| [0012](0012-evaporation-is-a-secondary-safety-net.md) | Evaporation is a secondary, time-proportional safety net — the sources have no evaporation term. *Updated 2026-08-01 (#262): virtual aging moved onto the same tick/factor as regular.* |
+| [0013](0013-track-bugs-and-findings-as-issues.md) | Track every bug and finding as a GitHub issue (label taxonomy, evidence, acceptance criteria) — the cross-session traceability discipline. |
+| [0014](0014-agent-skills-are-script-first.md) | Agent skills are script-first: analysis and validation run in scripts, raw data stays out of LLM context. |
+| [0015](0015-satellite-substrate-lives-in-the-image.md) | One AntHocNet build; the satellite substrate lives in the container image — no separate satellite binary. |
+| [0016](0016-directed-reactive-discovery-is-gated-and-off.md) | Reactive ants may follow the diffusion gradient (directed discovery), gated and default **off**. |
+| [0017](0017-linkstate-is-per-next-hop-and-regime-selected.md) | The congestion signal (`ILinkState`) is per-next-hop; its implementation is selected by what the build instantiates (wifi vs point-to-point/ISL). |
+| [0018](0018-emission-gate-compares-per-link.md) | The proactive emission gate compares virtual and regular pheromone per link, not best-vs-best — cancels the h/(h−1) hop ceiling. |
+
+## Adding an ADR
+
+Number sequentially (`NNNN-short-slug.md`), follow the existing
+Context / Decision / Alternatives / Consequences shape, and add a row here.
+When a change alters a documented decision, update the ADR (or supersede it
+with a new one) in the same PR — see [`AGENTS.md`](../../AGENTS.md)
+"Conventions".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,8 @@ The adapters implement these so the core stays I/O-free:
 incoming ant  ->  AntRouterLogic::onReceiveAnt(msg, prevHop)
                     - reactive forward ant (enableMultipath, default on): per-
                       generation acceptance band ([1] §3.1, #96) — a later
-                      (src,seq) copy within antAcceptanceFactor (1.5) of the
+                      (src,seq) copy within antAcceptanceFactor (a1=0.9, or
+                      a2=2.0 for a new first hop; thesis values, #177) of the
                       best seen on BOTH hops and travel time is admitted, so
                       several good paths get laid down; all other ants (and
                       everything when the gate is off): strict (src,seq)

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -82,6 +82,38 @@ python3 ns3/tools/make-charts.py     scenarios.csv --outdir docs/benchmarks
 python3 ns3/tools/update-benchmarks.py scenarios.csv docs/benchmarks.md
 ```
 
+### Reproducing via CI (manual dispatch)
+
+No local simulator is needed — the two campaign workflows run inside the
+published GHCR images (Actions → workflow → *Run workflow*):
+
+- **Paper benchmark** ([`paper-benchmark.yml`](../../.github/workflows/paper-benchmark.yml))
+  — one paper-regime scenario with `--diag`. Inputs mirror `anthocnet-compare`
+  flags (`nNodes`, `time`, `runs`, `areaX`/`areaY`, `pause`, `speed`,
+  `propagation`, `range`); `harness=baselines` runs the stock-ns-3 control
+  (no AntHocNet code linked), and `extraArgs` appends verbatim
+  `--ns3::anthocnet::RoutingProtocol::<Attr>=<value>` overrides, so an A/B arm
+  is a dispatch, not a branch.
+- **Scenario matrix + charts** ([`scenario-matrix.yml`](../../.github/workflows/scenario-matrix.yml))
+  — the taxonomy + the area/pause/scale sweeps. A real (non-`quick`) whole
+  sweep does **not** fit the 6 h hosted-runner ceiling
+  ([#121](https://github.com/danieljoppi/AntHocNet/issues/121)) — dispatch it
+  one point per job via `only=<sweep>` + `point=<value>`. With `commit=true`
+  the classified CSV lands in `docs/benchmarks/campaign/` and the regenerated
+  charts in `docs/benchmarks/`; otherwise everything stays in the run's
+  artifacts.
+
+Both take a `version` input naming the ns-3 image tag: `3.42` is the campaign
+pin, `3.42-opt` the optimized profile (see build profiles below), and a
+release-suffixed tag (e.g. `3.42-v1.1.0`) is **immutable** — pin one for a
+citable run and record the run ID with the numbers. The per-merge refresh of
+[`../benchmarks.md`](../benchmarks.md) needs no dispatch (`benchmarks.yml`,
+every merge to the default branch), and its publish step is gated on the
+validation anchors below. Before trusting or comparing dispatched numbers, run
+the validation loop in
+[`configuration.md` §5](../configuration.md#5-how-to-calibrate-a-parameter)
+(`scenario_check.py` preflight/results, `bench_parse.py --ab`).
+
 ## Scenario taxonomy & sweeps
 
 A single scenario is a poor verdict on a MANET protocol — performance swings with

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,9 +15,9 @@ One struct, two surfaces:
 
 | Layer | File | What it is |
 |---|---|---|
-| Core | [`core/include/anthocnet/core/config.h`](../core/include/anthocnet/core/config.h) | `anthocnet::core::Config` — **31 fields**, plain C++14 aggregate with default member initializers. The single source of truth; `AntRouterLogic` reads nothing else. |
-| NS-3 | [`ns3/model/anthocnet-routing-protocol.cc`](../ns3/model/anthocnet-routing-protocol.cc) | 25 `AddAttribute` blocks on `ns3::anthocnet::RoutingProtocol`. **19** of them write into `Config`; the other 6 are adapter-side state (queue timeouts, hold caps, the MAC failure detector, the MAC service-time EWMA, the adapter's own reactive-retry timer). |
-| NS-2 | [`ns2/src/ahn_router.cc`](../ns2/src/ahn_router.cc) | 10 `bind()`/`bind_bool()` TCL variables writing into `Config`, plus four compile-time `AHN_*` macros in [`ahn_router.h`](../ns2/src/ahn_router.h) (`AHN_HELLO_INTERVAL`, `AHN_PROACTIVE_INTERVAL`, `AHN_NETWORK_DIAMETER`, `AHN_LIFE_ANT`). |
+| Core | [`core/include/anthocnet/core/config.h`](../core/include/anthocnet/core/config.h) | `anthocnet::core::Config` — **36 fields**, plain C++14 aggregate with default member initializers. The single source of truth; `AntRouterLogic` reads nothing else. |
+| NS-3 | [`ns3/model/anthocnet-routing-protocol.cc`](../ns3/model/anthocnet-routing-protocol.cc) | 30 `AddAttribute` blocks on `ns3::anthocnet::RoutingProtocol`. **24** of them write into `Config`; the other 6 are adapter-side state (queue timeouts, hold caps, the MAC failure detector, the MAC service-time EWMA, the adapter's own reactive-retry timer). |
+| NS-2 | [`ns2/src/ahn_router.cc`](../ns2/src/ahn_router.cc) | 15 `bind()`/`bind_bool()` TCL variables writing into `Config`, plus four compile-time `AHN_*` macros in [`ahn_router.h`](../ns2/src/ahn_router.h) (`AHN_HELLO_INTERVAL`, `AHN_PROACTIVE_INTERVAL`, `AHN_NETWORK_DIAMETER`, `AHN_LIFE_ANT`). |
 
 So a field can be a core default only, or reachable from one adapter, or from
 both — the table in §2 says which. Anything not exposed by your adapter must be
@@ -143,7 +143,7 @@ The `ns-3 attribute` column is the name you pass to
 
 ### 3.2 Parameters with no recorded provenance
 
-**Four** of the thirty defaults have **no traceable justification for the
+**Four** of the thirty-six defaults have **no traceable justification for the
 number**. They are the standing #88/#169 risk, listed here so the next audit has
 a worklist rather than a haystack:
 
@@ -208,7 +208,7 @@ class of defect as a missing one.
 
 ### 3.4 ns-3 attributes that are *not* `Config` fields
 
-Six of the 24 attributes configure the NS-3 adapter, not the algorithm. They are
+Six of the 30 attributes configure the NS-3 adapter, not the algorithm. They are
 listed here so a sweep does not mistake one for a protocol parameter:
 
 | attribute | default | what it does |
@@ -254,20 +254,24 @@ type decides, wifi preferred where both exist.
 ### Reactive setup — `reactiveMaxBroadcasts`, `enableMultipath`, `antAcceptanceFactor`, `reactiveRetryInterval`, `maxPathLength`
 
 How routes are discovered. `reactiveMaxBroadcasts` bounds how often **one
-node** re-broadcasts **one generation** (default 2). Read its history before
-touching it, because the same name has meant two different things:
+node** re-broadcasts **one generation** (default `-1`, unbounded, since #177).
+Read its history before touching it, because the same name has meant two
+different things:
 
 - As a budget *carried on the ant* and decremented at each hop it was a **hop
   limit on discovery** — destinations beyond ~5 hops were never found (#169).
   Never reintroduce that form.
-- As a per-node count it does not limit reach at all, and it is **required**:
-  with multipath on, a reactive forward ant is admitted by the acceptance band
-  *instead of* `(src,seq)` duplicate suppression, and the band admits rather
-  than suppresses. Without the per-node count one discovery on a 7x7 grid cost
-  30,090 ants and ns-3 `large-scale` fell to 21.7% PDR (#173).
+- As a per-node count it does not limit reach at all, and for a while it was
+  **required**: with multipath on, a reactive forward ant is admitted by the
+  acceptance band *instead of* `(src,seq)` duplicate suppression, and the band
+  admits rather than suppresses. Without the per-node count one discovery on a
+  7x7 grid cost 30,090 ants and ns-3 `large-scale` fell to 21.7% PDR (#173).
+  What retired it is the two-factor band ([#177](https://github.com/danieljoppi/AntHocNet/issues/177)):
+  at the thesis's `a1 = 0.9` the band is self-limiting (154 ants on the same
+  grid), and leaving the count on cost delivery in dense graphs.
 
-Setting it to `-1` restores the unbounded behaviour and is a sensitivity
-experiment, not a configuration.
+Setting it to a finite value bounds re-broadcasts per `(node, generation)` and
+is a sensitivity experiment, not a configuration.
 
 `antAcceptanceFactor` is the multipath dial and its direction is
 counter-intuitive: **higher admits more ant copies**, i.e. more paths and more

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -19,7 +19,7 @@ The living compliance ledger is [issue #91](https://github.com/danieljoppi/AntHo
 | Mechanism | [1] § | Implementation | Status |
 |---|---|---|---|
 | Reactive path setup (forward/backward ants) | 3.1 | `core/ant_router_logic` | ✅ core-tested |
-| **Multipath** setup (1.5× hops+time acceptance filter) | 3.1 | `GenerationTracker`, `enableMultipath` (#96/#97) | ✅ default on |
+| **Multipath** setup (hops+time acceptance filter; [1] states 1.5×) | 3.1 | `GenerationTracker`, `enableMultipath` (#96/#97) | ✅ default on — factors are the thesis's `a1 = 0.9` / `a2 = 2.0` since #177 |
 | MAC-queue-aware per-hop cost `(Q+1)·T̂_mac` (A2) | 3.1 | `enableMacMetric` (#67/#70) | ✅ formula matches; default off (gated) |
 | Pheromone deposit `τ=((T̂+h·T_hop)/2)⁻¹`, running avg γ | 3.1 | `pheromone_engine` | ✅ |
 | Stochastic data routing, pheromone² | 3.2 | `betaData=2` (#70/#100) | ✅ aligned |
@@ -69,11 +69,14 @@ and `heavy-load` 85.0 → 51.4 %, with NRL rising 99.9 → 3071. Cause
 ([#173](https://github.com/danieljoppi/AntHocNet/issues/173)): with
 `enableMultipath` on, a reactive forward ant is admitted by the acceptance band
 *instead of* `(src,seq)` duplicate suppression, so removing the broadcast budget
-left the reactive flood unbounded in dense graphs. `reactiveMaxBroadcasts` is
-now a **per-(node, generation)** broadcast count (default 2) rather than a
-per-path budget — bounding the flood without reintroducing the #169 hop limit.
-Numbers measured between those two fixes carry the flood and are not
-representative either.
+left the reactive flood unbounded in dense graphs. `reactiveMaxBroadcasts`
+became a **per-(node, generation)** broadcast count (default 2 at the time)
+rather than a per-path budget — bounding the flood without reintroducing the
+#169 hop limit. Numbers measured between those two fixes carry the flood and
+are not representative either. ([#177](https://github.com/danieljoppi/AntHocNet/issues/177)
+later retired the count — default now `-1`, unbounded — because the thesis's
+`a1 = 0.9` acceptance band bounds the flood on its own; see
+[`configuration.md`](configuration.md) §4.)
 
 ## Where we ship [1]'s algorithm and the 2007 thesis superseded it
 
@@ -92,9 +95,11 @@ deliberate choices as three defects. Recorded here (audit:
    for first-hop-disjoint ants) and then records dropping the design: reactive
    setup is restricted to a single route, with multiple routes obtained through
    *proactive* maintenance instead.
-   [#177](https://github.com/danieljoppi/AntHocNet/issues/177) is measuring the
-   options; [#178](https://github.com/danieljoppi/AntHocNet/issues/178) records
-   the citation trap.
+   [#177](https://github.com/danieljoppi/AntHocNet/issues/177) measured the
+   options and adopted the thesis's **factors** (`a1 = 0.9`, `a2 = 2.0`) while
+   keeping [1]'s multipath **mechanism** — so this item is now a hybrid, not a
+   pure [1] choice; [#178](https://github.com/danieljoppi/AntHocNet/issues/178)
+   records the citation trap.
 2. **Proactive broadcast probability** (`proactiveBroadcastProb = 0.1`). Our
    exact value appears in the thesis, but in §4.3.4, *"Older versions of
    AntHocNet"*. In the shipped thesis algorithm proactive forward ants are

--- a/docs/publications/papers/2004-ppsn-anthocnet.md
+++ b/docs/publications/papers/2004-ppsn-anthocnet.md
@@ -107,7 +107,7 @@ neighbour notification.
 
 | Parameter | Paper value | § | Repo counterpart (`core/.../config.h`) | Status |
 |---|---|---|---|---|
-| Acceptance factor (hops AND time) | **1.5** (empirical) | 3.1 | `antAcceptanceFactor = 1.5`, gated by `enableMultipath` | ✅ matches (#96) |
+| Acceptance factor (hops AND time) | **1.5** (empirical) | 3.1 | `antAcceptanceFactor`, gated by `enableMultipath`; shipped 1.5 until v1.1.0 | ❗ deviation since [#177](https://github.com/danieljoppi/AntHocNet/issues/177): the 2007 thesis's two-factor band (`a1 = 0.9`, `a2 = 2.0` for a new first hop) measured better and is the default |
 | MAC-time running-average weight α | **0.7** | 3.1 | `macServiceAlpha` (ns-3 attr) = 0.7 | ✅ matches (#70) |
 | Pheromone running-average weight γ | **0.7** | 3.1 | `gamma = 0.7` | ✅ matches |
 | Per-hop cost formula | `(Q_mac + 1)·T̂_mac` | 3.1 | `enableMacMetric` path | ✅ formula confirmed (#70); repo default **off** (A2 gated) |


### PR DESCRIPTION
Documentation audit for developer- and research-friendliness as an open-source project. Two halves: **factual drift fixes** (things the docs said that the code no longer does) and **navigability additions** (maps and indexes so the three audiences — reproducing researcher, contributor, thesis reader — reach what they need in 1–2 hops from README).

## Accuracy fixes (docs said X, tree says Y)

| file | drift |
|---|---|
| `docs/configuration.md` | `Config` has **36** fields, not 31; ns-3 surface is **30** `AddAttribute` blocks (24 → `Config`), not 25/19; NS-2 surface is **15** binds, not 10; §4's `reactiveMaxBroadcasts` prose still said "(default 2)" / "−1 restores unbounded", contradicting §3.1's correct #177 record that **−1 is the default** |
| `docs/fidelity.md` | three spots described the pre-#177 state in present tense ("is now … default 2", "#177 is measuring") — #177 concluded and shipped in v1.1.0; mechanisms row implied the 1.5× band is the shipped filter (factors are a1=0.9/a2=2.0). Historical narrative preserved, present-tense claims corrected |
| `docs/publications/papers/2004-ppsn-anthocnet.md` | acceptance-factor row claimed "1.5 … ✅ matches" — a deviation since #177; now marked ❗ (this table is the fidelity reference, so a wrong "matches" is the worst kind of drift) |
| `docs/architecture.md`, `CONTEXT.md` glossary | acceptance factor "(1.5)" → a1=0.9 / a2=2.0 (#177) |
| `CONTEXT.md` | "30 fields … eleven unknown" → 36 fields, **4** unknown post-#182; "still-unverified `T_hop`" → resolved to the thesis's 3 ms (#88) |
| `AGENTS.md` | "all 30 `Config` fields" → 36 |

## Additions

- **`docs/README.md`** (new): the docs-tree map — task-grouped tables; `publications/`, `network-regimes.md`, `satellite-routing-prior-art.md`, `handoffs/` were previously unreachable from the README's doc table.
- **`docs/adr/README.md`** (new): ADR index **0001–0018** with one-line summaries, supersession notes, add-an-ADR convention.
- **`README.md`**: full source citations (the PPSN paper **and** the 2007 Ducatelle thesis — the provenance chain was not findable from the front page), a Contributing section (build/test per component, golden rules, ADR-0013 findings-tracking), docs-map + publications + network-regimes rows.
- **`CONTRIBUTING.md`**: two missing discipline bullets — findings tracked as issues (ADR-0013), and protocol-behaviour changes carry an **A/B against main on identical seeds** before merge (the #188/#254 rule every recent protocol PR followed but no contributor doc stated).
- **`docs/benchmarks/methodology.md`**: "Reproducing via CI (manual dispatch)" — workflows, image-tag semantics (`3.42` / `3.42-opt` / release-pinned), where results land, anchor gating, validation loop. Local reproduction was documented; the CI path that produces the repo's own recorded numbers was not.

## Verification

- **379 relative links** across every `.md` checked — all resolve.
- Core quickstart re-run as documented (cmake/make/ctest): build clean, **25/25**.
- Counts verified against the tree: 36 `Config` fields, 30 `AddAttribute` (24 → `Config`, 6 adapter-side), 15 NS-2 binds + 4 `AHN_*` macros.

Flagged for owner decision (not done): a `.github` PR template; GitHub repo description/topics (not settable from the tree). LICENSE, CITATION.cff, CODE_OF_CONDUCT, SECURITY all exist and were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_