### PR TITLE
docs: ant-type reference, ADR-0019/0020, and orientation updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,11 @@ results.
 | See what v1.0 reproduces / deviates from the paper | `docs/fidelity.md` |
 | Understand a structural decision / its "why" | `docs/adr/` |
 | **Pick up open work** | GitHub issues (epics #26–#31; start with `priority:P1`) |
+| **Know which release a piece of work serves, or why something is *not* planned** | [#298](https://github.com/danieljoppi/AntHocNet/issues/298) — the 2026 roadmap: literature gap analysis → epics #293–#297, #300–#302 → release goals v1.3.0…v3.0.0, plus the non-goals with the reasoning that would reverse each |
+| Understand the ant types (what each one is for, what it writes, which switch gates it) | [`docs/ant-types.md`](docs/ant-types.md) — comparison table + lifecycle diagrams for Hello / Reactive / Proactive / Repair / LinkFail and the backward ant |
+| See the whole stack, or which mechanism is live/inert in a given regime | [`docs/software-layers.md`](docs/software-layers.md) — core → ports → adapters → harnesses, mechanisms × their config switches, and per-regime support |
+| **Add support for a new network family** (FANET, VANET, …) | [ADR-0019](docs/adr/0019-network-families-change-the-evaluation-not-the-protocol.md) — a family is a *scenario* concern: mobility model, preset, preflight rules, anchor, metrics. **Never** family-specific protocol defaults; a mis-sized constant is an issue + A/B, not a preset. Tracks: [#300](https://github.com/danieljoppi/AntHocNet/issues/300), [#301](https://github.com/danieljoppi/AntHocNet/issues/301) |
+| Work on security / trust mechanisms | [ADR-0020](docs/adr/0020-security-is-a-default-off-profile.md) — same implementation, behind attributes, **default off**, default path provably byte-identical; no fork. Track: [#302](https://github.com/danieljoppi/AntHocNet/issues/302) (v3.0.0) |
 | Record a bug / finding, or hand off across sessions | [ADR-0013](docs/adr/0013-track-bugs-and-findings-as-issues.md) (always open/update an issue) + [`docs/handoffs/`](docs/handoffs/) |
 | Maintain the NS-2 patch / wire format | `docs/porting-notes.md`, `ns2/patch/` |
 | Change the algorithm | `core/src/`, `core/include/anthocnet/core/` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -155,6 +155,22 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 - **Open work is tracked in GitHub issues** — per-area epics #26–#31 and the
   open defects (#20–#23, #51), prioritized via `priority:P1..P3` labels
   (see §10).
+- **A 2026 roadmap exists** ([#298](https://github.com/danieljoppi/AntHocNet/issues/298)):
+  a literature gap analysis (recent MANET routing · satellite/LEO · evaluation
+  methodology, all three survey reports attached to the issue) crossed against
+  this repo's capability, with release goals **v1.3.0 → v3.0.0** and one epic
+  per gap — #293 statistics (95 % CIs, paired tests), #294 metrics (AoI, p95,
+  energy-per-bit, route stability), #295 realism (mobility beyond RWP, fading,
+  TCP, scale), #296 baselines (shortest-path oracle, AOMDV/GPSR), #297 satellite
+  evaluation credibility, #300 FANET, #301 VANET, #302 security. Read the issue
+  rather than this paragraph for status; what belongs here is that the roadmap
+  is the entry point for "what should I work on and why".
+- **Documentation covers the network regimes explicitly.** `docs/network-regimes.md`
+  (why MANET ≠ satellite, plus §6's mechanism × regime table),
+  `docs/software-layers.md` (stack, ant mechanisms × their config switches, and
+  what is live/redundant/inert/planned per regime) and `docs/ant-types.md` (the
+  five ant types compared, with lifecycle diagrams) are the three pages to read
+  before assuming a behaviour transfers between networks.
 
 ## 8. What is missing / caveats
 
@@ -209,6 +225,11 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 > `priority:P1`) and the OMNeT++/INET adapter proposal #32. Each ticket has
 > evidence, a fix sketch, and acceptance criteria; `priority:P1..P3` labels
 > order the backlog (ADR-0013).
+>
+> **For sequencing** — which of those to do first, and which release it serves —
+> read the 2026 roadmap [#298](https://github.com/danieljoppi/AntHocNet/issues/298):
+> it maps every gap to an epic (#293–#297, #300–#302) and a release goal, and
+> records the deliberate non-goals with the reasoning that would reverse each.
 
 - **Do not read a static list of "open" issues from this file.** An earlier
   revision named #51 as the highest-leverage open item and listed #20/#22/#23

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ History of the work is in the per-phase commits; design rationale is in
 |----------|---------|
 | [docs/README.md](docs/README.md) | **The docs map** — every page in `docs/`, grouped by what you are trying to do. |
 | [docs/ant-colony-routing.md](docs/ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet, and how they map to the code. Start here for the *idea*. |
+| [docs/ant-types.md](docs/ant-types.md) | The five ant types side by side: what triggers each, how it travels, what it writes, which switch gates it — plus lifecycle diagrams. |
 | [docs/architecture.md](docs/architecture.md) | Design, the core/adapter split, and the decision flow. |
 | [docs/software-layers.md](docs/software-layers.md) | Diagrams: the software stack, ant mechanisms + their config switches, and what runs (live/inert/planned) in each network regime. |
 | [docs/porting-notes.md](docs/porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, wire format, version caveats. |

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ History of the work is in the per-phase commits; design rationale is in
 | [docs/wire-format.md](docs/wire-format.md) | Canonical on-wire ant layout, version byte, and diff vs. the original and the papers. |
 | [docs/publications/](docs/publications/README.md) | Source-of-truth digests of the 2004 paper and 2007 thesis — what every fidelity claim is checked against. |
 | [docs/network-regimes.md](docs/network-regimes.md) | Why MANET and satellite/ISL routing are different problems (the satellite research track's ground rules), and which AntHocNet mechanism is live/inert in each regime (§6). |
-| [docs/adr/](docs/adr/README.md) | Architecture Decision Records 0001–0018, indexed — the "why" behind the structure. |
+| [docs/adr/](docs/adr/README.md) | Architecture Decision Records 0001–0020, indexed — the "why" behind the structure. |
 | [paper/](paper/) | JOSS software-paper draft (`paper.md`/`paper.bib`), for submission against this repo. |
 | [CONTEXT.md](CONTEXT.md) | Project orientation: domain background, repo map, current state, glossary, open questions. |
 | [AGENTS.md](AGENTS.md) | Build/verify/conventions and invariants for contributors and AI agents. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 | Page | What it is |
 |---|---|
 | [ant-colony-routing.md](ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet. Start here for the *idea*. |
+| [ant-types.md](ant-types.md) | Reference for the five ant types: comparison table, lifecycle diagrams (setup, maintenance, repair), and how to observe them at runtime. |
 | [architecture.md](architecture.md) | The core/adapter split, ports, and the decision flow. |
 | [software-layers.md](software-layers.md) | Three diagrams: the software stack, the ant mechanisms + the switches that gate them, and what is live/inert/planned per network regime. |
 | [network-regimes.md](network-regimes.md) | Why MANET and satellite/ISL are different routing problems — read before transferring an intuition between them. §6 tables which AntHocNet mechanism is live/inert in each regime. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,5 +46,5 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 | Page | What it is |
 |---|---|
-| [adr/](adr/README.md) | Architecture Decision Records 0001–0018, indexed with one-line summaries. |
+| [adr/](adr/README.md) | Architecture Decision Records 0001–0020, indexed with one-line summaries. |
 | [handoffs/](handoffs/) | Dated cross-session investigation handoffs (see ADR-0013 for the issue-first discipline). |

--- a/docs/adr/0019-network-families-change-the-evaluation-not-the-protocol.md
+++ b/docs/adr/0019-network-families-change-the-evaluation-not-the-protocol.md
@@ -1,0 +1,103 @@
+# ADR-0019: Network families change the evaluation, not the protocol
+
+- **Status:** Accepted — codifies existing practice; governs the family epics
+  [#300](https://github.com/danieljoppi/AntHocNet/issues/300) (FANET),
+  [#301](https://github.com/danieljoppi/AntHocNet/issues/301) (VANET) and the
+  realism epic [#295](https://github.com/danieljoppi/AntHocNet/issues/295)
+- **Date:** 2026-08-03
+
+## Context
+
+The 2026 roadmap research ([#298](https://github.com/danieljoppi/AntHocNet/issues/298))
+put four more network families in scope — FANET, VANET, static Wi-Fi mesh, and
+(further out) underwater and space–air–ground integrated networks — on top of
+the two regimes we already run. The obvious way to support a family is to give
+it its own profile: a preset that sets protocol attributes to values suited to
+that family's mobility and density.
+
+That instinct is wrong here, and the repo already has the evidence. Two prior
+decisions bound it:
+
+- [ADR-0015](0015-satellite-substrate-lives-in-the-image.md) refused a separate
+  satellite build for the *most* different regime we support. If a constellation
+  does not justify a second binary, a faster random-waypoint field certainly
+  does not justify a second attribute profile.
+- The A/B discipline ([`configuration.md`](../configuration.md) §5,
+  [#177](https://github.com/danieljoppi/AntHocNet/issues/177)) exists because
+  every default in this repo must trace to a source or a measurement. A
+  per-family profile is a bulk edit of defaults with no measurement behind any
+  of them — precisely the thing the discipline forbids, wearing a scenario's
+  clothes.
+
+There is also a fidelity cost. `docs/fidelity.md` makes claims about *the*
+protocol. A protocol whose constants depend on which preset you selected has no
+single fidelity story, and every claim would need a "which profile?" qualifier.
+
+## Decision
+
+**A network family is a scenario concern, not a protocol concern. Adding
+family support means adding mobility models, presets, preflight rules,
+anchors and metrics — never a family-specific set of protocol attribute
+defaults.**
+
+Concretely, adding a family may add:
+
+- a mobility model (`GaussMarkov`, Manhattan/SUMO trace import, …) and, if the
+  family needs it, harness plumbing such as the z-axis for 3D;
+- a `--scenario=<family>` preset fixing *scenario* knobs — node count, field,
+  speed, pause, traffic — with recorded provenance, exactly as `paper` and
+  `thesis` do;
+- `scenario_check.py` preflight coherence rules for the knobs it introduces;
+- its own `anchors.yml` entry (a floor from another family does not transfer);
+- metrics the family's literature expects.
+
+It may **not** add: a different `HelloInterval`, `QueueTimeout`, acceptance
+factor, or any other protocol default selected by family.
+
+When a run suggests a protocol constant is mis-sized for a family, that is a
+finding, not a preset: it opens an issue, gets an A/B on identical seeds, and —
+if the delta holds — changes the value **for everyone**, or becomes a gated
+mechanism with its own default-off switch. The satellite regime already works
+this way: the propagation-dominated timing mismatch is
+[#205](https://github.com/danieljoppi/AntHocNet/issues/205), an open ticket with
+measurements pending, not a `--scenario=satellite` block that quietly retunes
+`HopTime`.
+
+## What this does *not* claim
+
+It does not claim the protocol performs equally well everywhere, or that no
+constant will ever need to vary. It claims that **variation must be earned by
+measurement and expressed as a gated mechanism**, so that one binary with one
+set of defaults remains the thing being evaluated. The mechanism × regime table
+in [`network-regimes.md`](../network-regimes.md) §6 is the honest ledger of what
+that costs: on an ISL link, hello beacons are redundant and two Wi-Fi-coupled
+mechanisms are inert, and we report that rather than papering over it with a
+satellite profile.
+
+## Alternatives considered
+
+- **Per-family attribute profiles.** Rejected above: unmeasured bulk default
+  changes, and it dissolves the single fidelity story.
+- **A per-family build (or fork per family).** Rejected for the same reason
+  ADR-0015 rejected a satellite build, plus a combinatorial explosion:
+  families × regimes × metric arms.
+- **Auto-tuning constants from scenario parameters** (e.g. derive
+  `HelloInterval` from speed and range). Attractive and possibly correct, but it
+  is a *protocol mechanism* — an adaptive hello timer — and must be proposed,
+  gated, and measured as one. It is not a licence to hard-code per-family
+  numbers, and nothing here forecloses it.
+
+## Consequences
+
+- Family epics are scoped as harness work. #300 and #301 both carry a "knob
+  watchlist → A/B follow-ups, not pre-tuning" clause enforcing this ADR.
+- Cross-family comparisons stay meaningful: because every family runs the same
+  protocol configuration, a ranking change between families is a property of the
+  network, not of our tuning. That is what makes the ranking-stability statement
+  in #295/#300 worth publishing.
+- The mechanism × regime table becomes a maintained artifact: each new family
+  adds a column, and "live / redundant / inert" is the honest answer where a
+  profile would have hidden the question.
+- Baselines get the same treatment: AODV/OLSR/DSDV run at stock defaults in
+  every family, so a family-specific weakness in them is visible rather than
+  tuned away.

--- a/docs/adr/0020-security-is-a-default-off-profile.md
+++ b/docs/adr/0020-security-is-a-default-off-profile.md
@@ -1,0 +1,112 @@
+# ADR-0020: Security ships as a default-off profile, not a fork
+
+- **Status:** Accepted — governs
+  [#302](https://github.com/danieljoppi/AntHocNet/issues/302), targeted at
+  **v3.0.0**; no code yet (phase 0 of that epic is the threat-model ADR that
+  will follow this one)
+- **Date:** 2026-08-03
+
+## Context
+
+Trust- and security-aware ACO routing is the most common contemporary extension
+of AntHocNet in the literature: blackhole/grayhole mitigation, trust-weighted
+next-hop selection, fuzzy-trust hybrids. The 2026 roadmap research
+([#298](https://github.com/danieljoppi/AntHocNet/issues/298)) initially recorded
+security as a **non-goal**, on the grounds that a trust-aware AntHocNet is a new
+protocol wearing the name: this repository's value is being the paper-faithful
+reference implementation, and mechanisms absent from the 2004 paper and 2007
+thesis put an asterisk on every fidelity claim.
+
+The maintainer then asked for security support anyway — with the specific
+framing that it be *our* implementation plus a configuration to enable or
+disable it. That framing is what resolves the objection, so it is worth writing
+down as a decision rather than leaving it in an epic description: the reason
+security was a non-goal was never "security is uninteresting", it was
+"unconditional protocol change dilutes fidelity". A conditional one does not.
+
+The repo already has the pattern. `EnableMacMetric`, `EnableDirectedReactive`
+([ADR-0016](0016-directed-reactive-discovery-is-gated-and-off.md)) and
+`EnableMultipath` are all mechanisms that ship off or gated so the faithful
+behaviour remains the default and the deviation stays runnable and measurable.
+Security is the largest instance of that pattern, not an exception to it.
+
+## Decision
+
+**Security ships inside the same implementation, behind attributes, default
+off — and the default path must remain byte-identical to the paper-faithful
+protocol.**
+
+Four binding constraints:
+
+1. **One implementation, no fork.** All logic lives in `core/`
+   ([ADR-0002](0002-one-core-two-adapters.md),
+   [ADR-0003](0003-pure-core-returns-route-decisions.md)); adapters only expose
+   knobs. No security branch, no second binary, no `#ifdef SECURE`.
+2. **`EnableSecurity = false` by default, and provably inert when off.** Not
+   "we believe it is off" — a determinism check in the style of
+   [#129](https://github.com/danieljoppi/AntHocNet/issues/129) proves the OFF
+   path produces bit-identical traces to the pre-feature build. If the default
+   path moved, the change is wrong regardless of how well the ON path performs
+   (the [#292](https://github.com/danieljoppi/AntHocNet/issues/292) verification
+   pattern).
+3. **Wire changes obey the existing rule.** Authenticated ants add fields, so
+   `kWireVersion` bumps and the codec round-trip and fuzz coverage extend with
+   them ([ADR-0006](0006-on-wire-protocol-version.md), golden rule 4). The
+   authenticated layout is part of the documented wire format, not a private
+   extension.
+4. **Fidelity claims never cite a security-on run.** `docs/fidelity.md` marks
+   the profile as an extension; the paper-faithful subject of every fidelity
+   statement remains the default configuration.
+
+The trust signal enters through the **`ILinkMetric` seam**
+([`architecture.md`](../architecture.md)) wherever possible: that seam exists to
+let a different notion of link goodness be plugged in without the core learning
+about it, and a trust factor is exactly such a notion. This is a design
+preference, not a constraint — the epic's phase-0 ADR will decide it against the
+alternative of a trust term in the goodness composition, with the reasoning
+recorded there.
+
+## Why a new major version
+
+v3.0.0, not a minor. Not because the default behaviour changes — by constraint 2
+it must not — but because the release adds a protocol capability and on-wire
+fields beyond the paper-faithful core. That is a different *kind* of change from
+the v1.x evaluation-rigor line (statistics, metrics, realism, baselines) and the
+v2.0.0 dynamic-satellite line, and the version number should say so.
+
+## Alternatives considered
+
+- **Keep it a non-goal.** Rejected by the maintainer; and the stated reason for
+  the non-goal is fully addressed by constraints 1–4.
+- **A separate `anthocnet-secure` fork or build target.** Rejected: it doubles
+  the maintenance surface, guarantees drift, and makes the honest comparison
+  (secure vs faithful on identical seeds) harder rather than easier — the same
+  reasoning as ADR-0015.
+- **Security on by default, with a switch to disable it.** Rejected: it inverts
+  the repo's standing rule that a non-source mechanism ships off until measured,
+  and it would silently make every future benchmark a benchmark of the secured
+  protocol.
+- **Compile-time flag instead of a runtime attribute.** Rejected: a runtime
+  attribute is what makes the A/B on identical seeds possible in one binary,
+  which is how every other mechanism here is evaluated
+  ([#177](https://github.com/danieljoppi/AntHocNet/issues/177)).
+
+## Consequences
+
+- The vulnerability measurement comes first and stands alone: an attacker arm
+  (blackhole/grayhole) run against **all four protocols** is publishable before
+  any defense exists, and it is what makes a later defense delta meaningful.
+- A new benchmark obligation: the trust layer must read **NOISE** in benign
+  scenarios. A defense that costs delivery when no attacker is present is a
+  regression, and the A/B discipline is what catches it.
+- Ant authentication has a measurable, permanent overhead in `nrl_bytes`; that
+  cost is a first-class result of the epic, not a footnote.
+- [#263](https://github.com/danieljoppi/AntHocNet/issues/263) (adverts reflected
+  back at their originator) is the *accidental* instance of the forgery class
+  this profile addresses deliberately — fixing it remains independent of, and
+  prior to, any security work.
+- The mechanism × regime table ([`network-regimes.md`](../network-regimes.md)
+  §6) gains a profile that is **orthogonal** to regime: trust evidence differs
+  by medium (promiscuous overhear on Wi-Fi vs delivery feedback on
+  point-to-point ISLs), which is a phase-2 design input, not a per-regime
+  default ([ADR-0019](0019-network-families-change-the-evaluation-not-the-protocol.md)).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,8 @@ detail.
 | [0016](0016-directed-reactive-discovery-is-gated-and-off.md) | Reactive ants may follow the diffusion gradient (directed discovery), gated and default **off**. |
 | [0017](0017-linkstate-is-per-next-hop-and-regime-selected.md) | The congestion signal (`ILinkState`) is per-next-hop; its implementation is selected by what the build instantiates (wifi vs point-to-point/ISL). |
 | [0018](0018-emission-gate-compares-per-link.md) | The proactive emission gate compares virtual and regular pheromone per link, not best-vs-best — cancels the h/(h−1) hop ceiling. |
+| [0019](0019-network-families-change-the-evaluation-not-the-protocol.md) | A network family (FANET, VANET, …) is a scenario concern: mobility models, presets, preflight rules, anchors and metrics — never family-specific protocol defaults. |
+| [0020](0020-security-is-a-default-off-profile.md) | Security ships inside the same implementation behind attributes, default **off**, with the default path provably byte-identical — no fork, no second binary. |
 
 ## Adding an ADR
 

--- a/docs/ant-colony-routing.md
+++ b/docs/ant-colony-routing.md
@@ -171,6 +171,10 @@ goodness of going to destination `d` via next hop `n`. Because each
 `(destination)` can have several `(next hop)` entries, the tables together
 describe a **mesh of paths**, and data is spread over them.
 
+The sections below explain each mechanism in turn. For the five ant types side
+by side — trigger, direction, flood bound, what each writes, which switch gates
+it — see [`ant-types.md`](ant-types.md).
+
 ### Reactive route setup (on demand)
 
 A route is built only when there is traffic for it. When source `s` has data for

--- a/docs/ant-types.md
+++ b/docs/ant-types.md
@@ -1,0 +1,201 @@
+# The ant types
+
+AntHocNet's control plane is five ant types travelling in two directions. This
+page is the reference: what triggers each ant, how it moves, what it changes,
+and which switch turns it off. The *idea* behind them is in
+[`ant-colony-routing.md`](ant-colony-routing.md); where they sit in the software
+is [`software-layers.md`](software-layers.md); which ones are live in each
+network regime is [`network-regimes.md`](network-regimes.md) §6.
+
+Types and directions are declared in
+[`core/include/anthocnet/core/ant_message.h`](../core/include/anthocnet/core/ant_message.h)
+and all handling lives in one pure function —
+`AntRouterLogic::onReceiveAnt()` in
+[`core/src/ant_router_logic.cpp`](../core/src/ant_router_logic.cpp).
+
+## 1. Taxonomy: five types, two directions
+
+The wire values match the legacy `ANTTYPE*` bit flags so old traces stay
+comparable. **Direction is orthogonal to type**: three types make a round trip
+(forward out, backward home), two are one-way notifications that are never
+answered.
+
+```mermaid
+flowchart TB
+    ANT["<b>AntMessage</b><br/>type · direction · src · dst · seqNum<br/>visited[] · history[] · helloDests[]<br/>broadcastBudget · lifeAnt"]
+
+    ANT --> RT["<b>Round-trip ants</b><br/>Up → destination, Down → source"]
+    ANT --> OW["<b>One-way ants</b><br/>Up only, never answered"]
+
+    RT --> RE["<b>Reactive</b> 0x02<br/>find an unknown route"]
+    RT --> PR["<b>Proactive</b> 0x04<br/>maintain / improve a known route"]
+    RT --> RP["<b>Repair</b> 0x08<br/>rebuild a route that just broke"]
+
+    OW --> HE["<b>Hello</b> 0x01<br/>neighbour liveness + diffusion adverts"]
+    OW --> LF["<b>LinkFail</b> 0x10<br/>tell neighbours a route died"]
+
+    RE -.->|"at dst: flips"| BK["<b>direction = Down</b><br/>backward ant — the only<br/>thing that deposits pheromone"]
+    PR -.->|"at dst: flips"| BK
+    RP -.->|"at dst: flips"| BK
+
+    style RE fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style PR fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style RP fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style HE fill:#eef,stroke:#5b4fc4,stroke-width:2px
+    style LF fill:#f6dede,stroke:#c0392b,stroke-width:2px
+    style BK fill:#fff3d4,stroke:#c48f00,stroke-width:2px
+```
+
+The single most important row of the next table: **only a backward ant writes
+regular pheromone.** Forward ants gather evidence; hello adverts write the
+*virtual* table; LinkFail removes or discounts entries. Nothing else reinforces.
+
+## 2. Comparison table
+
+| | **Hello** | **Reactive** | **Proactive** | **Repair** | **LinkFail** |
+|---|---|---|---|---|---|
+| Wire value | `0x01` | `0x02` | `0x04` | `0x08` | `0x10` |
+| Purpose | neighbour liveness; carry diffusion adverts | discover a route nobody has | maintain and improve an in-use route | rebuild a route that just broke | announce that a route died |
+| Trigger | timer, every `HelloInterval` (1 s) | data packet with no route (≤1 per dest per `ReactiveRetryInterval` 0.25 s) | maintenance tick per active session (`ProactiveInterval` 10 s, session `SessionTtl` 5 s) | link/tx failure with no surviving route to that dest | neighbour loss, or repair deadline expiring |
+| Direction | Up only | Up, then Down | Up, then Down | Up, then Down | Up only |
+| Transport | broadcast, one hop | broadcast flood (unicast if `EnableDirectedReactive`) | unicast along pheromone; broadcast with prob `ProactiveBroadcastProb` 0.1 per hop to explore | broadcast | broadcast, hop by hop |
+| Flood bound | none — one hop, consumed locally | **not** per-ant (`broadcastBudget = -1`); bounded per (node, generation) by `reactiveMaxBroadcasts` (#169/#173) | `proactiveMaxBroadcasts` per path (#45) | `repairMaxBroadcasts` per path; plus `lifeAnt` lifetime | `repairMaxBroadcasts`; absorbed early if an alternate survives (#96) |
+| Payload | `helloDests[]` = (dest, best regular pheromone) adverts | `visited[]` path stack | `visited[]` path stack | `visited[]` + `lifeAnt` | `helloDests[]` = (dest, new best) — `0` means *no path left* |
+| Writes | **virtual** pheromone + neighbour set | nothing on the way out | nothing on the way out | nothing on the way out | removes/discounts **regular** pheromone at each receiver |
+| Answered by | — (consumed locally, never re-forwarded) | backward ant | backward ant | backward ant (which also cancels the repair deadline) | — |
+| Gate | `HelloInterval`; adverts need `EnableProactive` + `EnableDiffusion` | `EnableReactive` | `EnableProactive` | `EnableRepair` | `EnableLinkFail` (propagation only — the local pheromone update still applies) |
+| Hop ceiling | 1 | `maxPathLength` | `maxPathLength` | `maxPathLength` | — |
+
+And the direction that does the writing:
+
+| | **Backward ant** (`direction = Down`) |
+|---|---|
+| Created | at the destination of any Reactive / Proactive / Repair forward ant |
+| Transport | unicast, retracing `history[]` hop by hop |
+| Writes | **regular** pheromone at every node it passes — `computeBackAntState()` rebuilds the deposit from the carried path, `reinforceFromBackAnt()` applies it |
+| Deposit value | from `ILinkMetric` (default `ClassicMetric`, the paper's Eq. 2 over path time and hop count) |
+| Side effects | cancels a pending repair deadline for that destination; at the origin, returns `deliver()` so the adapter flushes queued data |
+
+## 3. Lifecycle: reactive route setup
+
+The core loop — a data packet with no route, and what it costs to get one.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App as App @ S
+    participant S as Source S
+    participant I as Intermediate nodes
+    participant D as Destination D
+
+    App->>S: data packet, no route
+    Note over S: queue the packet (RouteAction::Queue)<br/>≤1 ant per dest per ReactiveRetryInterval
+    S->>I: Reactive forward ant (broadcast)
+    Note over I: no pheromone for D →<br/>rebroadcast (bounded per node+generation)<br/>each hop appends to visited[]
+    I->>D: Reactive forward ant
+    Note over D: stamp own contribution<br/>createBackAnt(): direction = Down<br/>history[] = the path taken
+    D-->>I: Backward ant (unicast, retracing)
+    Note over I: computeBackAntState → reinforceFromBackAnt<br/><b>regular pheromone written here</b>
+    I-->>S: Backward ant
+    Note over S: deliver() → flush the queued data
+    S->>D: data now routed stochastically (BetaData = 2)
+```
+
+Multipath (`EnableMultipath`, on by default) is what makes step 6 happen more
+than once: later same-generation ants are admitted through the acceptance band
+(a1 = 0.9, a2 = 2.0 for a *new first hop*), so several backward ants deposit
+along several paths.
+
+## 4. Lifecycle: proactive maintenance and diffusion
+
+Two mechanisms that only exist while a flow is active. Hello adverts build the
+*virtual* table; proactive ants turn a promising virtual entry into a real,
+measured one.
+
+```mermaid
+flowchart LR
+    subgraph DIFF["Diffusion — every 1 s, one hop"]
+        H1["Node advertises its best<br/>regular pheromone per dest"] -->|Hello ant| H2["Neighbour writes the<br/><b>virtual</b> table (bootstrapped,<br/>discounted one hop)"]
+    end
+
+    subgraph PROA["Proactive — every 10 s, per active session"]
+        P1{"virtual ≥ regular<br/>× (1 + ProactiveVirtualMargin)?"}
+        P1 -->|"yes (margin 0 ⇒ always)"| P2["Proactive forward ant"]
+        P1 -->|no| P3["skip this tick"]
+        P2 --> P4{"per hop"}
+        P4 -->|"prob 0.9"| P5["unicast along pheromone"]
+        P4 -->|"prob 0.1<br/>ProactiveBroadcastProb"| P6["broadcast — explore"]
+        P5 & P6 --> P7["reaches dest → backward ant<br/><b>virtual guess becomes<br/>measured regular pheromone</b>"]
+    end
+
+    H2 -.->|"the gradient<br/>proactive ants test"| P1
+
+    style H2 fill:#eef,stroke:#5b4fc4
+    style P7 fill:#fff3d4,stroke:#c48f00
+```
+
+`ProactiveVirtualMargin` defaults to **0** (send every tick) — the thesis's 10 %
+gate was measured harmful in
+[#180](https://github.com/danieljoppi/AntHocNet/issues/180): it compares a
+bootstrapped estimate against a measured one, which suppressed nearly all
+maintenance and tripled reactive rediscovery.
+
+## 5. Lifecycle: failure, repair, and the death notice
+
+The only path where an ant *removes* pheromone rather than adding it.
+
+```mermaid
+flowchart TB
+    F["Link to next hop breaks<br/>(detector A: hello timeout ·<br/>detector D: Wi-Fi MAC tx failures)"]
+    F --> Q{"does a route to that dest<br/>survive via another neighbour?"}
+
+    Q -->|yes| ABS["absorb — prune the dead entry,<br/>keep forwarding<br/>(multipath, #96)"]
+    Q -->|no| RA["<b>Repair ant</b> (broadcast, lifeAnt budget)<br/>+ arm the repair deadline<br/>(RepairWaitFactor × lost path delay,<br/>else RepairTimeout)"]
+
+    RA --> W{"backward ant returns<br/>before the deadline?"}
+    W -->|yes| OK["route restored —<br/>deadline cancelled,<br/>queued data flushed"]
+    W -->|no| LFN["<b>LinkFail note</b> (broadcast)<br/>helloDests = (dest, 0.0)<br/>= no path left"]
+
+    LFN --> NB["each receiver:<br/>remove or discount its entry via<br/>the reporter, then re-propagate<br/>— unless its own best survives"]
+
+    style ABS fill:#e2f0ed,stroke:#0f7f70
+    style OK fill:#e2f0ed,stroke:#0f7f70
+    style LFN fill:#f6dede,stroke:#c0392b
+    style RA fill:#fff3d4,stroke:#c48f00
+```
+
+A LinkFail note carries the reporter's *new best* pheromone per destination, not
+just "dead": a non-zero value lets receivers re-bootstrap a discounted entry
+instead of dropping the destination entirely. `LinkfailNotifyInterval` (5 s)
+rate-limits notes about the same destination so one flapping link cannot storm
+the network ([#20](https://github.com/danieljoppi/AntHocNet/issues/20)).
+
+## 6. How to see them at runtime
+
+The types are not just a design abstraction — they are counted and traceable:
+
+- **`--diag`** on `anthocnet-compare` / `isl-grid` prints per-type Tx/Rx tallies
+  (`hello`, `reactive`, `proactive`, `repair`, `linkfail`, each split
+  forward/backward), plus first-delivery time, per-flow route-setup latency
+  ([#23](https://github.com/danieljoppi/AntHocNet/issues/23)), link-failure
+  origin/propagation/suppression counters
+  ([#20](https://github.com/danieljoppi/AntHocNet/issues/20)) and pheromone-table
+  gauges ([#133](https://github.com/danieljoppi/AntHocNet/issues/133)).
+- **ns-3 trace sources** `Tx` and `Rx` on
+  `ns3::anthocnet::RoutingProtocol` carry `(type, direction, broadcast)` per ant,
+  so an experiment can histogram the control plane without patching the core.
+- **`nrl` / `nrl_bytes`** aggregate all of it into the overhead the benchmark
+  tables report — control packets (and bytes) per delivered data packet.
+
+The planned ant-type **ablation matrix**
+([#244](https://github.com/danieljoppi/AntHocNet/issues/244)) turns the gate
+column of §2 into an experiment: disable one type at a time and measure what
+each actually buys.
+
+## See also
+
+- [`ant-colony-routing.md`](ant-colony-routing.md) — the concepts: stigmergy, ACO, AntNet, and how AntHocNet's mechanisms follow from them.
+- [`software-layers.md`](software-layers.md) — where ants sit in the stack, and the switch that gates each mechanism.
+- [`network-regimes.md`](network-regimes.md) §6 — which ant types are live, redundant, or inert on MANET vs satellite ISL.
+- [`configuration.md`](configuration.md) — every attribute named above, with its default and provenance.
+- [`wire-format.md`](wire-format.md) — the canonical on-wire ant layout and version byte.


### PR DESCRIPTION
Two docs commits on the same branch.

## 1. `docs/ant-types.md` — the ant-type reference

Four Mermaid diagrams plus two tables covering every ant the protocol emits:

1. **Taxonomy** — five types (Hello `0x01`, Reactive `0x02`, Proactive `0x04`, Repair `0x08`, LinkFail `0x10`) × two directions, drawn so the orthogonality is explicit: Reactive/Proactive/Repair make a round trip and flip to `Down` at the destination; Hello and LinkFail are one-way notifications never answered.
2. **Comparison table** — 13 rows × 5 types: wire value, purpose, trigger, direction, transport, flood bound, payload, what it writes, what answers it, gate attribute, hop ceiling. Plus a second table for the **backward ant**, which is a direction rather than a type and is the only thing that writes regular pheromone.
3. **Three lifecycle diagrams** — reactive setup (sequence: queue → flood → backward retrace → deposit → flush); proactive maintenance + diffusion (hello adverts build the virtual table; proactive ants convert a virtual guess into a measured regular entry; the 0.1 explore-broadcast branch); and the failure path (absorb vs repair ant vs LinkFail note — the only ant that *removes* pheromone).
4. **Observability** — `--diag` per-type tallies, the ns-3 `Tx`/`Rx` trace sources carrying `(type, direction, broadcast)`, `nrl`/`nrl_bytes`, and #244's ablation matrix framed as the experiment that turns the gate column into measured value.

Verified against `core/include/anthocnet/core/ant_message.h` and `core/src/ant_router_logic.cpp` — including reactive `broadcastBudget = -1` bounded per (node, generation) (#169/#173), repair `repairMaxBroadcasts` + `lifeAnt` (#45), the 0.1 explore-broadcast, hello consumed locally, LinkFail carrying `(dest, new best)` with `0.0` = no path left and absorbed when an alternate survives (#96), and the repair deadline cancelled by a returning backward ant.

## 2. ADR-0019 / ADR-0020 + orientation updates

Two decisions from the roadmap work were being applied without being written down:

- **[ADR-0019](``https://github.com/danieljoppi/AntHocNet/blob/claude/satellite-networking-simulation-dsjhay/docs/adr/0019-network-families-change-the-evaluation-not-the-protocol.md)`` — network families change the evaluation, not the protocol.** Adding a family means mobility models, a `--scenario` preset with provenance, preflight rules, its own anchor, and metrics — never family-specific protocol defaults. A constant that looks mis-sized for a family is a finding (issue + A/B), not a preset. Follows ADR-0015's precedent and the #177 discipline; preserves a single fidelity story and makes cross-family ranking comparisons meaningful. Governs #300/#301/#295.
- **[ADR-0020](https://github.com/danieljoppi/AntHocNet/blob/claude/satellite-networking-simulation-dsjhay/docs/adr/0020-security-is-a-default-off-profile.md) — security ships as a default-off profile, not a fork.** Records why the #298 non-goal was reversed and under what constraints: one implementation, `EnableSecurity=false` with the OFF path provably byte-identical (#129-style check, #292 pattern), `kWireVersion` bumped for authenticated-ant fields, fidelity claims never citing a security-on run. Explains the v3.0.0 major. Governs #302.

`CONTEXT.md` §7/§10 gain the roadmap entry point (#298) and pointers to the three regime docs; `AGENTS.md` where-to-look gains rows for the roadmap, `ant-types.md`, `software-layers.md`, and both new ADRs; ADR index and the `0001–0018` range references updated to `0001–0020`.

Docs-only — no code, no benchmark impact. `check_invariants.sh` clean; Mermaid blocks and table columns validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1