### PR TITLE
docs: software-layer diagrams — stack, ant mechanisms × config switches, per-regime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ History of the work is in the per-phase commits; design rationale is in
 | [docs/README.md](docs/README.md) | **The docs map** — every page in `docs/`, grouped by what you are trying to do. |
 | [docs/ant-colony-routing.md](docs/ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet, and how they map to the code. Start here for the *idea*. |
 | [docs/architecture.md](docs/architecture.md) | Design, the core/adapter split, and the decision flow. |
+| [docs/software-layers.md](docs/software-layers.md) | Diagrams: the software stack, ant mechanisms + their config switches, and what runs (live/inert/planned) in each network regime. |
 | [docs/porting-notes.md](docs/porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, wire format, version caveats. |
 | [docs/configuration.md](docs/configuration.md) | **Every tunable parameter, its default and where that default came from**, the ns-3 attribute / NS-2 bind for it, and the calibration loop. Read before changing a knob or trusting one. |
 | [docs/benchmarks.md](docs/benchmarks.md) | Results index → [metrics](docs/benchmarks/metrics.md), [methodology](docs/benchmarks/methodology.md), per-scenario and per-sweep pages. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 |---|---|
 | [ant-colony-routing.md](ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet. Start here for the *idea*. |
 | [architecture.md](architecture.md) | The core/adapter split, ports, and the decision flow. |
+| [software-layers.md](software-layers.md) | Three diagrams: the software stack, the ant mechanisms + the switches that gate them, and what is live/inert/planned per network regime. |
 | [network-regimes.md](network-regimes.md) | Why MANET and satellite/ISL are different routing problems — read before transferring an intuition between them. §6 tables which AntHocNet mechanism is live/inert in each regime. |
 
 ## Build, port, extend

--- a/docs/software-layers.md
+++ b/docs/software-layers.md
@@ -1,0 +1,204 @@
+# Software layers and per-regime function support
+
+How the one implementation is stacked, which ant mechanisms each configuration
+switch gates, and what is live, inert, or planned in each network regime. This
+is the visual companion to [`architecture.md`](architecture.md) (the core/adapter
+split in detail) and [`network-regimes.md`](network-regimes.md) §6 (the
+mechanism × regime table in prose). The rule everything below obeys: **one
+binary, one attribute set — regimes and families change the *evaluation*, not
+the protocol.**
+
+Three diagrams, because one would be unreadable: (1) the software stack, (2) the
+ant mechanisms and the switches that gate them, (3) what runs in each regime.
+
+## 1. The software stack
+
+Bottom-up: the simulator-agnostic algorithm, the ports that keep it I/O-free,
+the per-simulator adapters, and the harnesses that drive scenarios. Nothing in
+`core/` includes a simulator header; no adapter reimplements routing logic.
+
+```mermaid
+flowchart TB
+    subgraph HARNESS["Harnesses & scenarios (ns3/examples)"]
+        direction LR
+        H1["anthocnet-compare<br/>--scenario=paper / thesis<br/>MANET fields"]
+        H2["isl-grid<br/>+Grid torus<br/>satellite ISL"]
+        H3["manet-baselines<br/>stock-only control"]
+        H4["run-scenarios.py<br/>taxonomy + sweeps"]
+    end
+
+    subgraph ADAPT["Adapters (thin — no routing logic)"]
+        direction LR
+        subgraph NS3["ns3/ contrib module"]
+            A3["RoutingProtocol : Ipv4RoutingProtocol<br/>AntHeader : ns3::Header<br/>Ns3Clock / Ns3Rng<br/><b>~30 attributes</b> (the config surface)"]
+        end
+        subgraph NS2["ns2/ source patch"]
+            A2["AntHocNetAgent : Agent<br/>AntPacketHeader (POD)<br/>Ns2Clock / Ns2Rng<br/>TCL binds"]
+        end
+    end
+
+    subgraph PORTS["Ports (adapters implement, core consumes)"]
+        direction LR
+        P1["IClock"]
+        P2["IRng"]
+        P3["INeighborProvider"]
+        P4["ITimerScheduler"]
+    end
+
+    subgraph CORE["core/ — simulator-agnostic C++"]
+        direction TB
+        C1["<b>AntRouterLogic</b> — pure: onReceiveAnt / onDataPacket → RouteDecision"]
+        C2["PheromoneTable · PheromoneEngine<br/>(evaporate / reinforce / updateRegular / updateVirtual)"]
+        C3["AntHistoryTracker — (src,seqNum) dedup, FIFO-capped"]
+        C4["AntMessage (POD) · VisitedPath · AntMessageCodec (LE wire)"]
+        C5["ILinkMetric seam — ClassicMetric (default)<br/>registry: name → instance"]
+        C1 --- C2 --- C3 --- C4 --- C5
+    end
+
+    HARNESS --> ADAPT
+    ADAPT --> PORTS
+    PORTS --> CORE
+    A3 -. "attributes set core flags" .-> C1
+
+    style CORE fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style C5 fill:#fff3d4,stroke:#c48f00
+    style PORTS fill:#eef,stroke:#5b4fc4
+```
+
+The **`ILinkMetric` seam** (highlighted) is the designed extension point:
+`ClassicMetric` is the paper's Eq.2 default; energy-aware and fuzzy-composite
+metrics (#145/#146) and the future trust factor (#302) plug in here without the
+core learning about them. The **~30 ns-3 attributes** are the entire
+configuration surface — the next diagram groups them by the mechanism they gate.
+
+## 2. Ant mechanisms and their configuration gates
+
+Every AntHocNet mechanism is an ant family plus the switch that turns it on and
+the knobs that tune it. Defaults are the shipped values
+([`configuration.md`](configuration.md) has provenance for each). **Master
+switches** gate whole mechanisms; **tuning knobs** shape them.
+
+```mermaid
+flowchart LR
+    subgraph DISC["Route discovery"]
+        R1["<b>Reactive forward ants</b><br/>flood to find an unknown route<br/>gate: EnableReactive (on)"]
+        R2["Directed reactive<br/>steer one ant along the gradient<br/>gate: EnableDirectedReactive (off — A/B arm)"]
+        R3["Multipath acceptance band<br/>admit later good ants → disjoint paths<br/>gate: EnableMultipath (on) · a1=0.9 a2=2.0"]
+    end
+
+    subgraph MAINT["Maintenance & improvement"]
+        M1["<b>Proactive forward ants</b><br/>refresh/improve active paths (10 s)<br/>gate: EnableProactive (on)"]
+        M2["Diffusion — virtual pheromone<br/>hello adverts build the virtual table<br/>gate: EnableDiffusion (on)"]
+        M3["Emission gate<br/>send only if virtual ≥ regular + margin<br/>ProactiveVirtualMargin (0 = off, per #180)"]
+    end
+
+    subgraph NBR["Neighbour & failure"]
+        N1["<b>Hello beacons</b> (1 Hz)<br/>neighbour discovery + advert carrier<br/>HelloInterval"]
+        N2["Detector A — hello timeout<br/>always on"]
+        N3["Detector D — Wi-Fi MAC tx-failure<br/>gate: EnableMacFailureDetector (on)"]
+        N4["<b>Repair ants</b> + link-fail notes<br/>gate: EnableRepair (on) · EnableLinkFail (on)"]
+    end
+
+    subgraph COST["Cost / congestion metric"]
+        K1["ClassicMetric — delay+hops (default)"]
+        K2["A2 congestion metric<br/>(MAC-queue+1)·hop-time<br/>gate: EnableMacMetric (off)"]
+        K3["timing: HopTime 3 ms · QueueTimeout 3 s<br/>ReconvHoldCap 1 s · ReactiveRetryInterval 0.25 s"]
+    end
+
+    R1 --> M1 --> N1
+    R1 -. alternative .-> R2
+    R1 --> R3
+    M1 --> M2 --> M3
+    N1 --> N2 & N3 --> N4
+    K1 -. alternative .-> K2
+
+    style R1 fill:#e2f0ed,stroke:#0f7f70
+    style M1 fill:#e2f0ed,stroke:#0f7f70
+    style N1 fill:#e2f0ed,stroke:#0f7f70
+    style R2 fill:#fff3d4,stroke:#c48f00
+    style K2 fill:#fff3d4,stroke:#c48f00
+```
+
+Green = on by default (the paper-faithful protocol). Amber = default-off A/B
+arms you opt into with an attribute. Everything is one `--ns3::anthocnet::RoutingProtocol::<Attr>=<v>`
+away; the harnesses set none of these themselves (#177).
+
+## 3. What runs in each regime
+
+Same stack, same switches — but a mechanism can be **live**, **redundant**
+(runs, pays a cost, buys nothing), **inert** (physically cannot fire), or
+**planned**. The full argument per row is
+[`network-regimes.md`](network-regimes.md) §6; this is the map.
+
+```mermaid
+flowchart TB
+    subgraph LEGEND[" "]
+        direction LR
+        L1["● live"]:::live
+        L2["◐ redundant"]:::redu
+        L3["○ inert"]:::inert
+        L4["◇ planned"]:::plan
+    end
+
+    subgraph MANET["MANET — Wi-Fi broadcast (supported)"]
+        direction TB
+        MA["● reactive discovery — the design regime"]:::live
+        MB["● proactive + diffusion"]:::live
+        MC["● hello — sole neighbour discovery"]:::live
+        MD["● multipath · repair · link-fail"]:::live
+        ME["● detector A + D (Wi-Fi MAC)"]:::live
+        MF["◐ A2 metric — available, off by default"]:::redu
+    end
+
+    subgraph SAT["Satellite ISL — p2p +Grid (supported, static)"]
+        direction TB
+        SA["● reactive discovery — but geometry already knows the graph"]:::live
+        SB["● proactive + diffusion — carries the gradient"]:::live
+        SC["◐ hello — peer is fixed & known: NRL 12.18 for nothing (#204)"]:::redu
+        SD["● multipath — equal corridors; repair only on unscheduled cut"]:::live
+        SE["○ detector D — no Wi-Fi MAC on a p2p ISL (#206)"]:::inert
+        SF["○ A2 metric — no MAC queue to read (#206/#292)"]:::inert
+        SG["◇ timing profile mis-sized — propagation-dominated (#205)"]:::plan
+    end
+
+    subgraph FAM["FANET / VANET — mobility families (planned)"]
+        direction TB
+        FA["◇ 3D Gauss-Markov (FANET) / Manhattan+SUMO (VANET) — #300 / #301"]:::plan
+        FB["● all MANET mechanisms transfer unchanged (same Wi-Fi stack)"]:::live
+        FC["◇ knob watchlist: hello rate, hold caps, a1/a2 vs churn — A/B only"]:::plan
+    end
+
+    subgraph SEC["Security profile — orthogonal to regime (v3.0.0)"]
+        direction TB
+        XA["◇ trust factor via the ILinkMetric seam — #302"]:::plan
+        XB["◇ authenticated ants (kWireVersion bump) — EnableSecurity off by default"]:::plan
+    end
+
+    MANET --> SAT --> FAM --> SEC
+
+    classDef live fill:#e2f0ed,stroke:#0f7f70,stroke-width:1.5px;
+    classDef redu fill:#fff3d4,stroke:#c48f00,stroke-width:1.5px;
+    classDef inert fill:#f6dede,stroke:#c0392b,stroke-width:1.5px;
+    classDef plan fill:#eee,stroke:#888,stroke-dasharray:4 3;
+```
+
+Reading it column-wise gives each regime's honest one-liner. **MANET:**
+everything live — the protocol is in its design regime. **Satellite:** the
+discovery half runs but answers a solved problem, hello pays for nothing, the
+two Wi-Fi-coupled mechanisms (detector D, A2) are inert, and the timing is
+mis-sized — while the multipath/load half faces the real problem
+([#192](https://github.com/danieljoppi/AntHocNet/issues/192) research
+programme). **FANET/VANET:** no protocol change — the entire Wi-Fi mechanism set
+transfers; the work is mobility models, presets, anchors, and a knob *watchlist*
+resolved by measurement, not pre-tuning
+([#300](https://github.com/danieljoppi/AntHocNet/issues/300)/[#301](https://github.com/danieljoppi/AntHocNet/issues/301)).
+**Security:** orthogonal to all of them — it enters through the `ILinkMetric`
+seam and an authenticated-ant wire field, default-off and byte-identical when
+off ([#302](https://github.com/danieljoppi/AntHocNet/issues/302)).
+
+## See also
+
+- [`architecture.md`](architecture.md) — the core/adapter split and decision flow in detail.
+- [`network-regimes.md`](network-regimes.md) — why the regimes differ (§1–§5) and the mechanism × regime table (§6).
+- [`configuration.md`](configuration.md) — every attribute, its default, its provenance, and the calibration loop.
+- [README “Supported network regimes”](../README.md#supported-network-regimes) — the family and side-by-side comparison tables.


### PR DESCRIPTION
## What

New `docs/software-layers.md` — three Mermaid diagrams, the visual companion to `architecture.md` (core/adapter split in prose) and `network-regimes.md` §6 (mechanism × regime table in prose):

1. **The software stack**, bottom-up: `core/` value types + stateful components (`AntRouterLogic`, `PheromoneTable`/`Engine`, `AntHistoryTracker`, codec) and the `ILinkMetric` seam → ports (`IClock`/`IRng`/`INeighborProvider`/`ITimerScheduler`) → the ns-2 patch and ns-3 module adapters (the ~30 ns-3 attributes flagged as the whole config surface) → harnesses/scenarios. The `ILinkMetric` seam is highlighted as the designed extension point for energy/fuzzy metrics (#145/#146) and the future trust factor (#302).
2. **Ant mechanisms × config switches**, grouped by function (discovery / maintenance / neighbour & failure / cost metric), each with the master switch that gates it and the tuning knobs that shape it, colour-coded on-by-default (paper-faithful) vs default-off A/B arm.
3. **Per-regime support**: the same stack with each mechanism marked live / redundant / inert / planned across MANET (supported), satellite ISL (supported, static), FANET/VANET (planned — #300/#301), and the orthogonal security profile (#302). Legend + column-wise reading match `network-regimes.md` §6.

Docs-map entries added in `docs/README.md` and README.

## Why

Requested: a software-layer diagram showing the implementation, the ant configurations, and the functions supporting each network type — split across diagrams since one would be unreadable.

## Fact verification

All diagram content checked against source this session: core components from `architecture.md` + `core/` headers; attribute names/defaults from the `TypeId` block in `ns3/model/anthocnet-routing-protocol.cc`; regime live/inert status from `network-regimes.md` §6 (itself source-verified last PR). Mermaid `subgraph`/`end` and bracket balance validated before commit (3 blocks, all balanced).

Docs-only — no code, no benchmark impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_