### PR TITLE
docs: twelve diagrams — class, sequence, flow, layout and accounting views of the protocol, metrics and process

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ History of the work is in the per-phase commits; design rationale is in
 | [docs/ant-colony-routing.md](docs/ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet, and how they map to the code. Start here for the *idea*. |
 | [docs/ant-types.md](docs/ant-types.md) | The five ant types side by side: what triggers each, how it travels, what it writes, which switch gates it — plus lifecycle diagrams. |
 | [docs/architecture.md](docs/architecture.md) | Design, the core/adapter split, and the decision flow. |
+| [docs/roadmap.md](docs/roadmap.md) | Where the project is going: release ladder, epic dependency graph, exit criteria per release, and what is deliberately not planned. |
 | [docs/software-layers.md](docs/software-layers.md) | Diagrams: the software stack, ant mechanisms + their config switches, and what runs (live/inert/planned) in each network regime. |
 | [docs/porting-notes.md](docs/porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, wire format, version caveats. |
 | [docs/configuration.md](docs/configuration.md) | **Every tunable parameter, its default and where that default came from**, the ns-3 attribute / NS-2 bind for it, and the calibration loop. Read before changing a knob or trusting one. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 | [ant-colony-routing.md](ant-colony-routing.md) | Concepts primer: ant foraging → ACO → AntNet → AntHocNet. Start here for the *idea*. |
 | [ant-types.md](ant-types.md) | Reference for the five ant types: comparison table, lifecycle diagrams (setup, maintenance, repair), and how to observe them at runtime. |
 | [architecture.md](architecture.md) | The core/adapter split, ports, and the decision flow. |
+| [roadmap.md](roadmap.md) | Release ladder v1.3.0→v3.0.0, the epic dependency graph, per-release exit criteria, and the deliberate non-goals. Live status lives on #298. |
 | [software-layers.md](software-layers.md) | Three diagrams: the software stack, the ant mechanisms + the switches that gate them, and what is live/inert/planned per network regime. |
 | [network-regimes.md](network-regimes.md) | Why MANET and satellite/ISL are different routing problems — read before transferring an intuition between them. §6 tables which AntHocNet mechanism is live/inert in each regime. |
 

--- a/docs/adr/0008-neighbour-liveness-two-detectors.md
+++ b/docs/adr/0008-neighbour-liveness-two-detectors.md
@@ -48,6 +48,49 @@ single `loseNeighbor(n)`:
   proactive/diffusion off suppresses only the hello pheromone payload, not the
   hellos themselves.
 
+## The two detectors on one timeline
+
+Detector A is a timer; detector D is an event. They race, and whichever fires
+first calls the same `loseNeighbor(n)` — so the diagram below is the *fast*
+case (D wins) and the *portable* case (only A exists) drawn together.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant MAC as Wi-Fi MAC (adapter)
+    participant D as Detector D<br/>tx-failure (optional)
+    participant A as Detector A<br/>hello timeout (always)
+    participant C as AntRouterLogic
+    participant N as neighbours
+
+    Note over A: last-seen touched on ANY reception
+    MAC-->>D: unicast to n fails
+    MAC-->>D: ... again
+    MAC-->>D: ... 3rd time (TxFailureThreshold, #19 debounce)
+    D->>C: loseNeighbor(n) — immediately
+    Note over A: (without D, A would wait<br/>helloInterval × allowedHelloLoss)
+    A->>C: loseNeighbor(n) — on timeout
+
+    C->>C: prune pheromone via n
+    alt an alternate next hop survives (#96)
+        Note over C: <b>absorb</b> — keep forwarding,<br/>no repair, no notification
+    else no route to the destination left
+        C->>N: Repair ant (broadcast, lifeAnt budget)
+        Note over C: arm deadline =<br/>RepairWaitFactor × lost-path delay<br/>(else RepairTimeout)
+        alt backward ant returns in time
+            N-->>C: backward ant → route restored,<br/>deadline cancelled, queue flushed
+        else deadline expires
+            C->>N: LinkFail note (dest, 0.0)<br/>= no path left
+        end
+    end
+```
+
+Reading the race is the point of having two: **A alone is correct but slow**
+(it must wait out the hello budget, and on a mobile field that is the
+reconvergence tail), while **D alone is fast but blind** — it only ever fires
+for a neighbour this node is actively transmitting to, so an idle neighbour
+that walks away is invisible to it. Neither is redundant.
+
 ## Alternatives considered
 
 - **Make `INeighborProvider` authoritative** — the core diffs successive

--- a/docs/ant-colony-routing.md
+++ b/docs/ant-colony-routing.md
@@ -308,6 +308,79 @@ break. In this codebase the liveness side uses **two independent detectors**
 (missed-hello timeout + MAC unicast failure);
 [ADR-0008](adr/0008-neighbour-liveness-two-detectors.md).
 
+### The table, and the life of one pheromone entry
+
+Each node keeps **two** tables keyed the same way — `(neighbour, destination)` —
+but written by different mechanisms and read by different consumers:
+
+```mermaid
+flowchart LR
+    subgraph NODE["node i · PheromoneTable"]
+        direction TB
+        REG["<b>regular</b> T&#94;i<sub>nd</sub><br/>written only by <b>backward ants</b><br/>= measured path goodness"]
+        VIRT["<b>virtual</b><br/>written only by <b>hello adverts</b><br/>= diffused estimate, one hop discounted"]
+    end
+
+    BA["backward ant"] -->|"updateRegular()"| REG
+    HE["hello ant advert"] -->|"updateVirtual()"| VIRT
+
+    REG -->|"BetaData = 2<br/>(greedy)"| DATA["<b>data forwarding</b>"]
+    REG -->|"BetaAnts = 1<br/>(explorative)"| ANTS["ant next-hop choice"]
+    VIRT -->|"proactive ants only"| ANTS
+    VIRT -.->|"never — ADR-0007's<br/>load-bearing invariant"| DATA
+
+    style REG fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style VIRT fill:#eef,stroke:#5b4fc4,stroke-width:2px
+    style DATA fill:#fff3d4,stroke:#c48f00
+```
+
+The asymmetry is the point: an advert says *"I can reach X"*, not *"I have
+measured a good path to X"*. Steering an **ant** by that is a cheap probe;
+steering **data** by it would be a delivery bet on unverified information. That
+is why data never reads the virtual table
+([ADR-0007](adr/0007-proactive-diffusion-gated.md)) — and
+[ADR-0016](adr/0016-directed-reactive-discovery-is-gated-and-off.md) narrowed
+the rule to *ants may be steered by it* without touching the invariant.
+
+One entry's life, on the timeline that actually runs:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as backward ant
+    participant T as PheromoneTable entry (n,d)
+    participant E as evaporation tick
+    participant S as next-hop selection
+
+    B->>T: updateRegular() — deposit from<br/>ILinkMetric(path time, hops)
+    Note over T: entry now exists and competes
+    S->>T: read: P(n) ∝ pheromone^beta
+    loop every evaporationInterval (rides the hello timer)
+        E->>T: age by alpha^(dt / evaporationInterval)<br/>time-proportional retention
+        alt aged >= minPheromone (1e-5)
+            Note over T: survives, weaker
+        else aged < minPheromone
+            E-->>T: <b>evict</b> — entry removed
+        end
+    end
+    B->>T: a later backward ant re-deposits<br/>and the decay is undone
+```
+
+Two properties worth holding onto, because they are easy to get backwards:
+
+- **Reinforcement is the signal; evaporation is a safety net.** The 2004/2007
+  sources have *no* evaporation term at all — competition between paths comes
+  from fresher, better ants depositing more. Evaporation exists here to bound
+  stale state, and is deliberately secondary
+  ([ADR-0012](adr/0012-evaporation-is-a-secondary-safety-net.md); virtual
+  entries age on the same tick and factor as regular ones since
+  [#262](https://github.com/danieljoppi/AntHocNet/issues/262)).
+- **Eviction is quiet.** Falling below `minPheromone` removes the entry with no
+  packet, no notification, no trace — which is exactly why the
+  [#216](https://github.com/danieljoppi/AntHocNet/issues/216) investigation had
+  to reconstruct the decay arithmetic by hand to explain why a route never
+  disappeared.
+
 ### A note on evaporation
 
 The original AntHocNet has **no classic evaporation term**: pheromone is kept

--- a/docs/ant-types.md
+++ b/docs/ant-types.md
@@ -106,6 +106,50 @@ than once: later same-generation ants are admitted through the acceptance band
 (a1 = 0.9, a2 = 2.0 for a *new first hop*), so several backward ants deposit
 along several paths.
 
+That band is the protocol's headline claim, so it is worth seeing the copies
+compete rather than taking it on trust. One flood, one generation `(src, seq)`,
+three copies arriving at the destination:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant S as source S
+    participant P1 as path via A<br/>(first hop A)
+    participant P2 as path via B<br/>(first hop B)
+    participant D as destination D
+
+    S->>P1: reactive ant, generation (S, seq)
+    S->>P2: same generation, different first hop
+
+    P1->>D: copy 1 — 3 hops, 40 ms
+    Note over D: first arrival sets the<br/>generation's best: hops 3, time 40 ms
+    D-->>S: backward ant → deposits path A
+
+    P2->>D: copy 2 — first hop <b>B is new</b>
+    Note over D: new first hop ⇒ a2 = 2.0 applies<br/>4 hops ≤ 3×2.0 and 70 ms ≤ 40×2.0 → <b>admit</b>
+    D-->>S: backward ant → deposits path B<br/><i>this is the disjoint path</i>
+
+    P1->>D: copy 3 — first hop A already seen
+    Note over D: same first hop ⇒ a1 = 0.9 applies<br/>5 hops > 3×0.9 → <b>reject</b>
+    Note over D: no backward ant — the flood<br/>does not become a deposit storm
+
+    Note over S: S now holds pheromone for D via<br/>BOTH A and B — data is spread over them
+```
+
+Two asymmetries in that band do the work, and both are thesis values
+([#177](https://github.com/danieljoppi/AntHocNet/issues/177)):
+
+- **a1 = 0.9 is *below* 1.0**, so for an already-seen first hop the band
+  *suppresses* rather than admits — only ants better than the best so far get
+  through. (The 2004 paper says 1.5; the 2007 thesis reports its authors ran
+  0.9, "in order to only allow the best ants through", and the thesis
+  supersedes.)
+- **a2 = 2.0 is deliberately permissive**, applied only when the first hop is
+  one no accepted ant of this generation used. That is the mechanism actively
+  *rewarding* disjointness rather than merely tolerating it — which is why
+  a2 must stay ≥ a1, or the mechanism penalises exactly what it exists to
+  create.
+
 ## 4. Lifecycle: proactive maintenance and diffusion
 
 Two mechanisms that only exist while a flow is active. Hello adverts build the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,27 +84,47 @@ The adapters implement these so the core stays I/O-free:
 
 ## Decision flow
 
-```
-incoming ant  ->  AntRouterLogic::onReceiveAnt(msg, prevHop)
-                    - reactive forward ant (enableMultipath, default on): per-
-                      generation acceptance band ([1] §3.1, #96) — a later
-                      (src,seq) copy within antAcceptanceFactor (a1=0.9, or
-                      a2=2.0 for a new first hop; thesis values, #177) of the
-                      best seen on BOTH hops and travel time is admitted, so
-                      several good paths get laid down; all other ants (and
-                      everything when the gate is off): strict (src,seq)
-                      dedup -> Drop on duplicate
-                    - learn prevHop as neighbour
-                    - hello: update virtual table, consume
-                    - forward ant: stamp self; if dst==self spawn back ant;
-                      else select next hop (Unicast) or Broadcast
-                    - back ant: reinforce travelled link; if dst==self Deliver
-                      (flush queue); else advance one hop (Unicast)
-                  -> vector<RouteDecision>
+Two entry points, both pure, both returning `RouteDecision`s the adapter
+executes.
 
-local data    ->  AntRouterLogic::onDataPacket(dst)
-                    - route known -> Unicast
-                    - no route    -> Queue + reactive forward ant (Broadcast)
+```mermaid
+flowchart TB
+    IN(["incoming ant<br/><b>onReceiveAnt(msg, prevHop)</b>"]) --> DEDUP{"duplicate?"}
+
+    DEDUP -->|"reactive fwd ant +<br/>enableMultipath (default on)"| BAND{"within the acceptance band?<br/>a1 = 0.9, or a2 = 2.0 for a new<br/>first hop — on BOTH hops and<br/>travel time ([1] §3.1, #96/#177)"}
+    DEDUP -->|"all other ants,<br/>or gate off"| STRICT{"strict (src,seq)<br/>dedup"}
+
+    BAND -->|no| DROP1["Drop"]
+    STRICT -->|"seen"| DROP1
+    BAND -->|"yes — admit, so several<br/>good paths get laid down"| LEARN
+    STRICT -->|"fresh"| LEARN["learn prevHop as neighbour"]
+
+    LEARN --> KIND{"ant type / direction"}
+
+    KIND -->|hello| HELLO["update <b>virtual</b> table<br/>consume (never re-forwarded)"]
+    KIND -->|linkfail| LFN["apply to regular table,<br/>propagate unless our best survives"]
+
+    KIND -->|"forward ant"| FWD["stamp self"]
+    FWD --> ISDST{"dst == self?"}
+    ISDST -->|yes| SPAWN["spawn <b>back ant</b><br/>(direction = Down)"] --> UNI1["Unicast"]
+    ISDST -->|no| NEXT{"next hop known?"}
+    NEXT -->|yes| UNI2["Unicast"]
+    NEXT -->|no| BC["Broadcast<br/>(bounded per type)"]
+
+    KIND -->|"back ant"| REIN["<b>reinforce</b> the travelled link<br/>— the only pheromone write"]
+    REIN --> BDST{"dst == self?"}
+    BDST -->|yes| DELIV["Deliver<br/>(flush the pending queue)"]
+    BDST -->|no| UNI3["Unicast — advance one hop"]
+
+    DATA(["local data<br/><b>onDataPacket(dst)</b>"]) --> ROUTE{"route known?"}
+    ROUTE -->|yes| UNI4["Unicast"]
+    ROUTE -->|no| QUEUE["Queue<br/>+ reactive forward ant (Broadcast)<br/>≤1 per dest per ReactiveRetryInterval"]
+
+    style REIN fill:#fff3d4,stroke:#c48f00,stroke-width:2px
+    style HELLO fill:#eef,stroke:#5b4fc4
+    style DELIV fill:#e2f0ed,stroke:#0f7f70
+    style IN fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style DATA fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
 ```
 
 `RouteDecision { action, nextHop, message }` with

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,133 @@ adapters never reimplement routing logic.
 
 ## The core
 
+### Types and how they relate
+
+`AntRouterLogic` is the only stateful entry point; everything else is either a
+value type it moves around, a collaborator it owns, or a port it is handed.
+
+```mermaid
+classDiagram
+    class AntRouterLogic {
+        -NodeAddress address
+        -uint32 seqCounter
+        +onReceiveAnt(msg, prevHop) RouteDecision[]
+        +onDataPacket(dest, prevHop) RouteDecision[]
+        +onMaintenanceTick() RouteDecision[]
+        +reportNeighborLoss(n) RouteDecision[]
+        +reportTxFailure(next, dest) RouteDecision[]
+    }
+
+    class PheromoneTable {
+        -map regularByNeighbourDest
+        -map virtualByNeighbourDest
+        -set neighbours
+        +bestRegular(dest) double
+        +selectNextHop(dest, beta) NodeAddress
+        +setPheromoneRegular(dest, n, v)
+        +removePheromoneRegular(dest, n)
+    }
+
+    class PheromoneEngine {
+        +updateRegular(table, dest, obs)
+        +updateVirtual(table, hello)
+        +evaporateAll(table, dt)
+        +cleanNeighbor(table, n)
+    }
+
+    class AntHistoryTracker {
+        -deque insertionOrder
+        +seen(src, seq) bool
+        +remember(src, seq)
+        +clear()
+    }
+
+    class GenerationTracker {
+        +accept(src, seq, hops, time, firstHop) bool
+        +allowBroadcast(src, seq, max) bool
+        +clear()
+    }
+
+    class AntMessage {
+        +AntType type
+        +AntDirection direction
+        +NodeAddress src
+        +NodeAddress dst
+        +uint32 seqNum
+        +double timeStart
+        +double lifeAnt
+        +int broadcastBudget
+        +VisitedPath visited
+        +VisitedPath history
+        +HelloDest[] helloDests
+        +isForward() bool
+    }
+
+    class VisitedPath { +AntHop[] hops }
+    class AntHop { +NodeAddress node
+                   +double time }
+    class HelloDest { +NodeAddress node
+                      +double pheromone }
+
+    class AntMessageCodec {
+        +encode(msg) bytes
+        +decode(bytes) AntMessage
+    }
+
+    class RouteDecision {
+        +RouteAction action
+        +NodeAddress nextHop
+        +AntMessage message
+    }
+
+    class ILinkMetric {
+        <<interface>>
+        +pheromoneFor(observation) double
+    }
+    class ClassicMetric { +pheromoneFor(observation) double }
+
+    class IClock { <<interface>> +now() double }
+    class IRng { <<interface>> +uniform() double }
+    class ITimerScheduler { <<interface>> +schedule(delay, cb) }
+    class INeighborProvider { <<interface>> +neighbours() list }
+
+    AntRouterLogic *-- PheromoneTable
+    AntRouterLogic *-- PheromoneEngine
+    AntRouterLogic *-- AntHistoryTracker
+    AntRouterLogic *-- GenerationTracker
+    AntRouterLogic ..> RouteDecision : returns
+    AntRouterLogic ..> AntMessage : consumes / builds
+    AntRouterLogic o-- IClock
+    AntRouterLogic o-- IRng
+    AntRouterLogic o-- ITimerScheduler
+    AntRouterLogic o-- INeighborProvider
+    AntRouterLogic o-- ILinkMetric
+
+    PheromoneEngine ..> PheromoneTable : mutates
+    ILinkMetric <|.. ClassicMetric
+    AntMessage *-- VisitedPath
+    AntMessage *-- HelloDest
+    VisitedPath *-- AntHop
+    AntMessageCodec ..> AntMessage : encodes / decodes
+    RouteDecision *-- AntMessage
+```
+
+Three relationships carry the architecture:
+
+- **Composition (`*--`) is owned state**; the tables and trackers live and die
+  with the router logic and are never shared between nodes.
+- **Aggregation (`o--`) is injected** — every port and the link metric are
+  handed in. This is the entire reason the core compiles without a simulator:
+  there is no path from `AntRouterLogic` to a clock, a random number, or a
+  timer except through an interface someone else implements.
+- **`ILinkMetric` is the one open seam.** `ClassicMetric` (the paper's Eq. 2) is
+  the default; energy-aware and fuzzy-composite metrics
+  ([#145](https://github.com/danieljoppi/AntHocNet/issues/145),
+  [#146](https://github.com/danieljoppi/AntHocNet/issues/146)) and the planned
+  trust factor ([#302](https://github.com/danieljoppi/AntHocNet/issues/302))
+  plug in here without the core learning about any of them. Metrics are
+  stateless and const, so one process-lifetime instance is shared by every node.
+
 ### Value types
 
 - **`AntMessage`** — a plain, copyable description of an ant: type, direction,

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -219,6 +219,108 @@ is always attributable to a profile after the fact.
   comparisons are only meaningful profile-to-profile on the same scenario; the
   sanctioned A/B speed measurement is its own ticket.
 
+## The campaign loop, end to end
+
+Dispatching a run is the easy part; the loop exists so that a number cannot
+reach a document without passing the gates. Scripts do the arithmetic and the
+verdict — never eyeball a table ([ADR-0014](../adr/0014-agent-skills-are-script-first.md)).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor R as you / agent
+    participant PF as scenario_check.py<br/>preflight
+    participant GH as GitHub Actions
+    participant LOG as job log
+    participant RC as scenario_check.py<br/>results
+    participant BP as bench_parse.py /<br/>sweep_summary.py
+    participant IS as the issue
+
+    R->>PF: intended knobs (nodes, area, speed, load, windows)
+    alt preflight FAIL
+        PF-->>R: partitioned field / channel saturated /<br/>single-hop degeneracy / window vs link lifetime (#230)
+        Note over R: fix the config — cost so far: zero dispatches
+    else OK or WARN
+        PF-->>R: proceed (record what the WARN wants checked later)
+    end
+    R->>GH: actions_run_trigger (paper-benchmark / scenario-matrix)
+    Note over GH: a real point can exceed an hour —<br/>schedule a check-in, do not spin
+    GH-->>LOG: ##BENCH## · ##RUN## · # stddev · # diag
+    R->>LOG: get_job_logs (tail ~55 lines — cheap by design)
+    LOG-->>R: saved verbatim, one file per run
+    R->>RC: validate the saved cell
+    alt results FAIL
+        RC-->>R: #51-class harness regression —<br/>do not compare, publish, or quote
+    else PASS / scoped FAIL
+        RC-->>R: plausibility + anchors OK<br/>(a scoped FAIL invalidates only its metric family)
+    end
+    R->>BP: deltas, materiality, noise verdict
+    BP-->>R: IMPROVED / WORSE / MIXED / NOISE (+ paired sign test)
+    R->>IS: record verdict + run IDs (ADR-0013)
+```
+
+The two gates are not ceremony. `preflight` is what turns a misconfigured
+scenario into a zero-cost finding instead of a 115-minute one
+([#230](https://github.com/danieljoppi/AntHocNet/issues/230)), and `results` is
+what stops a harness regression from being published as a protocol result
+([#51](https://github.com/danieljoppi/AntHocNet/issues/51)).
+
+## Which check enforces what
+
+Every invariant that can block a merge or a publish, and where it lives. Anchor
+*values* are never duplicated — they are read from
+[`ns3/tools/anchors.yml`](../../ns3/tools/anchors.yml).
+
+```mermaid
+flowchart TB
+    subgraph CI["ci.yml — every push / PR (blocking)"]
+        direction TB
+        C1["core unit tests · ASan+UBSan"]
+        C2["codec fuzz (libFuzzer 60 s)"]
+        C3["NS-2 patch round-trip · adapter e2e + valgrind"]
+        C4["NS-3 build + module tests<br/>3.36 · 3.41 · 3.42 · 3.47 · 3.48"]
+        C5["<b>check-determinism.sh</b><br/>same seed twice ⇒ byte-identical<br/>(wifi + isl-grid, #129)"]
+        C6["<b>check-anchors.sh single-hop</b><br/>single_hop_pdr_min 99.0 (#51 detector)"]
+        C7["<b>check-sat-anchors.sh</b><br/>sat_single_isl_pdr_min 99.0 ·<br/>sat_hop_delay_slack_ms 1.5 (#237)"]
+        C8["core coverage (gcov) — <b>report-only</b>, no threshold (#162)"]
+    end
+
+    subgraph LINT["lint.yml — every PR"]
+        L1["Conventional-Commit PR title"]
+        L2["ruff over ns3/tools + skills"]
+        L3["<b>test_scenario_check.py</b><br/>every gate rule: one must-fire +<br/>one must-not-fire case"]
+    end
+
+    subgraph BENCH["benchmarks.yml — merge to default branch"]
+        B1["<b>Validation-anchor gate (blocks publish, #59)</b><br/>check-anchors.sh single-hop<br/>+ broch-low-mobility (aodv PDR ≥ 85.0)"]
+        B2["run the taxonomy → tables + charts"]
+        B3["auto-commit docs/benchmarks*"]
+        B1 --> B2 --> B3
+    end
+
+    subgraph MANUAL["manual campaigns"]
+        M1["paper-benchmark.yml · scenario-matrix.yml<br/>satellite-benchmark.yml"]
+        M2["gated by scenario_check.py<br/>preflight (before) + results (after)"]
+        M1 --- M2
+    end
+
+    style C5 fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style C6 fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style C7 fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style B1 fill:#fff3d4,stroke:#c48f00,stroke-width:2px
+    style L3 fill:#eef,stroke:#5b4fc4
+    style C8 fill:#eee,stroke:#888,stroke-dasharray:4 3
+```
+
+Two things this map makes obvious that prose kept hiding:
+
+- **The determinism anchor is the quietest and most load-bearing gate.** Nothing
+  else in the matrix would catch a change that makes results seed-dependent, and
+  every A/B verdict in this repo assumes identical seeds produce identical runs.
+- **Coverage is the only non-gate in the picture** (dashed): report-only by
+  decision, until a floor is chosen from measured evidence
+  ([#162](https://github.com/danieljoppi/AntHocNet/issues/162)).
+
 ## Validation anchors (known-expected results)
 
 A benchmark is only trustworthy if it reproduces a *known* result on a reference

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -71,6 +71,103 @@ same realisations. Metrics come from an NS-3 `FlowMonitor`:
   `maxPathLength` addresses) while an AODV RREQ is small and fixed. The measured
   packet-vs-byte comparison run is tracked in #132.
 
+## The metric families at a glance
+
+Five families, each measuring a different thing, each with its own validity
+rules. What follows the diagram is the per-family detail; this is the map.
+
+```mermaid
+flowchart TB
+    RUN["one run<br/>(seed, protocol, scenario)"]
+
+    RUN --> HEAD["<b>headline</b><br/>pdr · delay · delay99 · thrput<br/>jitter + jitter_eq51 · nrl + nrl_bytes<br/>delay_off50/off90 (#57)"]
+    RUN --> DROP["<b>drop causes</b> (#215)<br/>route · queue · mac · chan · ttl<br/><i>identity: pdr + Σ ≈ 100</i>"]
+    RUN --> ENER["<b>energy</b> (#209)<br/>energy_j · energy_per_pkt_j<br/>energy_res_min/mean/sd_j · first_death_s"]
+    RUN --> REOR["<b>reordering</b> (#212, RFC 4737)<br/>ratio · extent_mean/max · <b>buf_max</b>"]
+    RUN --> ROUTEQ["<b>route quality</b> (#217)<br/>path_hops_mean/max · jain_pkts<br/>path_div_used/max · path_entropy_bits"]
+
+    RUN --> DISP["<b>dispersion</b> (#28)<br/>*_sd over runs · ##RUN## per-seed rows (#128)"]
+    DISP -.->|"feeds"| CI["95% CI · paired tests<br/>(#293, planned)"]
+
+    style HEAD fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style DROP fill:#fff3d4,stroke:#c48f00
+    style ENER fill:#eef,stroke:#5b4fc4
+    style CI fill:#eee,stroke:#888,stroke-dasharray:4 3
+```
+
+**The trap each family carries**, stated once here and in detail below:
+`delay99` is survivorship-confounded across protocols (a protocol that drops
+hard packets looks better); `drop_queue_pct` misses DSDV's silent shedding
+(#229); `energy` absolutes are idle-dominated so only **deltas and spread** are
+readable; `reorder ratio/extent` measure route *flapping* rather than
+multipath, leaving **`buf_max`** as the honest multipath signal; and
+`path_div_*` is unquotable outside the dedicated cell (#230).
+
+## Where the drop-cause identity comes from
+
+Every offered packet lands in exactly one bucket. That is the whole of #215,
+and it is why the identity can be checked rather than trusted — measured
+values below are the 20-seed × 900 s disk arm
+([run 30772704321](https://github.com/danieljoppi/AntHocNet/actions/runs/30772704321)),
+percentages of offered packets:
+
+```mermaid
+sankey-beta
+offered,delivered,95.04
+offered,no route,1.88
+offered,channel loss,2.46
+offered,MAC retry exhaustion,0.52
+offered,TTL expiry,0.08
+```
+
+The five causes plus PDR sum to **99.98 %** here; the residual is data still
+queued when the run stopped, which is why the gate WARNs past 1 pp and FAILs
+past 5 pp rather than demanding exactly 100. Reading the same picture for
+AODV (84.73 delivered, 10.09 MAC) makes the contrast concrete: AntHocNet's
+losses are dominated by *route* state, AODV's by *MAC retry exhaustion*.
+
+A cause that accounts for nothing is the failure mode this instrumentation
+exists to expose — DSDV's routing-layer queue drops land in no bucket at all
+and open an 11.46 pp hole ([#229](https://github.com/danieljoppi/AntHocNet/issues/229)),
+which is why DSDV is excluded from cross-protocol drop comparisons.
+
+## How energy is accounted
+
+Not a battery model — an integration of the radio's own state trace, which is
+why its absolutes must be read carefully.
+
+```mermaid
+flowchart LR
+    PHY["WifiPhy <b>State</b> trace<br/>TX · RX · IDLE · CCA_BUSY · SWITCHING"]
+    PHY -->|"time in state × current × voltage"| INT["integrate per device"]
+    INT --> TOT["<b>energy_j</b><br/>total over all nodes"]
+    INT --> RES["<b>energy_res_*_j</b><br/>residual min / mean / <b>sd</b><br/>= forwarding-load spread"]
+    TOT -->|"÷ delivered data packets"| PER["<b>energy_per_pkt_j</b><br/>the cross-protocol comparable"]
+    RES --> DEATH["<b>first_death_s</b><br/>accounting only — the radio<br/>never actually switches off"]
+
+    style PER fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style RES fill:#eef,stroke:#5b4fc4
+    style DEATH fill:#eee,stroke:#888,stroke-dasharray:4 3
+```
+
+Three caveats that decide what may be claimed:
+
+- **Idle dominates.** At the shipped currents the idle draw is ≈0.82 W, so
+  total energy is mostly "the radio was switched on", not "the protocol worked
+  hard". Absolute joules are near-identical across protocols by construction —
+  compare **deltas** and the **residual spread**, never the totals.
+- **The modelled NIC is 802.11n while the harness runs 802.11b at 2 Mbit/s.**
+  The current values are ns-3's own provenance (Halperin, HotPower'10); they
+  are internally consistent, not a claim about the simulated radio.
+- **`first_death_s` is bookkeeping.** Energy is integrated but never enforced —
+  no node stops transmitting when its budget hits zero, so a "death" marks a
+  threshold crossing, not a topology change.
+
+`energy_per_pkt_j` is the one to quote across protocols, because it divides by
+what each protocol actually delivered; `energy_res_sd_j` is the one to quote
+about *fairness of forwarding load*, since a protocol that funnels traffic
+through a few relays drains them faster and widens the spread.
+
 ## Drop causes (#215, NS-3 only)
 
 PDR says how many packets went missing. These columns say **why**, as a

--- a/docs/porting-notes.md
+++ b/docs/porting-notes.md
@@ -23,6 +23,58 @@ These were latent in the original NS-2 module and are fixed in `core/`:
 5. **`randomDestination` never randomised.** Integer division `count/size` was
    0 for every entry but the last. Now a proper uniform draw.
 
+## What an adapter actually does (NS-2 vs NS-3)
+
+The same three steps in both: **decode to `AntMessage` → call the core →
+execute the returned `RouteDecision`s**. Only the simulator-facing calls
+differ. This is the contract a third adapter (OMNeT++/INET,
+[#32](https://github.com/danieljoppi/AntHocNet/issues/32)) has to satisfy.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SIM as simulator
+    participant AD as adapter
+    participant CO as AntRouterLogic (core)
+
+    SIM->>AD: packet arrives
+    Note over AD: NS-2: AntPacketHeader (POD, pooled)<br/>NS-3: AntHeader : ns3::Header
+    AD->>AD: decode via AntMessageCodec<br/>(canonical little-endian, shared)
+    AD->>CO: onReceiveAnt(msg, prevHop)
+    Note over CO: pure — no I/O, no simulator types.<br/>Clock/RNG reached only through ports
+    CO-->>AD: vector&lt;RouteDecision&gt;
+
+    loop each decision
+        alt Unicast / Broadcast
+            AD->>AD: encode AntMessage back to the header
+            Note over AD: NS-2: Scheduler::schedule + send()<br/>NS-3: Simulator::Schedule + Socket::SendTo
+            AD->>SIM: transmit
+        else Queue
+            AD->>AD: hold in the pending queue<br/>(released by a later Deliver)
+        else Deliver
+            AD->>SIM: hand to the local transport,<br/>flush the pending queue for that dest
+        else Drop / None
+            Note over AD: nothing leaves the node
+        end
+    end
+```
+
+Ports the adapter must supply for the core to stay I/O-free — the whole seam,
+and the entire porting checklist:
+
+| Port | NS-2 | NS-3 |
+|---|---|---|
+| `IClock` | `Scheduler::instance().clock()` | `Simulator::Now()` |
+| `IRng` | `Random` | `UniformRandomVariable` |
+| `ITimerScheduler` | `Scheduler::schedule` | `Simulator::Schedule` |
+| `INeighborProvider` | pheromone-table view (**advisory only** — never evicts, [ADR-0008](adr/0008-neighbour-liveness-two-detectors.md)) | same |
+
+The asymmetry that makes NS-2 the harder target is not in this diagram: NS-3
+receives an additive `contrib/` module, while NS-2 needs **edits inside the
+simulator's own tree**, which is why that side ships as an idempotent
+anchor-based patch ([ADR-0005](adr/0005-ns2-idempotent-anchor-patch.md)) rather
+than a drop-in — see the anchors below.
+
 ## NS-2 patch anchors
 
 `ns2/patch/apply-patch.sh` injects by these stable anchors (never line

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,106 @@
+# Roadmap
+
+The plan in one page. The authoritative, living version is
+[#298](https://github.com/danieljoppi/AntHocNet/issues/298) — it carries the
+literature gap analysis the epics came from, and issue state is always truer
+than a checked-in diagram. This page exists because the *ordering constraints*
+are the part that is hard to hold in your head, and a graph shows them better
+than prose.
+
+## Release ladder
+
+```mermaid
+flowchart LR
+    V13["<b>v1.3.0</b><br/>every number<br/>carries a CI"]
+    V14["<b>v1.4.0</b><br/>off the<br/>perfect disk"]
+    V15["<b>v1.5.0</b><br/>credible<br/>baselines"]
+    V16["<b>v1.6.0</b><br/>the family<br/>axis"]
+    V20["<b>v2.0.0</b><br/>the constellation<br/>actually moves"]
+    V30["<b>v3.0.0</b><br/>secured<br/>AntHocNet"]
+
+    V13 --> V14 --> V15 --> V16 --> V20 --> V30
+
+    style V13 fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style V20 fill:#e8e6f8,stroke:#5b4fc4,stroke-width:2px
+    style V30 fill:#f6dede,stroke:#c0392b,stroke-width:2px
+```
+
+The order is not arbitrary — statistics come first because every later claim is
+quoted with a confidence interval, and realism comes before baselines because
+adding a baseline to a scenario set you are about to change means measuring
+twice.
+
+## Epics and what blocks what
+
+Solid arrows are hard dependencies; dashed are "derisks / informs".
+
+```mermaid
+flowchart TB
+    subgraph FID["Protocol fidelity — orthogonal, land early"]
+        F179["#179 pheromone exponents<br/>(thesis says 20, we ship 1.0/2.0)"]
+        F180["#180 proactive rate + emission gate"]
+    end
+
+    E293["<b>#293</b> statistics<br/>95% CIs · paired tests · warm-up"]
+    E294["<b>#294</b> metrics<br/>AoI · p95/CDF · energy-per-bit · route stability"]
+    E295["<b>#295</b> realism<br/>mobility · fading · PHY · TCP · scale"]
+    E296["<b>#296</b> baselines<br/>oracle · AOMDV · GPSR"]
+    E300["<b>#300</b> FANET"]
+    E301["<b>#301</b> VANET"]
+    E297["<b>#297</b> satellite credibility<br/>handover metrics · calibration"]
+    E302["<b>#302</b> security<br/>default-off profile"]
+
+    SATBUILD["satellite build epics<br/>#192 #193 #194 #195 #196<br/>#208 #210 #211"]
+    ENABLE["enablers<br/>#121 affordability · #126 seed-splitting"]
+
+    ENABLE --> E293
+    F179 & F180 -.->|"change protocol character —<br/>re-baseline once, not twice"| E295
+    E293 --> E294 --> E295 --> E296
+    E295 --> E300 --> E301
+    E296 -.->|"oracle control"| E297
+    SATBUILD --> E297
+    E293 --> E302
+    F179 & F180 -.-> E302
+    E300 -.->|"high-churn cell for<br/>trust evidence"| E302
+
+    style E293 fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
+    style E297 fill:#e8e6f8,stroke:#5b4fc4,stroke-width:2px
+    style E302 fill:#f6dede,stroke:#c0392b,stroke-width:2px
+    style FID fill:#fff8e6,stroke:#c48f00
+```
+
+**The one sequencing rule worth memorising:** the fidelity fixes (#179, #180)
+change the protocol's character, so they must land *before* v1.4.0's expensive
+realism campaigns — otherwise every published grid is measured twice. They are
+otherwise independent of the epic chain.
+
+## What each release must show to ship
+
+| Release | Exit criteria |
+|---|---|
+| **v1.3.0** | Every published table carries a 95 % CI; `bench_parse --ab` reports paired-difference verdicts; runs-floor and warm-up policy documented. |
+| **v1.4.0** | Headline grid under ≥2 mobility × ≥2 channel models with a ranking-stability statement; TCP arm; a published 200-node point. |
+| **v1.5.0** | Oracle control in both suites; AOMDV and GPSR spikes resolved (working arm **or** a written infeasibility verdict with threat-to-validity text). |
+| **v1.6.0** | README family table shows ≥4 supported families, each with a results page, plus a cross-family ranking-stability statement. |
+| **v2.0.0** | A committed time-varying Walker result: scheduled handovers, failure overlay, oracle + geographic comparators, handover metric family, calibration deltas vs Hypatia/LENS. |
+| **v3.0.0** | Four-protocol vulnerability table under blackhole/grayhole; defense profile recovering PDR under attack while reading **NOISE** in benign scenarios; `EnableSecurity=false` path proven byte-identical. |
+
+## Deliberate non-goals
+
+Recorded with the reasoning that would reverse each — see the rationale comment
+on [#298](https://github.com/danieljoppi/AntHocNet/issues/298). Briefly: a DRL
+baseline is *planned but gated* (a leaky comparison would damage credibility);
+Sionna RT ray tracing is an upgrade path, not a goal; WSN/IoT (RPL's problem),
+DTN store-carry-forward (a capability the protocol structurally lacks), and
+NR-V2X sidelink (a different L2/PHY stack) are out.
+
+Security was a non-goal and was **reversed** by converting the objection into a
+design constraint ([ADR-0020](adr/0020-security-is-a-default-off-profile.md)) —
+that is the template for revisiting any of the others.
+
+## See also
+
+- [#298](https://github.com/danieljoppi/AntHocNet/issues/298) — the roadmap issue: gap analysis, the three literature surveys, live status.
+- [ADR-0019](adr/0019-network-families-change-the-evaluation-not-the-protocol.md) — why family support is scenario work, never per-family protocol defaults.
+- [ADR-0020](adr/0020-security-is-a-default-off-profile.md) — why security is a default-off profile rather than a fork.
+- [`network-regimes.md`](network-regimes.md) · [`software-layers.md`](software-layers.md) · [`ant-types.md`](ant-types.md) — the regime and mechanism references the epics build on.

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -23,6 +23,29 @@ we do *not* negotiate alternative layouts.
 
 ## Frame layout (current code)
 
+The fixed 37-byte head, then three length-prefixed variable arrays:
+
+```mermaid
+packet-beta
+0-7: "version (u8)"
+8-15: "type (u8)"
+16-23: "direction (u8)"
+24-55: "src (i32)"
+56-87: "dst (i32)"
+88-119: "seqNum (u32)"
+120-183: "timeStart (f64)"
+184-247: "lifeAnt (f64)"
+248-279: "broadcastBudget (i32)"
+280-295: "nVisited (u16)"
+296-359: "visited[] — 12 bytes per AntHop, then nHistory / history[] / nHello / helloDests[]"
+```
+
+Everything after `nVisited` is variable-length and repeats the same shape:
+a `u16` count followed by that many 12-byte records (`{i32 node; f64 value}`).
+Each count is rejected on decode if it exceeds its cap — `kMaxVisitedOnWire`,
+`kMaxHistoryOnWire`, `kMaxHelloOnWire` — so a malformed or hostile frame cannot
+allocate unboundedly. Byte offsets and semantics per field:
+
 | Offset | Field | Type | Bytes | Meaning |
 |-------:|-------|------|------:|---------|
 | 0  | `version`   | `u8`     | 1 | Wire-format version (`kWireVersion`, currently `0x03`). Checked first; a mismatch is rejected in O(1). |


### PR DESCRIPTION
The full diagram set from this session, in four commits. Mixed forms, each chosen to fit its subject: **1 class diagram, 5 sequence diagrams, 4 flowcharts, 1 packet layout, 1 Sankey.**

## Structure

- **Class diagram** (`architecture.md`) — `AntRouterLogic` with the collaborators it owns, the value types it moves, the `ILinkMetric` strategy, and the four ports. The relationship *kinds* are the payload: composition = owned per-node state; aggregation = injected, which is precisely why the core compiles without a simulator; `ILinkMetric` = the single open seam where #145/#146 metrics and the #302 trust factor attach.
- **Decision flow** (`architecture.md`) — the ASCII block redrawn: both entry points, the acceptance band vs strict dedup split, and the backward-ant reinforce highlighted as the only pheromone write.
- **Wire-format layout** (`wire-format.md`) — the fixed 37-byte head as a packet diagram, plus the repeating `u16 count + 12-byte records` shape and the decode caps that stop a malformed frame allocating unboundedly.

## Behaviour over time (sequence diagrams)

- **Multipath acceptance band** (`ant-types.md`) — one generation, three copies: a2=2.0 admitting the disjoint first hop, a1=0.9 rejecting a worse copy on a seen hop, so a flood doesn't become a deposit storm. Notes why a1 sits *below* 1.0 (thesis value, superseding the paper's 1.5) and why a2 ≥ a1 is structural.
- **Pheromone entry lifecycle** (`ant-colony-routing.md`) — deposit → evaporation ticks → eviction below `minPheromone` → re-deposit. Paired with a flowchart of the two tables and their consumer asymmetry (virtual is read by proactive ants, never by data).
- **The two failure detectors** (`adr/0008`) — drawn as the race they are, then prune → #96 absorb, or repair ant + armed deadline → backward ant or `LinkFail`.
- **The campaign loop** (`benchmarks/methodology.md`) — preflight → dispatch → fetch → results → parse → record, both failure branches drawn.
- **Adapter contract** (`porting-notes.md`) — decode → `onReceiveAnt` → execute decisions, with per-simulator calls named. The contract an OMNeT++ adapter (#32) must satisfy.

## Planning, process and metrics

- **`docs/roadmap.md` (new)** — release ladder v1.3.0 → v3.0.0 and the epic dependency graph. States that **#298 stays authoritative for status**, so the diagram never becomes a second source of truth for issue state.
- **CI gate map** (`methodology.md`) — every blocking invariant mapped to its workflow, with anchor *values* left in `anchors.yml` rather than duplicated. Surfaces two things prose hid: the determinism anchor is the quietest yet most load-bearing gate, and coverage is the only non-gate in the picture.
- **Metric families + energy + drop-cause Sankey** (`metrics.md`) — answers "do we have anything for energy or other metrics?": we had definitions, no visuals. The Sankey is labelled with the **measured** 20-seed × 900 s disk arm (95.04 delivered, 1.88 route, 2.46 channel, 0.52 MAC, 0.08 TTL → 99.98 %), and the energy flowchart states the three caveats that decide what may be claimed — idle draw dominates so only deltas and spread are readable, the modelled NIC is 802.11n while the harness runs 802.11b, and `first_death_s` is bookkeeping since energy is never enforced.

## Conventions applied

- **No source-file line references in any diagram or doc** — line numbers rot on the next edit and a stale pointer is worse than none. Line-precise citations stay in commit messages and PR bodies, where they're pinned to a commit.
- Notation kept renderer-portable (no generics, no inline comments in class bodies, one attribute per line) since these are read on GitHub.
- All Mermaid blocks validated for their own nesting rules — flowchart `subgraph`/`end`, sequence `alt`/`loop`/`end`, and bracket balance across every block type.
- Facts verified against source, not memory: `pheromone_engine.cpp`, `ant_message.h`, `ant_router_logic.cpp`, `anchors.yml`, the workflow files, and the wire-format offset table. `check_invariants.sh` clean.

Docs-only — no code, no benchmark impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1