### PR TITLE
test(core): exercise GenerationTracker's eviction (#166), and add the matched-delivery delay99 that #308 needs

### DIFF
--- a/core/include/anthocnet/core/ant_history.h
+++ b/core/include/anthocnet/core/ant_history.h
@@ -104,6 +104,10 @@ public:
     /// which is a hop limit on discovery (#169).
     bool allowBroadcast(NodeAddress src, std::uint32_t seqNum, int maxBroadcasts);
 
+    /// Generations currently resident. Mirrors AntHistoryTracker::size(); the
+    /// cap it is checked against is the golden-rule-5 bound (#166).
+    std::size_t size() const { return best_.size(); }
+
     void clear();
 
 private:

--- a/core/tests/test_ant_history.cpp
+++ b/core/tests/test_ant_history.cpp
@@ -33,5 +33,96 @@ int main() {
     // The evicted entry is treated as new again.
     CHECK(bounded.record(1, 1));
 
+    // ---------------------------------------------------------------------
+    // GenerationTracker's bound (#166).
+    //
+    // Golden rule 5 applies to both trackers, but only AntHistoryTracker's cap
+    // was exercised above. GenerationTracker has *two* eviction sites --
+    // accept() and allowBroadcast() -- and neither was reachable from any test:
+    // every scenario stayed far under the cap. The bound could have been
+    // deleted, mis-ordered or made off-by-one with the whole suite still green,
+    // which is the exact regression class the extraction already paid for once
+    // (unbounded (src,seq) history, CONTEXT.md bug #4).
+    //
+    // A small cap keeps this in microseconds; the production default allocates
+    // orders of magnitude more.
+    // ---------------------------------------------------------------------
+    const double a1 = 0.9, a2 = 2.0;   // the shipped acceptance factors (#177)
+
+    // accept(): the cap holds, and eviction is FIFO.
+    {
+        GenerationTracker g(/*maxEntries*/ 3);
+        for (std::uint32_t seq = 1; seq <= 3; ++seq) {
+            CHECK(g.accept(/*src*/ 1, seq, /*hops*/ 2, /*time*/ 10.0,
+                           /*firstHop*/ 9, a1, a2));
+        }
+        CHECK_EQ(g.size(), static_cast<std::size_t>(3));
+
+        // A fourth generation evicts the first, and only the first.
+        CHECK(g.accept(1, 4, 2, 10.0, 9, a1, a2));
+        CHECK_EQ(g.size(), static_cast<std::size_t>(3));
+
+        // Generation 1 is genuinely forgotten: an ant that would have been
+        // rejected against its recorded best (20 hops vs a 0.9*2 band) is now
+        // admitted as the first of a "new" generation. This is the side of the
+        // memory-for-correctness trade the bound puts us on -- eviction reopens
+        // a generation rather than permanently rejecting it -- and asserting it
+        // is what makes the FIFO order observable at all.
+        CHECK(g.accept(1, 1, /*hops*/ 20, /*time*/ 999.0, 9, a1, a2));
+
+        // Generations 3 and 4 were never evicted, so their bands still bind:
+        // 20 hops against a best of 2 is far outside a2=2.0.
+        CHECK(!g.accept(1, 3, 20, 999.0, 9, a1, a2));
+        CHECK(!g.accept(1, 4, 20, 999.0, 9, a1, a2));
+        // ...and both bands still work on a surviving generation, so eviction
+        // has not corrupted the entries it left alone. Note a1 = 0.9 < 1: over
+        // an *already-admitted* first hop an equal-cost ant is rejected (2 hops
+        // is not <= 0.9*2), and only a strictly better one gets in. Over an
+        // unseen first hop the same equal-cost ant is admitted under a2 = 2.0.
+        CHECK(!g.accept(1, 4, /*hops*/ 2, /*time*/ 10.0, /*firstHop*/ 9, a1, a2));
+        CHECK(g.accept(1, 4, /*hops*/ 1, /*time*/ 5.0, /*firstHop*/ 9, a1, a2));
+        CHECK(g.accept(1, 4, /*hops*/ 1, /*time*/ 5.0, /*firstHop*/ 8, a1, a2));
+    }
+
+    // allowBroadcast(): its own eviction site, reached when multipath is off or
+    // the ant originates here, so accept() never recorded the generation.
+    {
+        GenerationTracker g(/*maxEntries*/ 2);
+        CHECK(g.allowBroadcast(/*src*/ 7, /*seq*/ 1, /*maxBroadcasts*/ 2));
+        CHECK(g.allowBroadcast(7, 2, 2));
+        CHECK_EQ(g.size(), static_cast<std::size_t>(2));
+        CHECK(g.allowBroadcast(7, 3, 2));          // evicts generation 1
+        CHECK_EQ(g.size(), static_cast<std::size_t>(2));
+
+        // The flood bound is per *resident* generation, not absolute: generation
+        // 1 was evicted with one broadcast claimed, so it starts over and this
+        // node can put it on the medium maxBroadcasts times again. That is a
+        // real consequence of golden rule 5 for the #173/#174 bound -- worth
+        // pinning, because it means the per-node guarantee degrades to
+        // "maxBroadcasts per generation per residency" once a node sees more
+        // than maxHistory concurrent generations. The shipped cap is large
+        // enough that this does not arise in the evaluated scenarios; the test
+        // exists so that a future reduction of maxHistory cannot silently
+        // weaken the flood bound.
+        CHECK(g.allowBroadcast(7, 1, 2));
+        CHECK(g.allowBroadcast(7, 1, 2));
+        CHECK(!g.allowBroadcast(7, 1, 2));         // count binds again at 2
+
+        // A generation that never left keeps its accumulated count.
+        CHECK(g.allowBroadcast(7, 3, 2));          // second claim
+        CHECK(!g.allowBroadcast(7, 3, 2));         // third refused
+    }
+
+    // maxEntries == 0 means unbounded for GenerationTracker too, matching
+    // AntHistoryTracker -- the `maxEntries_ != 0` guard, not a 0-sized cap that
+    // would evict every entry immediately.
+    {
+        GenerationTracker g(/*maxEntries*/ 0);
+        for (std::uint32_t seq = 1; seq <= 64; ++seq) {
+            CHECK(g.accept(1, seq, 2, 10.0, 9, a1, a2));
+        }
+        CHECK_EQ(g.size(), static_cast<std::size_t>(64));
+    }
+
     return RUN_TESTS();
 }

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -103,6 +103,43 @@ readable; `reorder ratio/extent` measure route *flapping* rather than
 multipath, leaving **`buf_max`** as the honest multipath signal; and
 `path_div_*` is unquotable outside the dedicated cell (#230).
 
+## Matched-delivery delay99 (`##MATCH##`, #308, NS-3 only)
+
+`delay99` takes each protocol's tail over **its own** delivered set, and those
+sets are not the same size. AntHocNet delivers ~10 pp more than AODV at the
+paper base scenario, and some of that surplus is precisely the packets that
+waited through a reconvergence. So an unknown part of AntHocNet's worse tail is
+**packets AODV never delivered at all**, not slower service of the packets both
+carry. That is the survivorship confound named above, and until #308 nothing
+measured it.
+
+Every `anthocnet-compare` run now also emits, per run and per protocol:
+
+```
+##MATCH## <run> <proto> <rxSelf> <rxMin> <delay99Ms> <delay99MatchedMs>
+```
+
+`rxMin` is the smallest delivered count across the protocols **in that run**;
+`delay99Matched` re-reads each protocol's 99th percentile at that *absolute*
+count — the delay below which `0.99 × rxMin` of its packets arrived. For the
+protocol that delivered fewest it equals its own `delay99`; for the others it
+is the tail of their fastest `rxMin` packets. `na` means that protocol did not
+deliver enough packets to reach the target (it cannot happen for the protocol
+that set `rxMin`).
+
+**Read it in one direction only.** If the gap *persists* after truncation, the
+delivery surplus cannot account for it — conclusive. If the gap *closes*, that
+is consistent with the surplus explaining the tail but does not establish it,
+because truncating the slowest packets assumes the surplus is the slow ones
+rather than showing it. A closing gap is grounds for per-packet attribution
+(#308 phase 1), not its answer.
+
+It is emitted on its own `##MATCH##` marker rather than as extra `##RUN##`
+columns, because the `##RUN##` field order is consumed **positionally** by
+`bench_parse.py` and the campaign scripts, and appending to it would silently
+shift their mapping — the failure mode the `# stddev` cross-check exists to
+catch (#293).
+
 ## Where the drop-cause identity comes from
 
 Every offered packet lands in exactly one bucket. That is the whole of #215,

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -548,6 +548,15 @@ struct Result {
     double jitterEq51Ms = 0.0;   // #89: the thesis's eq 5.1, a different quantity
     double dOff50Ms = -1.0;      // delay at the 50th pct of *offered* (sent)
     double dOff90Ms = -1.0;      // packets, undelivered = inf; -1 encodes inf
+    // #308: the delivered-delay histogram this run's percentiles were read
+    // from, retained so a *matched-delivery* percentile can be taken after all
+    // protocols have run. delay99 compares tails over different-sized
+    // delivered sets — AntHocNet delivers ~10 pp more than AODV — so part of
+    // its worse tail may be the packets AODV never delivered at all. Answering
+    // that needs one protocol's distribution queried at another's delivery
+    // count, which is only possible once both exist.
+    std::map<uint32_t, uint64_t> delayHist;  // bin index -> delivered count
+    double delayBinWidth = 0.0;              // seconds; 0 when no deliveries
     // #209 energy:
     double energyJ = 0.0;        // total consumed over all nodes (J)
     double energyPerPktJ = 0.0;  // energyJ / delivered data packets (J/pkt)
@@ -982,6 +991,10 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             }
         }
     }
+    // #308: keep the histogram for the matched-delivery percentile computed
+    // after every protocol has run (see MatchedDelay99Ms below).
+    r.delayHist = delayBins;
+    r.delayBinWidth = binWidth;
 
     // #57 offered-load delay percentiles: the q-th percentile over *sent*
     // packets, treating undelivered as infinite delay. Monotone-honest — a
@@ -1571,9 +1584,25 @@ int main(int argc, char* argv[]) {
         double divUsed = 0, divMax = 0, divEntropy = 0, jain = 0;
     };
     std::vector<Agg> agg(list.size());
+    // #308: per (protocol, run), enough of the delivered-delay distribution to
+    // re-take a percentile at another protocol's delivery count. Protocols run
+    // outermost, so the comparison is only possible after the whole grid exists.
+    struct MatchCell {
+        std::map<uint32_t, uint64_t> hist;
+        double   binWidth = 0.0;
+        uint64_t rx = 0;
+        double   delay99Ms = 0.0;
+    };
+    std::vector<std::vector<MatchCell>> matchGrid(
+        list.size(), std::vector<MatchCell>(runs));
     for (std::size_t i = 0; i < list.size(); ++i) {
         for (uint32_t s = 1; s <= runs; ++s) {
             Result r = RunOne(list[i], P, s);
+            MatchCell& mc = matchGrid[i][s - 1];
+            mc.hist = r.delayHist;
+            mc.binWidth = r.delayBinWidth;
+            mc.rx = r.rxPackets;
+            mc.delay99Ms = r.delay99Ms;
             // #128: per-run (per-seed) row for paired statistics. Every
             // protocol sees the identical RNG realisation per run, so
             // downstream can pair rows by run number (per-seed deltas, sign
@@ -1697,6 +1726,65 @@ int main(int argc, char* argv[]) {
             agg[i].delay99Sd = sd(agg[i].delay99 * runs, agg[i].delay99Sq);
             agg[i].nrlSd = sd(agg[i].nrl * runs, agg[i].nrlSq);
             agg[i].nrlBytesSd = sd(agg[i].nrlBytes * runs, agg[i].nrlBytesSq);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // #308: matched-delivery 99th-percentile delay.
+    //
+    // delay99 compares tails over delivered sets of different sizes. AntHocNet
+    // delivers ~10 pp more than AODV, and some of that surplus is exactly the
+    // packets that waited through a reconvergence — so part of its worse tail
+    // may be the packets AODV never delivered at all rather than slower
+    // service of the packets both carry.
+    //
+    // Per run, take the smallest delivered count across the protocols
+    // (`rxMin`) and re-read every protocol's 99th percentile at that *absolute*
+    // count: the delay below which 0.99*rxMin of its packets arrived. For the
+    // protocol that delivered fewest this is its own delay99; for the others it
+    // is the tail of their fastest rxMin packets.
+    //
+    // Read it in one direction only. If the gap persists after truncation, the
+    // delivery surplus cannot account for it — that is conclusive. If the gap
+    // closes, it is *consistent with* the surplus explaining the tail but does
+    // not establish it, because truncating the slowest packets assumes the
+    // surplus is the slow ones rather than showing it. Treat a closing gap as
+    // grounds for the per-packet attribution in #308's phase 1, not as its
+    // answer.
+    //
+    // Emitted as ##MATCH## rather than extra ##RUN## columns: the ##RUN##
+    // field order is consumed positionally by bench_parse.py and by the CI
+    // campaign scripts, and appending to it would silently shift their mapping.
+    {
+        auto quantileAt = [](const MatchCell& c, uint64_t targetCount) {
+            if (c.binWidth <= 0.0 || targetCount == 0) return -1.0;
+            uint64_t cum = 0;
+            for (const auto& kv : c.hist) {
+                cum += kv.second;
+                if (cum >= targetCount)
+                    return 1000.0 * (kv.first + 0.5) * c.binWidth;
+            }
+            return -1.0;  // fewer deliveries than the target: undefined here
+        };
+        for (uint32_t s = 1; s <= runs; ++s) {
+            uint64_t rxMin = 0;
+            bool have = false;
+            for (std::size_t i = 0; i < list.size(); ++i) {
+                const uint64_t rx = matchGrid[i][s - 1].rx;
+                if (!have || rx < rxMin) { rxMin = rx; have = true; }
+            }
+            if (!have || rxMin == 0) continue;
+            const uint64_t target = static_cast<uint64_t>(0.99 * rxMin);
+            for (std::size_t i = 0; i < list.size(); ++i) {
+                const MatchCell& c = matchGrid[i][s - 1];
+                const double matched = quantileAt(c, target);
+                std::cout << std::fixed << "##MATCH## " << s << ' ' << list[i]
+                          << ' ' << c.rx << ' ' << rxMin
+                          << ' ' << std::setprecision(1) << c.delay99Ms << ' ';
+                if (matched < 0) std::cout << "na";
+                else std::cout << std::setprecision(1) << matched;
+                std::cout << "\n";
+            }
         }
     }
 


### PR DESCRIPTION
Two commits, closing #166 and turning on the measurement #308's first phase depends on.

## 1. `GenerationTracker` eviction is now exercised — closes #166

**Correcting the ticket's premise while implementing it.** #166 says the dedup-history eviction is untested and points at `ant_history.cpp:43-44`. Both are stale:

- `AntHistoryTracker`'s cap has been covered since `test_ant_history.cpp` was created (2026-07-23 — *two days before* #166 was filed), in the "Bounded tracker evicts oldest entries" block.
- Lines 43-44 today sit inside `isNewFirstHop()`, unrelated to eviction.

The gap the coverage run actually found is **`GenerationTracker`**, which #166 never names — and it has **two** eviction sites, `accept()` and `allowBroadcast()`. Neither was reachable from any test: every scenario stayed far under the cap, so the bound could have been deleted, mis-ordered or made off-by-one with all 25 core tests green. That is the regression class the extraction already paid for once (CONTEXT.md bug #4, the unbounded `(src,seq)` history the bound exists to fix).

**Asserted:**
- `accept()` — size never exceeds `maxEntries`; the fourth generation evicts the first and only the first.
- Eviction is **observable, not just a size change**: a forgotten generation is re-admitted as a fresh first ant even at 20 hops / 999 s, far outside its old band. This pins which side of the memory-for-correctness trade the code is on — eviction *reopens* a generation rather than permanently rejecting it.
- Surviving generations keep both bands intact after evictions, so eviction doesn't corrupt neighbours.
- `allowBroadcast()` — its own eviction site, plus the consequence: an evicted generation's broadcast count restarts, so the #173/#174 per-node flood bound degrades to *"maxBroadcasts per generation per residency"* once a node sees more than `maxHistory` concurrent generations. The shipped cap is far too large for this to arise in the evaluated scenarios; the test exists so a future reduction of `maxHistory` cannot silently weaken the flood bound.
- `maxEntries == 0` means unbounded, matching `AntHistoryTracker`.

**One assertion was wrong on the first run and the test caught it.** With `a1 = 0.9 < 1`, an equal-cost ant arriving over an *already-admitted* first hop is correctly rejected (2 hops is not ≤ 0.9×2) — only a strictly better one gets in, or an equal-cost one over an unseen first hop under `a2 = 2.0`. Both branches are now asserted explicitly instead of assumed.

### Mutation check (#166 requires it)

A bounded-structure test that passes against a broken bound is worthless. Four mutations, each rebuilt and re-run:

| | Mutation | Result |
|---|---|---|
| M1 | delete the eviction in `accept()` | **test FAILS** ✅ |
| M2 | delete the eviction in `allowBroadcast()` | **test FAILS** ✅ |
| M3 | off-by-one, `>` → `>=` | **test FAILS** ✅ |
| M4 | FIFO → LIFO (evict newest) | **test FAILS** ✅ |
| — | restored source | test PASSES ✅ |

Branch coverage on `core/src/ant_history.cpp`: **54 % → 72 %** (39 → 52 of 72 taken). Both eviction sites leave the missing-branch list. Full suite: 25/25 pass.

Adds `GenerationTracker::size()`, mirroring `AntHistoryTracker::size()` — the cap cannot be asserted from outside without it.

## 2. Matched-delivery delay99 — the measurement #308 turns on

#21's tail is now *confirmed* (≈12× the combined interval half-width) but not *understood*, and nothing in the harness could tell the two candidate explanations apart.

**The confound:** `delay99` takes each protocol's tail over **its own** delivered set, and those sets are different sizes. AntHocNet delivers ~10 pp more than AODV, and some of that surplus is exactly the packets held through a reconvergence. So an unknown share of its worse tail is *packets AODV never delivered at all*, rather than slower service of the packets both carry. The docs already named this confound — "a protocol that drops hard packets looks better" — but nothing measured it.

`anthocnet-compare` now retains the delivered-delay histogram it **already builds** for the percentile (1 ms bins — no new instrumentation, no extra simulation cost) and, once every protocol has run, re-reads each protocol's 99th percentile at the smallest delivered count of that run:

```
##MATCH## <run> <proto> <rxSelf> <rxMin> <delay99Ms> <delay99MatchedMs>
```

Per run, so the comparison pairs on identical seeds and carries a CI like every other number.

**The inference is one-directional, and the docs say so.** If the gap *persists* after truncation, the delivery surplus cannot account for it — conclusive. If it *closes*, that is only *consistent with* the surplus explaining the tail: truncating the slowest packets assumes the surplus is the slow ones rather than showing it. Stating this now matters, because the tempting misreading — *"gap closed, tail explained, ship the hold cap as a default"* — would adopt a protocol change on the strength of an assumption.

Emitted on its own `##MATCH##` marker rather than as extra `##RUN##` columns: the `##RUN##` field order is consumed **positionally** by `bench_parse.py` and the campaign scripts, so appending would silently shift their mapping — exactly the failure the `# stddev` cross-check exists to catch (#293).

## ⚠️ Verification status — read before quoting any matched number

- **#166:** fully verified locally — built, run, mutation-checked, coverage measured.
- **The ns-3 change is NOT compile-verified locally.** There is no ns-3 toolchain in this container. CI builds the examples and *runs* `anthocnet-compare` (both the normal and the sanitizer job) plus the determinism gate, which covers compilation and crash-freedom.
- Those CI runs pass `--protocols=anthocnet`, so `rxMin` equals the single protocol's own `rx` and `matched == delay99`: **the path executes but the cross-protocol arithmetic is not exercised** until a multi-protocol dispatch. That dispatch is the next step on #308, and no matched number should be quoted before it lands.

Closes #166 · Refs #21, #293, #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_