### PR TITLE
docs: regime comparison tables — networks side by side, mechanism live/inert per regime

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,43 @@ track the default branch; the `-<release>` tier is fixed to a release.
 
 Build them yourself or see the full matrix in [docker/README.md](docker/README.md).
 
+## Supported network regimes
+
+The same protocol binary runs in two very different networks. What is *unknown*
+in each regime is what decides which of AntHocNet's mechanisms matter there —
+the full argument is in [docs/network-regimes.md](docs/network-regimes.md).
+
+| | MANET — paper field | MANET — thesis field | Satellite — ISL +Grid |
+|---|---|---|---|
+| Harness | [`anthocnet-compare`](ns3/examples/anthocnet-compare.cc) `--scenario=paper` | [`anthocnet-compare`](ns3/examples/anthocnet-compare.cc) `--scenario=thesis` | [`isl-grid`](ns3/examples/isl-grid.cc) |
+| Nodes / field | 50 · 1500×300 m (Broch '98 calibration field) | 100 · 2400×800 m (Ducatelle 2007 §5.1.3) | rows×cols torus (default 6×6), static snapshot |
+| Mobility | RandomWaypoint, 1–20 m/s, pause 30 s | RandomWaypoint, 1–10 m/s, pause 30 s | none — topology fixed by construction |
+| Medium | 802.11b @ 2 Mbit/s, shared broadcast channel (disk or two-ray propagation) | same | point-to-point ISLs, 10 Mbit/s, 5 ms/link, one `/30` subnet each, degree 4 |
+| Topology | unknown — discovered by ants | unknown — discovered by ants | deterministic — degree/link count asserted every run |
+| Loss | collisions, retry exhaustion, mobility | same | none on the link; any loss indicts the stack |
+| Traffic | 20 CBR flows × 512 bps | 20 CBR flows × 2048 bps | 4 CBR flows × 4096 bps + adversarial cells (scripted link cut, corridor congestion) |
+| Baselines | AODV / OLSR / DSDV on identical seeds | same | same, plus (planned) precomputed shortest-path control ([#216](https://github.com/danieljoppi/AntHocNet/issues/216)) |
+| Results | [docs/benchmarks.md](docs/benchmarks.md) | [docs/benchmarks.md](docs/benchmarks.md) | [docs/benchmarks/satellite/isl-grid.md](docs/benchmarks/satellite/isl-grid.md) |
+
+**AntHocNet configuration per regime** — one attribute set (defaults below, every
+knob in [docs/configuration.md](docs/configuration.md)); what differs is which
+mechanisms are *live*, because some bind to the Wi-Fi MAC and some answer a
+problem the regime doesn't have:
+
+| Mechanism | Default | MANET (Wi-Fi) | Satellite ISL (p2p) |
+|---|---|---|---|
+| Reactive forward-ant flood (`EnableReactive`) | on | active — the route-discovery workhorse | active, but discovery is answering a question the geometry already answers ([regimes §5](docs/network-regimes.md)) |
+| Proactive ants + diffusion (`EnableProactive`, `EnableDiffusion`, 10 s) | on | active — path maintenance/improvement | active — carries the virtual gradient over the grid |
+| Hello beacons (`HelloInterval`, 1 Hz) | on | active — the only neighbour discovery | active but **redundant**: the peer is fixed and known — NRL 12.18 with nothing to discover ([#204](https://github.com/danieljoppi/AntHocNet/issues/204)) |
+| Multipath acceptance (`EnableMultipath`, a1 = 0.9 / a2 = 2.0) | on | active | active — the torus offers equal-cost corridors by construction |
+| Local repair ants (`EnableRepair`) | on | active — mobility breaks links constantly | active — but only *unscheduled* failure exercises it (scripted-cut cell) |
+| Link-failure notifications (`EnableLinkFail`) | on | active | active |
+| Hello-timeout failure detector (A) | always on | active | active |
+| Wi-Fi MAC transmit-failure detector (D) (`EnableMacFailureDetector`) | on | active | **inert** — binds to `WifiNetDevice`; no Wi-Fi MAC on an ISL |
+| A2 congestion metric (`EnableMacMetric`) | **off** | available — reads the Wi-Fi MAC queue | **inert even when on** — no queue signal on p2p until generalised ([#206](https://github.com/danieljoppi/AntHocNet/issues/206), [#292](https://github.com/danieljoppi/AntHocNet/issues/292)) |
+| Directed reactive discovery (`EnableDirectedReactive`) | **off** | A/B arm — degrades to flooding without a gradient | A/B arm — the regime it was designed to probe ([#245](https://github.com/danieljoppi/AntHocNet/issues/245)) |
+| Timing profile (`HopTime` = 3 ms, hold caps, retry timers) | thesis values | calibrated for 802.11 contention | mis-sized: delay is propagation-dominated, retuning open ([#205](https://github.com/danieljoppi/AntHocNet/issues/205)) |
+
 ## What changed from the original
 
 The original project was a whole vendored `ns-allinone-2.34` snapshot with the
@@ -165,7 +202,7 @@ History of the work is in the per-phase commits; design rationale is in
 | [docs/fidelity.md](docs/fidelity.md) | What v1.0 reproduces from the 2004 paper and where it deliberately deviates. |
 | [docs/wire-format.md](docs/wire-format.md) | Canonical on-wire ant layout, version byte, and diff vs. the original and the papers. |
 | [docs/publications/](docs/publications/README.md) | Source-of-truth digests of the 2004 paper and 2007 thesis — what every fidelity claim is checked against. |
-| [docs/network-regimes.md](docs/network-regimes.md) | Why MANET and satellite/ISL routing are different problems (the satellite research track's ground rules). |
+| [docs/network-regimes.md](docs/network-regimes.md) | Why MANET and satellite/ISL routing are different problems (the satellite research track's ground rules), and which AntHocNet mechanism is live/inert in each regime (§6). |
 | [docs/adr/](docs/adr/README.md) | Architecture Decision Records 0001–0018, indexed — the "why" behind the structure. |
 | [paper/](paper/) | JOSS software-paper draft (`paper.md`/`paper.bib`), for submission against this repo. |
 | [CONTEXT.md](CONTEXT.md) | Project orientation: domain background, repo map, current state, glossary, open questions. |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ The same protocol binary runs in two very different networks. What is *unknown*
 in each regime is what decides which of AntHocNet's mechanisms matter there —
 the full argument is in [docs/network-regimes.md](docs/network-regimes.md).
 
+**The ad-hoc family** first — MANET is one point on an axis of how constrained
+the mobility is, and each sibling changes the evaluation, not the protocol:
+
+| Family | Mobility character | What changes vs plain MANET | Status in this repo |
+|---|---|---|---|
+| **MANET** (ground, generic) | unconstrained random motion (RWP), 1–20 m/s | — the design regime | **supported** — the two fields below |
+| **VANET** (vehicles) | road-constrained (Manhattan grid, SUMO traces), 10–40 m/s, platooning | topology churn is fast but *street-shaped*; density swings block-by-block | not yet — road/trace mobility planned ([#61](https://github.com/danieljoppi/AntHocNet/issues/61), epic [#295](https://github.com/danieljoppi/AntHocNet/issues/295)) |
+| **FANET** (UAVs) | 3D smooth trajectories (Gauss-Markov), 10–30 m/s, sparse | third dimension, high link churn, energy-critical nodes | not yet — Gauss-Markov planned ([#61](https://github.com/danieljoppi/AntHocNet/issues/61), [#295](https://github.com/danieljoppi/AntHocNet/issues/295)); recent surveys rate AntHocNet strongest-in-class here, which is why it's next |
+| **LEO ISL mesh** (satellites) | deterministic orbits — topology computable years ahead | the inversion: topology known, *traffic* unknown ([regimes §3](docs/network-regimes.md)) | **supported** — static +Grid snapshot; dynamics planned (epic [#297](https://github.com/danieljoppi/AntHocNet/issues/297)) |
+
+The two supported regimes in detail:
+
 | | MANET — paper field | MANET — thesis field | Satellite — ISL +Grid |
 |---|---|---|---|
 | Harness | [`anthocnet-compare`](ns3/examples/anthocnet-compare.cc) `--scenario=paper` | [`anthocnet-compare`](ns3/examples/anthocnet-compare.cc) `--scenario=thesis` | [`isl-grid`](ns3/examples/isl-grid.cc) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 |---|---|
 | [ant-colony-routing.md](ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet. Start here for the *idea*. |
 | [architecture.md](architecture.md) | The core/adapter split, ports, and the decision flow. |
-| [network-regimes.md](network-regimes.md) | Why MANET and satellite/ISL are different routing problems — read before transferring an intuition between them. |
+| [network-regimes.md](network-regimes.md) | Why MANET and satellite/ISL are different routing problems — read before transferring an intuition between them. §6 tables which AntHocNet mechanism is live/inert in each regime. |
 
 ## Build, port, extend
 

--- a/docs/network-regimes.md
+++ b/docs/network-regimes.md
@@ -160,6 +160,45 @@ matters exactly when that view is stale or unreachable, i.e. under unpredicted
 failure and handover churn rather than under steady-state congestion. See
 [`satellite-routing-prior-art.md`](satellite-routing-prior-art.md) §5.1.
 
+## 6. What runs where — mechanism × regime
+
+Section 5 gives the argument; this table gives the inventory. One attribute set
+(defaults in [`configuration.md`](configuration.md)) serves both regimes — no
+per-regime build, no per-regime preset. What differs is which mechanisms are
+*live*: some bind to the Wi-Fi MAC and physically cannot fire on a
+point-to-point ISL, and some answer a question the regime doesn't ask. The
+harnesses set **no** protocol attributes; every A/B arm goes through explicit
+`--ns3::anthocnet::RoutingProtocol::<Attr>=<v>` overrides
+([#177](https://github.com/danieljoppi/AntHocNet/issues/177)), so a table row
+below describes the *default* run of that regime's harness.
+
+| Mechanism (attribute) | Default | MANET (Wi-Fi broadcast) | Satellite ISL (p2p grid) |
+|---|---|---|---|
+| Reactive forward-ant flood (`EnableReactive`) | on | **live, essential** — the only way to learn a topology nobody knows | live, but steerable-not-blind is the honest framing (§5): the flood re-derives direction the geometry already gives |
+| Proactive ants (`EnableProactive`, `ProactiveInterval` 10 s) + diffusion (`EnableDiffusion`) | on | live — path maintenance and improvement during a session | live — diffusion carries the virtual gradient across the grid; it is what `EnableDirectedReactive` would steer along |
+| Proactive emission gate (`ProactiveVirtualMargin`) | **0 = off** | off deliberately — the thesis's 10% gate measured harmful ([#180](https://github.com/danieljoppi/AntHocNet/issues/180)) | same |
+| Hello beacons (`HelloInterval` 1 Hz) | on | live, essential — sole neighbour-discovery mechanism | live but **redundant**: one fixed, known peer per link; measured cost NRL 12.18 on a churn-free grid ([#204](https://github.com/danieljoppi/AntHocNet/issues/204)) |
+| Multipath acceptance (`EnableMultipath`, a1 `AntAcceptanceFactor` 0.9, a2 `AntAcceptanceFactorNewHop` 2.0) | on | live — disjoint paths when density allows | live — the torus has equal-length corridors by construction; this is the half of the protocol with a real satellite claim (§5) |
+| Local repair ants (`EnableRepair`, `RepairWaitFactor` 5, `RepairTimeout` 1 s) | on | live, constantly exercised — mobility breaks links | live, exercised only by *unscheduled* failure — the `--breakLink` cell ([#260](https://github.com/danieljoppi/AntHocNet/issues/260)); scheduled failure belongs to the control's tables |
+| Link-failure notifications (`EnableLinkFail`, cooldown `LinkfailNotifyInterval` 5 s) | on | live | live |
+| Failure detector A — hello timeout | always on | live | live (and sufficient: `Ipv4::SetDown` on a cut link also raises the interface event) |
+| Failure detector D — Wi-Fi MAC transmit failures (`EnableMacFailureDetector`, `TxFailureThreshold` 3) | on | live — the fast detector ([ADR-0008](adr/0008-neighbour-liveness-two-detectors.md)) | **inert** — subscription requires a `WifiNetDevice`; a p2p ISL has none |
+| A2 congestion metric (`EnableMacMetric`, `MacServiceAlpha` 0.7) | **off** | available — reads `WifiMacQueue` (AC_BE_NQOS) occupancy | **inert even if enabled** — no Wi-Fi MAC queue to read; needs a generalised congestion signal ([#206](https://github.com/danieljoppi/AntHocNet/issues/206)); the corridor experiments ([#216](https://github.com/danieljoppi/AntHocNet/issues/216)) exposed the deeper attribution gap ([#292](https://github.com/danieljoppi/AntHocNet/issues/292)) |
+| Directed reactive discovery (`EnableDirectedReactive`) | **off** | A/B arm — no gradient yet ⇒ degrades to the stock flood | A/B arm — the regime this switch exists to probe (§5, [#245](https://github.com/danieljoppi/AntHocNet/issues/245)) |
+| Pending-queue timing (`QueueTimeout` 3 s, `ReconvHoldCap` 1 s, `RepairHoldCap` 0, `ReactiveRetryInterval` 0.25 s) | #21/#103 frontier values | live — tuned on this regime's delay tail | live but calibrated against 802.11 contention delays, not 5–18 ms propagation floors ([#205](https://github.com/danieljoppi/AntHocNet/issues/205)) |
+| Goodness timing reference (`HopTime` 3 ms) | thesis value ([#88](https://github.com/danieljoppi/AntHocNet/issues/88)) | live — matches an unloaded 802.11 hop | mis-sized — an ISL hop is 5 ms of pure propagation before queueing ([#205](https://github.com/danieljoppi/AntHocNet/issues/205)) |
+| Pheromone dynamics (`Alpha` 0.7, `Gamma` 0.7, `BetaAnts` 1.0, `BetaData` 2.0) | shipped values (thesis says 20 — [#179](https://github.com/danieljoppi/AntHocNet/issues/179)) | live | live — and on a static grid the closed-form orbit of these constants is exactly reproducible ([#216](https://github.com/danieljoppi/AntHocNet/issues/216) derivation) |
+
+Reading the table column-wise gives each regime's honest summary. **MANET:**
+everything live; the protocol is in its design regime. **Satellite ISL:** the
+discovery half runs but answers a solved problem, two Wi-Fi-coupled mechanisms
+(detector D, A2 metric) are inert, hello pays overhead for nothing, and the
+timing constants are calibrated for a medium that isn't there — while the
+multipath/load-response half faces exactly the problem the regime does have.
+That asymmetry is the satellite research programme
+([#192](https://github.com/danieljoppi/AntHocNet/issues/192)), not a defect
+list.
+
 ## Provenance of the numbers
 
 Measurements are from this repository's own CI, not from the literature:

--- a/docs/network-regimes.md
+++ b/docs/network-regimes.md
@@ -23,11 +23,12 @@ flowchart LR
     subgraph axis [" topology unpredictable  ──────────▶  computable years ahead "]
     direction LR
     A["<b>MANET</b><br/>random waypoint<br/>shared radio"]
+    F["FANET<br/>3D, smooth<br/>trajectories"]
     B["VANET<br/>road-constrained"]
     C["WSN / IoT<br/>static, energy-bound"]
     D["GEO<br/>one hop, ~119 ms"]
     E["<b>LEO ISL mesh</b><br/>+Grid, 4 links/node"]
-    A ~~~ B ~~~ C ~~~ D ~~~ E
+    A ~~~ F ~~~ B ~~~ C ~~~ D ~~~ E
     end
     style A fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
     style E fill:#e8e6f8,stroke:#5b4fc4,stroke-width:2px
@@ -37,6 +38,19 @@ GEO sits near the deterministic end but is a different shape again: a bent-pipe
 hop to a gateway, with essentially no path to choose. That is why SNS3 — the
 most mature ns-3 satellite module — is the wrong substrate for routing work
 ([#199](https://github.com/danieljoppi/AntHocNet/issues/199)).
+
+The intermediate families change the *evaluation*, not the protocol: the same
+binary runs everywhere, but each family constrains mobility differently, so
+each needs its own mobility model, scenario shape, and — sometimes — metrics
+before a number from it means anything.
+
+| Family | Mobility | What it changes | Status in this repo |
+|---|---|---|---|
+| **MANET** | unconstrained random (RWP), 1–20 m/s, 2D | nothing — the regime the 2004/2007 sources designed and tuned for | supported: the paper and thesis fields ([benchmarks](benchmarks.md)) |
+| **FANET** | 3D smooth trajectories (Gauss-Markov standard), 10–30 m/s, sparse | third dimension (our nodes sit at z = 0 today), faster link churn, energy budgets that matter | not yet: Gauss-Markov + 3D are the [#61](https://github.com/danieljoppi/AntHocNet/issues/61)/[#295](https://github.com/danieljoppi/AntHocNet/issues/295) scope. Priority rationale: 2024–2026 FANET surveys evaluate AntHocNet directly and rate it strongest among the classical protocols they test — the family where the protocol's reputation is currently made |
+| **VANET** | road-constrained (Manhattan, SUMO traces), 10–40 m/s, platooning | churn is fast but street-shaped; density swings block-by-block; RSU/infrastructure hybrids common | not yet: Manhattan / SUMO trace-driven mobility is in [#61](https://github.com/danieljoppi/AntHocNet/issues/61)/[#295](https://github.com/danieljoppi/AntHocNet/issues/295) scope |
+| **WSN / IoT** | static or near-static, energy-bound | routing problem becomes energy/sleep scheduling, not topology discovery | out of scope (energy-aware `ILinkMetric` is the nearest hook, [#145](https://github.com/danieljoppi/AntHocNet/issues/145)) |
+| **LEO ISL mesh** | deterministic orbits | the §3 inversion: topology known, traffic unknown | supported as a static +Grid snapshot; dynamics are epic [#297](https://github.com/danieljoppi/AntHocNet/issues/297) |
 
 ## 2. The two topologies
 


### PR DESCRIPTION
## What

README gains a **"Supported network regimes"** section with two tables:

1. **The three runnable networks side by side** — MANET paper field (Broch '98, 50 nodes, 1500×300 m), MANET thesis field (Ducatelle 2007 §5.1.3, 100 nodes, 2400×800 m), and the satellite ISL +Grid torus (`isl-grid`, default 6×6, static snapshot) — comparing harness, mobility, medium, topology knowability, loss regime, traffic, baselines, and where each one's results live.
2. **AntHocNet configuration per regime** — one attribute set serves both regimes (no per-regime preset; A/B arms go through explicit `--ns3::anthocnet::RoutingProtocol::<Attr>=<v>` overrides, #177). The table states per mechanism whether it is live, redundant, or inert in each regime: hello beacons essential on Wi-Fi but redundant on a fixed-peer ISL (#204, NRL 12.18); detector D and the A2 metric bind to `WifiNetDevice`/`WifiMacQueue` and are physically inert on p2p ISLs (#206, #292); `EnableDirectedReactive` is the satellite-facing A/B arm (#245); the timing profile is 802.11-calibrated and mis-sized for propagation-dominated links (#205).

`docs/network-regimes.md` gains **§6 "What runs where — mechanism × regime"**: the full-detail version of README table 2, one row per mechanism with attributes and defaults (`EnableReactive`; `EnableProactive`/`EnableDiffusion` + the deliberately-off `ProactiveVirtualMargin` gate per #180; `HelloInterval`; `EnableMultipath` a1=0.9/a2=2.0; `EnableRepair`; `EnableLinkFail`; detectors A/D; `EnableMacMetric`; `EnableDirectedReactive`; queue timing at the #21/#103 frontier; `HopTime` #88; pheromone constants vs #179), each row linking the issue where its regime behaviour was established. Ends with the column-wise reading: MANET fully in-design-regime; satellite runs the discovery half against a solved problem while the multipath/load half faces the real one — the #192 research programme stated as a table.

Docs-map entries for `network-regimes.md` (README + docs/README.md) updated to mention §6.

## Fact verification

All table facts checked against source this session: attribute names/defaults from the `TypeId` block in `ns3/model/anthocnet-routing-protocol.cc`; detector D subscription requires `WifiNetDevice` (`anthocnet-routing-protocol.cc:632`); `isl-grid` defaults `rows=6, cols=6, nFlows=4, cbrBps=4096, islDelayMs=5, islRate=10Mbps` (`ns3/examples/isl-grid.cc:644-647`); neither harness sets protocol attributes.

## Verification

Docs-only change — no code, no benchmark impact. Links checked against existing files (including the ADR-0008 filename `0008-neighbour-liveness-two-detectors.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_