### PR TITLE
docs: add the PR template — verification and record sections mirror the repo's merge discipline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+Title: conventional-commit style, lowercase subject — `feat(core): add the …`,
+not `feat(core): Add the …` (lint-title enforces this).
+Scopes in use: core, ns2, ns3, bench, ci, docs.
+-->
+
+## What & why
+
+<!-- What changes, and the reasoning/measurement behind it. Link the issue
+     that motivated it — findings and decisions live in issues (ADR-0013),
+     so a reviewer can trace the evidence chain. -->
+
+## Verification
+
+<!-- Keep only the rows that apply, with real numbers/output:
+- core `make test` result (a core/ logic change must add or extend a core test — golden rule)
+- protocol-behaviour change: A/B against `main` on identical seeds (both regimes
+  where relevant), runs linked — see CONTRIBUTING.md
+- wire-format change: `kWireVersion` bumped, both adapter headers + `test_codec` + `docs/wire-format.md` updated
+- docs-only: link check
+-->
+
+## Record
+
+<!-- Delete what doesn't apply:
+- ADR added/updated (a documented decision changed)
+- `docs/configuration.md` / `docs/fidelity.md` rows touched (a default or
+  fidelity claim changed)
+- Closes #NNN / Refs #NNN
+-->


### PR DESCRIPTION
## What & why

Closes the one remaining flagged item from the #285 docs audit that is fixable from the tree (repo description/topics are GitHub settings and stay a maintainer action). Adds `.github/pull_request_template.md` encoding what every recent PR already did by convention, so external contributors see the bar before CI does:

- **title**: conventional-commit, lowercase subject (lint-title enforces it — the rule has bitten once already, PR #276's first title);
- **What & why**: link the motivating issue — findings and decisions live in issue threads per ADR-0013, and a reviewer needs the evidence chain;
- **Verification**: the core-test rule for `core/` changes (golden rule), the A/B-against-main-on-identical-seeds rule for protocol-behaviour changes (CONTRIBUTING.md), the `kWireVersion` checklist for wire changes;
- **Record**: ADR / `configuration.md` / `fidelity.md` touch-points when a decision or default changed.

Comment-only scaffolding — sections render empty until filled, and the guidance never appears in the submitted body.

## Verification

Docs-only (one new file, no links to check beyond the template's none).

## Record

Refs #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_