### PR TITLE
feat(bench): corridor-cell pheromone sampler — the #216 mechanism trace for arms that fail to shift

### DIFF
--- a/docs/benchmarks/satellite/isl-grid.md
+++ b/docs/benchmarks/satellite/isl-grid.md
@@ -103,7 +103,13 @@ port 10 is excluded from the data metrics and from the NRL control counter.
 `viaLoaded`/`viaClean`/`viaOther` count probe data packets by the interface
 they leave the source on (east / west / off-row), **from `loadStart` onward**;
 `probePdr`/`probeDelayMs` are the probe flow's own whole-run FlowMonitor
-numbers. **Pass criterion:** the congestion-aware arm
+numbers. AntHocNet runs additionally emit a `# pher` line every 30 s from
+`loadStart` — the probe source's regular/virtual pheromone toward each
+corridor's first hop for the probe destination
+(`# pher <proto> seed=<s> t=<t> eastR=<> eastV=<> westR=<> westV=<>`) — the
+mechanism trace for arms that fail to shift: it shows whether a
+clean-corridor gradient ever forms at the source and whether diffusion (the
+`V` columns) feeds it. **Pass criterion:** the congestion-aware arm
 (`--ns3::anthocnet::RoutingProtocol::EnableMacMetric=true`) moves probe
 traffic off the loaded corridor (`viaClean` dominates, or at least the
 loaded share drops materially vs the blind arms) *and* its

--- a/ns3/examples/isl-grid.cc
+++ b/ns3/examples/isl-grid.cc
@@ -58,6 +58,7 @@
 #include "ns3/olsr-module.h"
 #include "ns3/dsdv-module.h"
 #include "ns3/anthocnet-helper.h"
+#include "ns3/anthocnet-routing-protocol.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -180,6 +181,30 @@ uint32_t    g_ifClean = 0;           // src interface entering the west corridor
 uint64_t    g_viaLoaded = 0, g_viaClean = 0, g_viaOther = 0;
 uint64_t    g_probeTx = 0, g_probeRx = 0;
 double      g_probeDelay = 0.0;      // s, summed over delivered probe packets
+
+// #216 mechanism sampler: while the corridor cell is on, print the probe
+// source's regular/virtual pheromone toward each corridor's first hop for the
+// probe destination every 30 s — "# pher" diagnostic lines, invisible to the
+// results parsers like "# corridor". This is the instrument the gate x metric
+// interference investigation needed: on an arm that fails to shift, it shows
+// whether a west (clean-corridor) gradient ever forms at the source, and
+// whether diffusion (the virtual column) feeds it.
+std::string g_pherProto;
+uint32_t    g_pherSeed = 0;
+Ipv4Address g_pherEast, g_pherWest;
+
+void PherSample(Ptr<Node> src) {
+    Ptr<ns3::anthocnet::RoutingProtocol> rp =
+        src->GetObject<ns3::anthocnet::RoutingProtocol>();
+    if (!rp) return;  // baselines carry no pheromone table
+    double er, ev, wr, wv;
+    rp->GetPheromoneDiag(g_corridorDst, g_pherEast, er, ev);
+    rp->GetPheromoneDiag(g_corridorDst, g_pherWest, wr, wv);
+    std::cout << std::fixed << std::setprecision(4) << "# pher " << g_pherProto
+              << " seed=" << g_pherSeed << " t=" << Simulator::Now().GetSeconds()
+              << " eastR=" << er << " eastV=" << ev << " westR=" << wr
+              << " westV=" << wv << std::endl;
+}
 
 void CorridorTx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t iface) {
     if (Simulator::Now().GetSeconds() < g_corridorLoadAt) return;
@@ -455,6 +480,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         }
         Ptr<Ipv4L3Protocol> l3 = nodes.Get(Idx(0, 0, P))->GetObject<Ipv4L3Protocol>();
         if (l3) l3->TraceConnectWithoutContext("Tx", MakeCallback(&CorridorTx));
+
+        // #216 mechanism sampler (see the globals above): every 30 s from the
+        // load start, read the source's pheromone toward each corridor. Only
+        // anthocnet has a table — PherSample no-ops on the baselines.
+        g_pherProto = proto;
+        g_pherSeed = seed;
+        g_pherEast = nodeAddr[east];
+        g_pherWest = nodeAddr[west];
+        for (double t = P.corridorLoadAt + 0.5; t < P.simTime - 1.0; t += 30.0) {
+            Simulator::Schedule(Seconds(t), &PherSample, nodes.Get(Idx(0, 0, P)));
+        }
     }
 
     std::ostringstream rate;

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -353,6 +353,17 @@ void RoutingProtocol::onRouteChanged(::anthocnet::core::NodeAddress dest,
     m_routeChangedTrace(static_cast<uint32_t>(dest), static_cast<uint32_t>(nb), added);
 }
 
+void RoutingProtocol::GetPheromoneDiag(Ipv4Address dest, Ipv4Address neighbor,
+                                       double& regular, double& virt) const {
+    regular = 0.0;
+    virt = 0.0;
+    if (!m_logic) return;
+    const NodeAddress d = ToCore(dest);
+    const NodeAddress n = ToCore(neighbor);
+    regular = m_logic->table().getPheromoneRegular(d, n);
+    virt = m_logic->table().getPheromoneVirtual(d, n);
+}
+
 // --- item 10/A2: MAC congestion signals (core::ILinkState) ------------------
 
 int RoutingProtocol::macQueueLength(NodeAddress nextHop) const {

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -81,6 +81,14 @@ public:
     void onRouteChanged(::anthocnet::core::NodeAddress dest,
                         ::anthocnet::core::NodeAddress nb, bool added) override;
 
+    // #216 diagnostic: read the current regular and virtual pheromone for
+    // (dest, neighbour), both given as canonical Ipv4 addresses. Zeroes when
+    // the routing logic is not yet constructed. Read-only — used by the
+    // isl-grid corridor cell's "# pher" sampler to watch whether a gradient
+    // toward the clean corridor ever forms at the probe source.
+    void GetPheromoneDiag(Ipv4Address dest, Ipv4Address neighbor,
+                          double& regular, double& virt) const;
+
     // core::ILinkState (item 10/A2): supply MAC congestion signals for the
     // congestion-aware per-hop metric. Only meaningful when EnableMacMetric is
     // set; the core queries these while stamping a forward ant, naming the


### PR DESCRIPTION
## What & why

Adds the instrument the gate×metric interference investigation needs (#216, 2026-08-02 comments): on the 12 Mbps corridor the metric-ON arms fail to escape the saturated link (gate+metric **0/5** shift at 91.9 ms; metric-only 2/5), and the two candidate mechanisms — (a) hello loss on the loaded link starving the diffusion entries the gate needs to point west, vs (b) the `(Q+1)·T̂` stamps failing to build a west-vs-east gradient at the source — are indistinguishable from the existing counters. Both are directly visible in the source's pheromone table over time.

- `ns3/model/anthocnet-routing-protocol.{h,cc}` — `GetPheromoneDiag(dest, neighbour, out regular, out virt)`: a read-only diagnostic accessor over the core table via the existing canonical-address mapping; zeroes before the logic exists. **No core change** (`AntRouterLogic::table()` is already public API used by the core tests).
- `ns3/examples/isl-grid.cc` — when the corridor cell is on, sample the probe source's regular/virtual pheromone toward each corridor's first hop for the probe destination, every 30 s from `corridorLoadAt`:

  ```
  # pher <proto> seed=<s> t=<t> eastR=<> eastV=<> westR=<> westV=<>
  ```

  ~10 lines per (anthocnet, seed); `PherSample` no-ops on the baselines. Diagnostic-prefixed like `# corridor`, so invisible to the `ROW`/`ISL_RUN` parsers by the same argument recorded on PR #280.
- `docs/benchmarks/satellite/isl-grid.md` — the line format and what it answers.

## Verification

- Corridor-off runs untouched (sampler lives inside the corridor branch) — CI smoke/anchor/determinism gates see no new output; the six-version matrix is the compile check.
- Invariant checker clean (no core change, no wire change).
- Every API used already appears in the module or example (`GetObject`, `Simulator::Schedule` with a bound arg, `ToCore`, table getters).

## Record

Refs #216 (the mechanism-verdict comment lands there after the instrumented stuck-seed runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_