### PR TITLE
fix(docs): unrenderable mermaid block + CI gate, Zenodo DOI, NS-2 deprecation, and the roadmap plan

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         # sweep_summary.py predate this and carry E701s that are not this
         # change's to fix. Add new skill scripts here as they land.
         run: |
-          ruff check ns3/tools \
+          ruff check ns3/tools docs/tools \
             .claude/skills/benchmark-results/scenario_check.py \
             .claude/skills/benchmark-results/test_scenario_check.py
       - name: Benchmark-gate self-test
@@ -40,6 +40,16 @@ jobs:
         # failing the self-check its own documentation defines. Cheap (no
         # simulator, no network, ~1 s) and it runs on every PR.
         run: python3 .claude/skills/benchmark-results/test_scenario_check.py
+      - name: Mermaid render gate (docs)
+        # A sequenceDiagram message carrying &lt;/&gt; parses as balanced text
+        # locally but is a hard parse error in Mermaid's sequence grammar, so
+        # GitHub renders "Unable to render rich display" for the whole diagram.
+        # It shipped because the pre-commit check verified structure
+        # (subgraph/end, bracket balance) and never asked whether Mermaid could
+        # parse the block. Stdlib-only, <1 s, runs on every PR.
+        run: |
+          python3 docs/tools/check-mermaid.py --self-test
+          python3 docs/tools/check-mermaid.py .
       - name: Config default parity (core vs ns-2 vs ns-3)
         # A Config default that drifts in one tree only is the #252/#254
         # failure mode: proactiveInterval leaked 10 -> 2 in a PR that claimed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Note: the **software release version** (below) is distinct from the **on-wire
 protocol version** (`kWireVersion`, see [docs/wire-format.md](docs/wire-format.md)),
 which gates packet compatibility independently.
 
+## Unreleased
+
+### Deprecated
+- **NS-2 support.** `v1.2.0` is the **last release that ships the NS-2
+  adapter**; it is removed at `v2.0.0`
+  ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)). Nothing already
+  published is withdrawn — pin the `v1.2.0` tag or its immutable images
+  (`ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` / `:2.35-v1.2.0`), which stay
+  pullable and citable at that release's DOI. The simulator-agnostic `core/`,
+  its ports seam and the "no NS headers in `core/`" rule are unaffected.
+
 
 First tagged release. Establishes the simulator-agnostic architecture, both
 adapters, the benchmark harness, and reproducible CI/packaging.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,13 @@ license: GPL-2.0-only
 repository-code: "https://github.com/danieljoppi/AntHocNet"
 url: "https://github.com/danieljoppi/AntHocNet"
 doi: "10.5281/zenodo.20981979"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.20981979"
+    description: "Concept DOI — always resolves to the latest released version."
+  - type: doi
+    value: "10.5281/zenodo.21762983"
+    description: "Version DOI — v1.2.0, the release this file describes."
 keywords:
   - MANET
   - ad hoc networks

--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ The repository no longer bundles a copy of any simulator. You install AntHocNet
 onto *your own* NS-2 or NS-3 tree:
 
 - **NS-2** — installed as an idempotent, version-independent source patch
-  (`ns-2.34` / `ns-2.35`).
+  (`ns-2.34` / `ns-2.35`). **Deprecated:
+  [v1.2.0](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.2.0) is the
+  last release that ships NS-2 support** — see
+  [#307](https://github.com/danieljoppi/AntHocNet/issues/307). Pin that tag (or
+  its immutable images `ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` /
+  `:2.35-v1.2.0`) if you need it; published tags are not withdrawn.
 - **NS-3** — installed as an additive `contrib/` module (ns-3.36+, with a
   `wscript` for older waf builds).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 | Page | What it is |
 |---|---|
-| [porting-notes.md](porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, version caveats. |
+| [porting-notes.md](porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, version caveats. **NS-2 is deprecated — v1.2.0 is the last release shipping it ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)).** |
 | [wire-format.md](wire-format.md) | Canonical on-wire ant layout and the `kWireVersion` rules (golden rule 4). |
 | [configuration.md](configuration.md) | Every tunable, its default's **provenance**, the ns-3/NS-2 surface for it, and the calibration loop. |
 | [cross-validation.md](cross-validation.md) | NS-2 vs NS-3 behaviour re-validation (not bit-for-bit parity). |

--- a/docs/ant-colony-routing.md
+++ b/docs/ant-colony-routing.md
@@ -317,7 +317,7 @@ but written by different mechanisms and read by different consumers:
 flowchart LR
     subgraph NODE["node i · PheromoneTable"]
         direction TB
-        REG["<b>regular</b> T&#94;i<sub>nd</sub><br/>written only by <b>backward ants</b><br/>= measured path goodness"]
+        REG["<b>regular</b> — the paper's T(n,d)<br/>written only by <b>backward ants</b><br/>= measured path goodness"]
         VIRT["<b>virtual</b><br/>written only by <b>hello adverts</b><br/>= diffused estimate, one hop discounted"]
     end
 

--- a/docs/porting-notes.md
+++ b/docs/porting-notes.md
@@ -42,7 +42,7 @@ sequenceDiagram
     AD->>AD: decode via AntMessageCodec<br/>(canonical little-endian, shared)
     AD->>CO: onReceiveAnt(msg, prevHop)
     Note over CO: pure — no I/O, no simulator types.<br/>Clock/RNG reached only through ports
-    CO-->>AD: vector&lt;RouteDecision&gt;
+    CO-->>AD: a list of RouteDecision
 
     loop each decision
         alt Unicast / Broadcast

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,6 +49,7 @@ flowchart TB
     E301["<b>#301</b> VANET"]
     E297["<b>#297</b> satellite credibility<br/>handover metrics · calibration"]
     E302["<b>#302</b> security<br/>default-off profile"]
+    E307["<b>#307</b> remove NS-2<br/>v1.2.0 is the last release with it"]
 
     SATBUILD["satellite build epics<br/>#192 #193 #194 #195 #196<br/>#208 #210 #211"]
     ENABLE["enablers<br/>#121 affordability · #126 seed-splitting"]
@@ -61,11 +62,13 @@ flowchart TB
     SATBUILD --> E297
     E293 --> E302
     F179 & F180 -.-> E302
+    E307 -.->|"lands with the v2.0.0 major —<br/>dropping a platform is breaking"| E297
     E300 -.->|"high-churn cell for<br/>trust evidence"| E302
 
     style E293 fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
     style E297 fill:#e8e6f8,stroke:#5b4fc4,stroke-width:2px
     style E302 fill:#f6dede,stroke:#c0392b,stroke-width:2px
+    style E307 fill:#eee,stroke:#888,stroke-dasharray:4 3
     style FID fill:#fff8e6,stroke:#c48f00
 ```
 
@@ -82,8 +85,28 @@ otherwise independent of the epic chain.
 | **v1.4.0** | Headline grid under ≥2 mobility × ≥2 channel models with a ranking-stability statement; TCP arm; a published 200-node point. |
 | **v1.5.0** | Oracle control in both suites; AOMDV and GPSR spikes resolved (working arm **or** a written infeasibility verdict with threat-to-validity text). |
 | **v1.6.0** | README family table shows ≥4 supported families, each with a results page, plus a cross-family ranking-stability statement. |
-| **v2.0.0** | A committed time-varying Walker result: scheduled handovers, failure overlay, oracle + geographic comparators, handover metric family, calibration deltas vs Hypatia/LENS. |
+| **v2.0.0** | A committed time-varying Walker result: scheduled handovers, failure overlay, oracle + geographic comparators, handover metric family, calibration deltas vs Hypatia/LENS. **Also the NS-2 removal** ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)) — dropping a supported platform is breaking, so it lands with a major. |
 | **v3.0.0** | Four-protocol vulnerability table under blackhole/grayhole; defense profile recovering PDR under attack while reading **NOISE** in benign scenarios; `EnableSecurity=false` path proven byte-identical. |
+
+## Platform support
+
+**NS-2 is being retired.** `v1.2.0` is the **last release that ships the NS-2
+adapter** ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)); removal
+lands at v2.0.0. Anyone who needs NS-2 should pin the `v1.2.0` tag or its
+immutable images (`ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` /
+`:2.35-v1.2.0`) — already-published tags are not withdrawn, and v1.2.0 stays
+citable at its version DOI.
+
+The reasoning is in #307; the short version is that NS-2 is the only target
+requiring edits inside the simulator's own tree, it never got a benchmark
+harness (#25), and contemporary reviewers read NS-2 in a 2026 paper as a
+reproducibility red flag rather than a credential.
+
+What this does **not** change: the simulator-agnostic core, the ports seam, and
+the "no NS headers in `core/`" golden rule all stay. With one shipped adapter
+the *claim* of simulator-independence loses its second witness, which is why
+the OMNeT++/INET adapter ([#32](https://github.com/danieljoppi/AntHocNet/issues/32))
+stops being a nice-to-have and becomes the proof obligation.
 
 ## Deliberate non-goals
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,6 +7,31 @@ than a checked-in diagram. This page exists because the *ordering constraints*
 are the part that is hard to hold in your head, and a graph shows them better
 than prose.
 
+## How this plan is tracked
+
+Each roadmap issue carries a **`release:` label**, so every column of this plan
+is a live query rather than a diagram that drifts:
+
+| Release | Board |
+|---|---|
+| v1.3.0 | [`release:v1.3.0`](https://github.com/danieljoppi/AntHocNet/issues?q=is%3Aopen+label%3A%22release%3Av1.3.0%22) |
+| v1.4.0 | [`release:v1.4.0`](https://github.com/danieljoppi/AntHocNet/issues?q=is%3Aopen+label%3A%22release%3Av1.4.0%22) |
+| v1.5.0 | [`release:v1.5.0`](https://github.com/danieljoppi/AntHocNet/issues?q=is%3Aopen+label%3A%22release%3Av1.5.0%22) |
+| v1.6.0 | [`release:v1.6.0`](https://github.com/danieljoppi/AntHocNet/issues?q=is%3Aopen+label%3A%22release%3Av1.6.0%22) |
+| v2.0.0 | [`release:v2.0.0`](https://github.com/danieljoppi/AntHocNet/issues?q=is%3Aopen+label%3A%22release%3Av2.0.0%22) |
+| v3.0.0 | [`release:v3.0.0`](https://github.com/danieljoppi/AntHocNet/issues?q=is%3Aopen+label%3A%22release%3Av3.0.0%22) |
+| all epics | [`epic`](https://github.com/danieljoppi/AntHocNet/issues?q=is%3Aopen+label%3Aepic) |
+
+Labels, not milestones or a Projects board, because a label is visible in every
+issue list and search without leaving the issues view, and because it survives
+being edited by anyone with write access rather than needing project-level
+permissions. A Projects v2 board over the same labels is a strict addition if
+one is ever wanted — it would read these labels, not replace them.
+
+Only issues the ladder actually gates are labelled. Most of the ~90 open issues
+are unscheduled work that lands whenever it lands; putting a `release:` on
+everything would make the query useless.
+
 ## Release ladder
 
 ```mermaid
@@ -54,8 +79,13 @@ flowchart TB
 
     SATBUILD["satellite build epics<br/>#192 #193 #194 #195 #196<br/>#208 #210 #211"]
     ENABLE["enablers<br/>#121 affordability · #126 seed-splitting"]
+    I309["<b>#309</b> hold-cap sweep<br/>900 s · 20 seeds · CIs"]
+    E308["<b>#308</b> close the delay tail<br/>#21 confirmed at 12x the interval"]
 
     ENABLE --> E293
+    E293 --> I309
+    I309 --> E308
+    F179 & F180 -.->|"both move which path<br/>data takes"| E308
     F179 & F180 -.->|"change protocol character —<br/>re-baseline once, not twice"| E295
     E293 --> E294 --> E295 --> E296
     E295 --> E300 --> E301
@@ -72,6 +102,7 @@ flowchart TB
     style E302 fill:#f6dede,stroke:#c0392b,stroke-width:2px
     style E307 fill:#eee,stroke:#888,stroke-dasharray:4 3
     style E32 fill:#eaf2fb,stroke:#2c6fbb,stroke-width:2px
+    style E308 fill:#fde9e9,stroke:#c0392b,stroke-width:2px
     style FID fill:#fff8e6,stroke:#c48f00
 ```
 
@@ -84,8 +115,8 @@ otherwise independent of the epic chain.
 
 | Release | Exit criteria |
 |---|---|
-| **v1.3.0** | Every published table carries a 95 % CI; `bench_parse --ab` reports paired-difference verdicts; runs-floor and warm-up policy documented. |
-| **v1.4.0** | Headline grid under ≥2 mobility × ≥2 channel models with a ranking-stability statement; TCP arm; a published 200-node point. |
+| **v1.3.0** | Every published table carries a 95 % CI — headline done ([#110](https://github.com/danieljoppi/AntHocNet/issues/110)), pause/area/scale and the hold-cap sweep ([#309](https://github.com/danieljoppi/AntHocNet/issues/309)) outstanding; `bench_parse --ab` reports paired-difference verdicts; runs-floor and warm-up policy documented. |
+| **v1.4.0** | Headline grid under ≥2 mobility × ≥2 channel models with a ranking-stability statement; TCP arm; a published 200-node point. **Plus a verdict on the delay tail** ([#308](https://github.com/danieljoppi/AntHocNet/issues/308)) — either a measured statement that it is the price of the delivery advantage, or a change that reduces it. |
 | **v1.5.0** | Oracle control in both suites; AOMDV and GPSR spikes resolved (working arm **or** a written infeasibility verdict with threat-to-validity text). |
 | **v1.6.0** | README family table shows ≥4 supported families, each with a results page, plus a cross-family ranking-stability statement. **Plus the OMNeT++/INET adapter** ([#32](https://github.com/danieljoppi/AntHocNet/issues/32)) — VANET evaluation runs on Veins, so the adapter is what makes #301 a real arm rather than an ns-3 approximation of one. |
 | **v2.0.0** | A committed time-varying Walker result: scheduled handovers, failure overlay, oracle + geographic comparators, handover metric family, calibration deltas vs Hypatia/LENS. **Also the NS-2 removal** ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)) — dropping a supported platform is breaking, so it lands with a major. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,6 +50,7 @@ flowchart TB
     E297["<b>#297</b> satellite credibility<br/>handover metrics · calibration"]
     E302["<b>#302</b> security<br/>default-off profile"]
     E307["<b>#307</b> remove NS-2<br/>v1.2.0 is the last release with it"]
+    E32["<b>#32</b> OMNeT++/INET adapter<br/>the Veins entry ticket"]
 
     SATBUILD["satellite build epics<br/>#192 #193 #194 #195 #196<br/>#208 #210 #211"]
     ENABLE["enablers<br/>#121 affordability · #126 seed-splitting"]
@@ -63,12 +64,14 @@ flowchart TB
     E293 --> E302
     F179 & F180 -.-> E302
     E307 -.->|"lands with the v2.0.0 major —<br/>dropping a platform is breaking"| E297
+    E32 -->|"Veins is the de-facto<br/>VANET stack"| E301
     E300 -.->|"high-churn cell for<br/>trust evidence"| E302
 
     style E293 fill:#e2f0ed,stroke:#0f7f70,stroke-width:2px
     style E297 fill:#e8e6f8,stroke:#5b4fc4,stroke-width:2px
     style E302 fill:#f6dede,stroke:#c0392b,stroke-width:2px
     style E307 fill:#eee,stroke:#888,stroke-dasharray:4 3
+    style E32 fill:#eaf2fb,stroke:#2c6fbb,stroke-width:2px
     style FID fill:#fff8e6,stroke:#c48f00
 ```
 
@@ -84,7 +87,7 @@ otherwise independent of the epic chain.
 | **v1.3.0** | Every published table carries a 95 % CI; `bench_parse --ab` reports paired-difference verdicts; runs-floor and warm-up policy documented. |
 | **v1.4.0** | Headline grid under ≥2 mobility × ≥2 channel models with a ranking-stability statement; TCP arm; a published 200-node point. |
 | **v1.5.0** | Oracle control in both suites; AOMDV and GPSR spikes resolved (working arm **or** a written infeasibility verdict with threat-to-validity text). |
-| **v1.6.0** | README family table shows ≥4 supported families, each with a results page, plus a cross-family ranking-stability statement. |
+| **v1.6.0** | README family table shows ≥4 supported families, each with a results page, plus a cross-family ranking-stability statement. **Plus the OMNeT++/INET adapter** ([#32](https://github.com/danieljoppi/AntHocNet/issues/32)) — VANET evaluation runs on Veins, so the adapter is what makes #301 a real arm rather than an ns-3 approximation of one. |
 | **v2.0.0** | A committed time-varying Walker result: scheduled handovers, failure overlay, oracle + geographic comparators, handover metric family, calibration deltas vs Hypatia/LENS. **Also the NS-2 removal** ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)) — dropping a supported platform is breaking, so it lands with a major. |
 | **v3.0.0** | Four-protocol vulnerability table under blackhole/grayhole; defense profile recovering PDR under attack while reading **NOISE** in benign scenarios; `EnableSecurity=false` path proven byte-identical. |
 
@@ -103,10 +106,34 @@ harness (#25), and contemporary reviewers read NS-2 in a 2026 paper as a
 reproducibility red flag rather than a credential.
 
 What this does **not** change: the simulator-agnostic core, the ports seam, and
-the "no NS headers in `core/`" golden rule all stay. With one shipped adapter
-the *claim* of simulator-independence loses its second witness, which is why
-the OMNeT++/INET adapter ([#32](https://github.com/danieljoppi/AntHocNet/issues/32))
-stops being a nice-to-have and becomes the proof obligation.
+the "no NS headers in `core/`" golden rule all stay.
+
+### Why OMNeT++ (#32) is scheduled at v1.6.0, not v2.0.0
+
+The obvious reason to build a second adapter is to keep proving the core is
+simulator-agnostic once NS-2 is gone. That reason is **weaker than it looks**:
+`v1.2.0` is tagged, immutable and DOI-pinned, so the two-adapter demonstration
+stays permanently citable after removal. Nobody can claim the seam was never
+exercised — they can check out the tag and exercise it.
+
+The reason that does hold up is **audience**. VANET evaluation happens on
+Veins (OMNeT++ + SUMO); it is the de-facto stack for the family, and ns-3 has
+no equal-status counterpart. OMNeT++/INET is also co-dominant with ns-3 in
+contemporary MANET protocol comparisons. So the adapter is not overhead paid
+to defend an architectural claim — it is the entry ticket to the VANET epic
+([#301](https://github.com/danieljoppi/AntHocNet/issues/301)), which is why it
+is scheduled with the family axis at **v1.6.0** rather than alongside the NS-2
+removal at v2.0.0.
+
+Satellite is the counter-case and the reason not to schedule it any earlier:
+LEO/constellation work is overwhelmingly ns-3 (Hypatia, ns-3-leo), so #297
+gains nothing from an OMNeT++ adapter.
+
+**Honest caveat on the usage claim.** No bibliometric study we found reports
+2024–2026 simulator shares for this field, so "co-dominant" and "de-facto" are
+judgements from the recent MANET/VANET evaluation literature and from which
+toolchains those papers actually run on — not measured percentages. They
+should not be quoted as statistics in a publication.
 
 ## Deliberate non-goals
 

--- a/docs/tools/check-mermaid.py
+++ b/docs/tools/check-mermaid.py
@@ -29,7 +29,7 @@ import pathlib
 import re
 import sys
 
-BLOCK = re.compile(r"```mermaid\n(.*?)```", re.S)
+BLOCK = re.compile(r"```mermaid\n(.*?)```", re.DOTALL)
 # Named entities (&lt; &gt; &amp; &quot; &nbsp;) and numeric ones (&#94; &#x5e;).
 ENTITY = re.compile(r"&(?:[a-zA-Z][a-zA-Z0-9]{1,10}|#[0-9]{1,5}|#x[0-9a-fA-F]{1,4});")
 

--- a/docs/tools/check-mermaid.py
+++ b/docs/tools/check-mermaid.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Reject Mermaid blocks that GitHub will refuse to render.
+
+Why this exists
+---------------
+A ``sequenceDiagram`` message containing the HTML entities ``&lt;``/``&gt;``
+(written to express a C++ template such as ``vector<RouteDecision>``) parses
+locally as balanced text but is a hard parse error in Mermaid's sequence
+grammar, so GitHub replaces the whole diagram with "Unable to render rich
+display". It shipped because the pre-commit check verified *structure*
+(``subgraph``/``end`` nesting, bracket balance) and never asked whether Mermaid
+could actually parse the block.
+
+The rule enforced here is deliberately narrow, because a check that fires on
+innocent input gets ignored and then is not a gate (#229's lesson): HTML
+entities are never *needed* inside a Mermaid block — plain words render better
+and parse everywhere — so forbidding them outright has no false positives.
+Inline tags such as ``<b>``, ``<i>`` and ``<br/>`` are left alone; they are used
+throughout the existing diagrams and render correctly.
+
+Usage:
+    python3 docs/tools/check-mermaid.py            # scan the repo's markdown
+    python3 docs/tools/check-mermaid.py --self-test
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+BLOCK = re.compile(r"```mermaid\n(.*?)```", re.S)
+# Named entities (&lt; &gt; &amp; &quot; &nbsp;) and numeric ones (&#94; &#x5e;).
+ENTITY = re.compile(r"&(?:[a-zA-Z][a-zA-Z0-9]{1,10}|#[0-9]{1,5}|#x[0-9a-fA-F]{1,4});")
+
+
+def findings(text: str, path: str = "<input>") -> list[str]:
+    """Return one message per offending line; empty list means clean."""
+    out = []
+    for block in BLOCK.finditer(text):
+        base = text[: block.start()].count("\n") + 1  # 1-based line of the fence
+        for offset, line in enumerate(block.group(1).split("\n"), start=1):
+            for hit in ENTITY.finditer(line):
+                out.append(
+                    f"{path}:{base + offset}: HTML entity {hit.group(0)!r} inside a "
+                    f"mermaid block — write it as plain text instead "
+                    f"(entities break Mermaid's sequence grammar and GitHub "
+                    f"renders nothing)"
+                )
+    return out
+
+
+def scan(root: pathlib.Path) -> int:
+    problems = []
+    for md in sorted(root.rglob("*.md")):
+        if any(part in {".git", "node_modules"} for part in md.parts):
+            continue
+        problems += findings(md.read_text(encoding="utf-8"), str(md.relative_to(root)))
+    for line in problems:
+        print(f"FAIL: {line}")
+    print(f"checked markdown under {root}; {len(problems)} problem(s)")
+    return 1 if problems else 0
+
+
+def self_test() -> int:
+    """Every rule gets a case that must fire and one that must stay quiet."""
+    must_fire = [
+        # The exact shipped defect.
+        "```mermaid\nsequenceDiagram\n    A-->>B: vector&lt;RouteDecision&gt;\n```\n",
+        # Numeric entity in a flowchart label.
+        '```mermaid\nflowchart LR\n    A["T&#94;i"] --> B\n```\n',
+    ]
+    must_not_fire = [
+        # Inline tags and arrows are fine and are used across the docs.
+        '```mermaid\nflowchart LR\n    A["<b>bold</b><br/>next"] --> B{"q?"}\n```\n',
+        "```mermaid\nsequenceDiagram\n    A-->>B: a list of RouteDecision\n    Note over A: 5 > 3\n```\n",
+        # Entities outside a mermaid block are none of this check's business.
+        "Prose mentioning &lt;T&gt; and a table | &amp; | value |\n",
+    ]
+    failures = 0
+    for case in must_fire:
+        if not findings(case):
+            failures += 1
+            print("SELF-TEST FAIL: expected a finding, got none for:\n" + case)
+    for case in must_not_fire:
+        got = findings(case)
+        if got:
+            failures += 1
+            print(f"SELF-TEST FAIL: expected silence, got {got} for:\n" + case)
+    print("self-test:", "PASS" if not failures else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="run the rule's own cases")
+    ap.add_argument("root", nargs="?", default=".", help="directory to scan")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    return scan(pathlib.Path(args.root))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ns2/README.md
+++ b/ns2/README.md
@@ -7,6 +7,18 @@ nothing here ships a copy of NS-2.
 
 Validated targets: **ns-2.34** and **ns-2.35**.
 
+> [!WARNING]
+> **NS-2 support is deprecated.**
+> [v1.2.0](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.2.0) is the
+> **last release that ships this adapter**; it is removed at v2.0.0
+> ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)). Nothing already
+> published is withdrawn — pin the `v1.2.0` tag, or its immutable images
+> `ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` / `:2.35-v1.2.0`, and that
+> release stays citable at its own DOI. The simulator-agnostic
+> [`core/`](../core) is unaffected: it is the ns-3 adapter and any future one
+> (OMNeT++/INET, [#32](https://github.com/danieljoppi/AntHocNet/issues/32)) that
+> carry it forward.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Five commits, five separable changes; the first is the reason the PR exists.

## 1. The render bug, and a gate so it cannot recur

GitHub refused to render the adapter sequence diagram in `docs/porting-notes.md` — *"Unable to render rich display / Parse error on line 12"*. The message carried the HTML entities `&lt;`/`&gt;` to express `vector<RouteDecision>`. Balanced text, but a **hard parse error in Mermaid's sequence grammar**.

**Why it shipped:** my pre-commit validation checked *structure* — `subgraph`/`end`, `alt`/`loop`/`end`, bracket balance — and never asked whether Mermaid could **parse** the block.

**Fixes:** the message now reads `a list of RouteDecision`; `ant-colony-routing.md`'s `&#94;` (superscript in `T^i_nd`) becomes plain `the paper's T(n,d)` — that one renders fine and was found by the new gate, which is the point of having one.

**Verified with a real parser this time:** installed `mermaid-cli`, pointed puppeteer at the preinstalled chromium, and rendered **all 25 mermaid blocks**. The failure reproduced locally with byte-identical text to GitHub's error; all 25 render after the fix.

**New gate** `docs/tools/check-mermaid.py`, wired into `lint.yml`. Rejects HTML entities inside mermaid blocks — deliberately narrow, since entities are never *needed* there (so no false positives) while inline `<b>`/`<i>`/`<br/>` tags are left alone. Ships with `--self-test`: two must-fire cases, three must-stay-quiet, per the #229/#230 rule that a check must be proven to do both.

A follow-up commit fixes two ruff 0.16.0 findings on that script (`EXE001` shebang/exec bit, `FURB167` `re.S` alias). Worth recording: local ruff is 0.15.8 and pip wouldn't replace it, so a local pass was **not** evidence — the same version drift `lint.yml`'s own comment already warns about.

## 2. Zenodo DOI (#289)

`CITATION.cff` now carries both identifiers from the v1.2.0 deposition: the **concept** DOI `10.5281/zenodo.20981979` stays the top-level `doi:` (always resolves to latest, matches the README badge), with the **version** DOI `10.5281/zenodo.21762983` recorded alongside so a citation can pin to the exact release. Validated by parsing the file.

## 3. NS-2 deprecation notice (#307)

Records the decision that **`v1.2.0` is the last release shipping the NS-2 adapter**, with the notice in README, `ns2/README.md`, `docs/README.md` and `CHANGELOG.md` (Unreleased → Deprecated). Each says the same three things, because the failure mode of a deprecation is discovering it at upgrade time: last release with it, removal at v2.0.0, and **nothing already published is withdrawn** — the tag and its immutable images stay pullable and citable.

**No code removal here** — `ns2/` still builds and its CI jobs still run (all green on this PR). This is phase 1 of #307's three phases, deliberately separated because the notice is cheap and reversible while removal is breaking and has an open question in front of it (the paper's cross-simulator framing, raised on #307 for an explicit call).

## 4. OMNeT++ (#32) scheduled at v1.6.0 — correcting §3's own reasoning

The roadmap section written in commit 3 justified #32 as the *replacement witness* for simulator-independence once NS-2 goes. **That argument does not hold**, and this commit corrects it rather than leaving it in the tree: `v1.2.0` is tagged, immutable and DOI-pinned, so the two-adapter demonstration stays permanently citable and checkable after removal. A proof does not stop being a proof because the artifact moved on.

The reason that survives is **audience**. VANET evaluation runs on Veins (OMNeT++ + SUMO) — the de-facto stack for the family, with no equal-status ns-3 counterpart — and OMNeT++/INET is co-dominant with ns-3 in contemporary MANET protocol comparisons. That makes #32 the **entry ticket to #301 (VANET)**, so it lands with the family axis at v1.6.0, not alongside the NS-2 removal at v2.0.0.

Satellite is the counter-case and the reason not to pull it earlier: LEO work is overwhelmingly ns-3 (Hypatia, ns-3-leo), so #297 gains nothing from a second adapter.

Recorded with an explicit caveat, because it would otherwise leak into the paper: **no bibliometric study we could find reports 2024–2026 simulator shares for this field.** "Co-dominant" and "de-facto" are judgements from the recent evaluation literature and the toolchains those papers run on — not measured percentages. Good enough to schedule engineering against; not quotable as statistics.

## 5. The roadmap becomes a live board, plus two missing items

Every issue the ladder gates now carries a **`release:` label**, and `docs/roadmap.md` links the six resulting boards. Labels rather than milestones or a Projects v2 board: a label is visible in every issue list and search without leaving the issues view, and editing one needs only write access. A Projects board over the same labels stays a strict addition — it would read these labels, not replace them. Only 22 of ~90 open issues are labelled; a `release:` on everything makes the query useless.

Two items were missing from the plan entirely:

- **#309 (v1.3.0)** — the hold-cap sweep is still 300 s and five-seed, and #110's scope is area/pause/scale, so nothing owned it. It is the evidence behind the draft's only constructive response to the delay tail, and its "delivery cost within noise" claim rests on a 1.6 pp PDR spread at five seeds — precisely the claim that run count cannot support.
- **#308 (v1.4.0)** — the 20-seed campaign puts the disk d99 gap at ≈12× the combined interval half-width, confirming #21 as a real effect. Nothing owned fixing it: #21 is a symptom report whose stated plan (re-measure after #19) is spent, and its parent is closed. The epic's first deliverable is deliberately a **decision, not a patch** — a matched-PDR comparison, since a protocol delivering ~10 pp more packets may show a worse tail *because* of the win.

Also closed **#25** (NS-2 benchmark harness) as not planned, obsoleted by #307.

## Verification

- All 15 CI checks green at `e3a8247`, including both NS-2 adapter e2e jobs and the new mermaid gate.
- Both roadmap mermaid blocks rendered through `mmdc` after every edit, not just entity-scanned.
- `check_invariants.sh` PASS.

Refs: #21, #25, #32, #110, #289, #293, #298, #301, #307, #308, #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1