### PR TITLE
fix(bench): re-emit ##MATCH## in the compact result block

### DIFF
--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -233,6 +233,16 @@ jobs:
           # binaries / the baselines harness — means-only block stays valid.
           grep '^##RUN##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #308: the matched-delivery percentile rows. Same reason as ##RUN##
+          # above, and the same omission cost a full re-fetch: the first
+          # matched run (30813020804) emitted 40 ##MATCH## lines that this
+          # step did not re-emit, so they sat above the compact block and
+          # needed tail_lines=215 instead of ~50 — and the top row still
+          # scrolled off, dropping one seed from a 20-seed paired analysis.
+          # Any new ##MARKER## the harness gains has to be added here too;
+          # emitting it is only half of shipping it.
+          grep '^##MATCH##' "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
           # the *only* place the #209/#212/#215/#217 metric families appear in a
           # single-point run — the fixed-width table cannot carry them (its field

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -140,6 +140,16 @@ columns, because the `##RUN##` field order is consumed **positionally** by
 shift their mapping — the failure mode the `# stddev` cross-check exists to
 catch (#293).
 
+> **Adding a marker is two changes, not one.** The harness emitting a
+> `##MARKER##` line is only half of shipping it: `paper-benchmark.yml`'s
+> *"Compact result block"* step re-emits a **explicit allow-list** of markers at
+> the end of the log so one cheap `get_job_logs` tail carries everything. A
+> marker missing from that grep still reaches `paper-results.txt` (and the
+> artifact, which is proxy-blocked) but sits far above the compact block. That
+> is exactly what happened to `##MATCH##` on its first run: `tail_lines=215`
+> instead of ~50, and the top row scrolled off anyway, costing one seed out of
+> twenty in a paired analysis.
+
 ## Where the drop-cause identity comes from
 
 Every offered packet lands in exactly one bucket. That is the whole of #215,


### PR DESCRIPTION
The harness emitting a marker is only half of shipping it.

`paper-benchmark.yml`'s *"Compact result block"* step re-emits an **explicit allow-list** of markers at the end of the log so one cheap `get_job_logs` tail carries everything. `##MATCH##` was added to the harness in #310 and never added to that list.

## What it cost, on the first real run

Run [30813020804](https://github.com/danieljoppi/AntHocNet/actions/runs/30813020804) emitted 40 `##MATCH##` lines. They reached `paper-results.txt` and the artifact — but artifacts are proxy-blocked, and the lines sat *above* the compact block in the log. Reading them took `tail_lines=215` instead of ~50, and the top row **still scrolled off**, dropping run 1's AntHocNet value and leaving a 20-seed campaign with 19 usable pairs.

The #308 verdict survived at n = 19. It did not have to.

## Why this is the same defect twice

The step's own comment already documents this failure mode, from #230:

> the `# paths/energy/drops/stddev/reorder` diagnostic lines … were therefore unreachable from a cheap tail … That made the #230 window calibration — five points, read only from `# paths` — **40× more expensive** than the runs it was reading.

I reintroduced it by adding a marker without extending the grep. `docs/benchmarks/metrics.md` now states the rule where the marker is documented, so the next marker does not repeat it:

> **Adding a marker is two changes, not one.**

## Verification

Cannot be verified without a dispatch — the step only runs inside `paper-benchmark`. The change is a single `grep '^##MATCH##' … >> bench-rows.txt || true`, structurally identical to the `##RUN##` line directly above it and with the same `|| true` guard, so an older binary that emits no `##MATCH##` still produces a valid block. The next matched run confirms it.

Refs: #230, #293, #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysnYsCcApHebSb1BebUX1)_