### PR TITLE
docs(bench): statistical policy — runs floor, ci methods, warm-up, rng — plus a runs-floor gate

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -267,7 +267,7 @@ def parse_results(path):
     if first.startswith("protocol,runs,rows,cols,"):
         for r in csv.DictReader(text.splitlines()):
             yield {"where": f"isl-grid {r.get('rows')}x{r.get('cols')}",
-                   "proto": r.get("protocol"),
+                   "proto": r.get("protocol"), "runs": r.get("runs"),
                    "pdr": r.get("pdr_pct"), "delay": r.get("delay_ms"),
                    "delay99": r.get("delay99_ms"), "nrl": r.get("nrl"),
                    "jitter": r.get("jitter_ms"),
@@ -310,7 +310,7 @@ def parse_results(path):
     if first.startswith("kind,") or ",protocol," in first:
         for r in csv.DictReader(text.splitlines()):
             yield {"where": f"{r.get('group')}={r.get('x')}",
-                   "proto": r.get("protocol"),
+                   "proto": r.get("protocol"), "runs": r.get("runs"),
                    "pdr": r.get("pdr_pct"), "delay": r.get("delay_ms"),
                    "delay99": r.get("delay99_ms"), "nrl": r.get("nrl"),
                    "jitter": r.get("jitter_ms"),
@@ -342,6 +342,12 @@ def parse_results(path):
         return
     rows = []          # yielded in table order
     by_proto = {}      # diagnostics merge into the protocol's last row
+    # #293 runs-floor: a saved cell's per-seed ##RUN## rows reveal the run
+    # count the 9-number table/##BENCH## block does not carry.
+    run_counts = {}
+    for proto in re.findall(r"^##RUN##\s+\d+\s+([A-Za-z][\w-]*)", text,
+                            re.MULTILINE):
+        run_counts[proto] = run_counts.get(proto, 0) + 1
     for line in text.splitlines():
         m = ROW.match(line)
         if m:
@@ -350,7 +356,7 @@ def parse_results(path):
                 continue
             row = {"where": os.path.basename(path), "proto": proto,
                    "pdr": nums[0], "delay": nums[1], "delay99": nums[2],
-                   "nrl": nums[4]}
+                   "nrl": nums[4], "runs": run_counts.get(proto)}
             if len(nums) >= 6:
                 row["jitter"] = nums[5]
             if len(nums) >= 11:  # #209: ... nrlBytes, energy(J), J/pkt
@@ -397,6 +403,16 @@ def cmd_results(a):
                     return None
             pdr, delay, d99 = num("pdr"), num("delay"), num("delay99")
             nrl, jit = num("nrl"), num("jitter")
+            # #293 runs-floor: published points need >=10 runs (tail-quantile
+            # claims 20 — see docs/benchmarks/methodology.md "Statistical
+            # policy"). WARN, not FAIL: low-run cells are legitimate cheap
+            # probes, they just must not be published or quoted. Rows without
+            # a run count (a bare table with no ##RUN## rows) skip the rule.
+            runs = num("runs")
+            if runs is not None and runs < 10:
+                report("WARN", f"{tag}: {int(runs)} run(s) — below the #293 "
+                               f"published-point floor (>=10; tail quantiles "
+                               f"need 20). Diagnostic only, do not publish.")
             if pdr is None or not (0.0 <= pdr <= 100.0):
                 report("FAIL", f"{tag}: PDR {r.get('pdr')} outside [0,100]")
             if delay is not None and d99 is not None and d99 < delay:

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -63,7 +63,7 @@ sc = _load_scenario_check()
 CLEAN = {
     "kind": "scenario", "group": "taxonomy", "x": "paper-base",
     "scenario": "paper-base", "class": "sparse / mobile",
-    "protocol": "anthocnet", "runs": "2", "nNodes": "50", "areaX": "1500",
+    "protocol": "anthocnet", "runs": "20", "nNodes": "50", "areaX": "1500",
     "speed": "20", "pause": "30", "flows": "20", "propagation": "range",
     "pdr_pct": "89.4", "delay_ms": "40.0", "delay99_ms": "200.0",
     "throughput_kbps": "9.0", "nrl": "2.0", "jitter_ms": "10.0",
@@ -145,6 +145,33 @@ def expect(cond, name, detail):
 def _clean():
     levels, out = run_results()
     expect(levels == [], "clean", f"expected no reports, got {levels}\n{out}")
+
+
+# --- #293 runs-floor ----------------------------------------------------------
+
+
+@case("#293 a 5-run cell WARNs below the published-point floor")
+def _runs_floor_fires():
+    # 5 was the pre-#110 sweep run count — exactly the data the floor exists
+    # to keep out of publications (DSDV's delay99 dispersion was invisible
+    # at 5 seeds, #293).
+    levels, out = run_results(runs="5")
+    expect("WARN" in levels, "runs-floor-fires",
+           f"runs=5 did not WARN\n{out}")
+    expect("published-point floor" in out, "runs-floor-fires",
+           f"WARN did not name the floor\n{out}")
+
+
+@case("#293 the floor stays quiet at 10 runs and on rows with no run count")
+def _runs_floor_quiet():
+    levels, out = run_results(runs="10")
+    expect(levels == [], "runs-floor-quiet",
+           f"runs=10 (the floor) must not WARN\n{out}")
+    # A bare table row with no ##RUN## rows carries no run count: skip.
+    levels, out = run_cell(
+        "anthocnet 89.4 40.0 200.0 9.0 2.0\n")
+    expect(levels == [], "runs-floor-no-count",
+           f"row without a run count must not WARN\n{out}")
 
 
 # --- #230 path diversity -----------------------------------------------------
@@ -457,9 +484,11 @@ def _divcell_sanity_fires():
 # The CSV fixture is a realistic 4x4 torus at the anchor knobs: 16 satellites,
 # 32 ISLs, islDelayMs=5, 8 flows. delay 10.4 ms is the measured hop-delay
 # identity reading (h=2, d=5 ms: 10.39 ms, CI run 30190452648, anchors.yml).
+# runs sits at the #293 published-point floor so the clean fixture stays
+# clean; the runs-floor WARN has its own must-fire case below.
 
 ISL_CLEAN = {
-    "protocol": "anthocnet", "runs": "3", "rows": "4", "cols": "4",
+    "protocol": "anthocnet", "runs": "20", "rows": "4", "cols": "4",
     "nodes": "16", "links": "32", "isl_delay_ms": "5.0", "flows": "8",
     "pdr_pct": "100.0", "delay_ms": "10.4", "delay99_ms": "10.9",
     "throughput_kbps": "32.28", "nrl": "1.401", "nrl_bytes": "0.988",

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -145,6 +145,74 @@ PDR / mean+99th-percentile delay / NRL vs. the swept parameter:
 Unlike the paper (AODV only), every baseline (AODV/OLSR/DSDV) is run on identical
 realisations, so the classification covers all of them.
 
+## Statistical policy ([#293](https://github.com/danieljoppi/AntHocNet/issues/293))
+
+Every number published in these pages or in the papers repo carries a **95%
+confidence interval**, or is explicitly marked single-run/diagnostic. The
+computation lives in
+[`.claude/skills/benchmark-results/stats_util.py`](../../.claude/skills/benchmark-results/stats_util.py)
+(consumed by `bench_parse.py` / `sweep_summary.py`; self-tested by
+`test_stats.py` in `lint.yml`) — change the methods there and here together.
+
+### Runs floor
+
+- **Published points: ≥ 10 runs.** `scenario_check.py results` WARNs on any
+  cell below it (a low-run cell is a legitimate cheap probe; it just must not
+  be published or quoted).
+- **Headline cells and tail-quantile claims: 20 runs** (thesis parity —
+  Ducatelle §5.1.3 uses 20 repetitions).
+- The floor is **metric-dependent by design**: tail metrics disperse far more
+  than PDR. The #110 20-seed headline measured DSDV `delay99` half-widths of
+  ±119.90 ms (disk) / ±122.94 ms (two-ray) — an order of magnitude wider,
+  relative to the mean, than any other cell, i.e. per-seed bimodality that
+  five seeds could not expose. A floor derived from PDR stability would have
+  passed that cell at 5 runs. Hence: means may be published at 10; anything
+  quoting `delay99` (or another tail quantile) needs 20.
+
+### CI method per metric
+
+| metric family | interval | why |
+|---|---|---|
+| `pdr`, `delay`, `thrput`, `nrl`, `nrl_bytes` (per-run aggregates, roughly symmetric across seeds) | Student-t, `t_{0.975,n-1} · sd/√n` | standard small-sample CI on a mean |
+| `delay99` (a per-run p99), other tail quantiles | **percentile bootstrap** over the per-run values (10 000 resamples, fixed seed — the interval is reproducible byte-for-byte) | the across-seed distribution of a p99 is skewed; a symmetric t-CI on it is not defensible |
+| paired A/B differences (identical seeds) | CI on the **per-seed difference** (t for `pdr`/`nrl`, bootstrap for `delay99`) **plus a two-sided Wilcoxon signed-rank test** (exact for n ≤ 25 without ties) | overlapping per-arm CIs do **not** imply non-significance; the paired difference is the honest test |
+
+Significance in an A/B is "the difference CI excludes zero" — when per-seed
+`##RUN##` rows are present, this **replaces** `bench_parse.py`'s materiality
+thresholds (which remain the fallback for aggregate-only cells). Sweeps that
+produce many comparisons get a multiple-comparison note (at α = 0.05, expect
+~1 false positive per 20 cells); treat isolated marginal p-values accordingly.
+
+### Warm-up / transient policy
+
+**Nothing is discarded post-hoc, deliberately.** FlowMonitor is installed over
+the whole run and every packet from each flow's application start counts —
+including packets sent before the protocol has converged a route. Route-setup
+and reconvergence cost is part of what this repo measures (the #21/#308 delay
+tail lives exactly there); a warm-up cut would quietly delete the finding.
+The transient is handled by scenario design instead:
+
+- traffic starts are staggered **uniformly over [0, 180] s** in the
+  paper/thesis presets ([0, 5] s elsewhere), so flows do not all pay setup
+  simultaneously;
+- runs last **900 s**, an order of magnitude above observed convergence
+  times, so the steady state dominates every mean;
+- per-flow route-setup latency is reported separately (#23: the
+  `setupMedS=`/`setupMaxS=`/`flowsNoDelivery=` fields, first delivery − flow
+  start), so setup cost is visible rather than averaged away.
+
+The queue-depth sampler starts after a 10% warm-up (diagnostic only, #73); no
+published metric is windowed. Steady-state RWP speed decay (#61) remains an
+open realism item tracked for the v1.4.0 campaigns, not a statistics one.
+
+### RNG scheme
+
+Per the ns-3 manual: **fixed seed, advancing run number** —
+`RngSeedManager::SetSeed(1)`, `SetRun(seed)` with `seed` = 1…N. Every
+protocol in a comparison sees the **identical realisation** per run (same
+topology, mobility, traffic draw), which is what makes the paired analysis
+above valid and is protected by the determinism anchor (#129) below.
+
 ## Build profiles: `default` for CI, `release` for campaigns
 
 ns-3 builds under a *build profile*, and until [#123](https://github.com/danieljoppi/AntHocNet/issues/123)


### PR DESCRIPTION
## What

Implements **#293 items 4 and 5** — the policy half of the v1.3.0 exit criterion (the computation half landed in #313).

### `docs/benchmarks/methodology.md` — new "Statistical policy" section

- **Runs floor**: published points ≥ 10 runs; headline cells and tail-quantile claims **20** (thesis parity, Ducatelle §5.1.3). The floor is **metric-dependent by design**, with the #110 evidence recorded: DSDV `delay99` half-widths of ±119.90 ms (disk) / ±122.94 ms (two-ray) at n=20 — per-seed bimodality a PDR-derived floor would have passed at 5 seeds.
- **CI method per metric**: t-distribution for per-run aggregate means; percentile bootstrap (10 000 resamples, fixed seed, byte-for-byte reproducible) for `delay99`/tail quantiles; paired A/B = per-seed difference CI + two-sided Wilcoxon signed-rank, "CI excludes zero" replacing materiality thresholds when `##RUN##` rows exist; multiple-comparison note for many-cell sweeps.
- **Warm-up/transient policy**: nothing is discarded post-hoc, **deliberately** — FlowMonitor covers the whole run including pre-convergence packets, because setup/reconvergence cost is a finding this repo measures (#21/#308). The transient is handled by the [0, 180] s staggered starts, the 900 s duration, and the separate #23 setup-latency fields (`setupMedS`/`setupMaxS`/`flowsNoDelivery`). The queue sampler's 10% warm-up (#73) is diagnostic-only. Steady-state RWP (#61) stays a v1.4.0 realism item.
- **RNG scheme**: `RngSeedManager::SetSeed(1)` + `SetRun(seed)`, seed = 1…N (ns-3 manual) — identical realisation per protocol per run, guarded by the determinism anchor (#129).

### Enforcement

`scenario_check.py results` now **WARNs on any cell below 10 runs** ("diagnostic only, do not publish"). Run count comes from the CSV `runs` column (campaign + isl-grid schemas) or, for saved text cells, from counting that protocol's `##RUN##` rows; bare tables with no count skip the rule. WARN rather than FAIL: low-run probes are legitimate — publishing them is not.

### Tests

Must-fire (runs=5, the pre-#110 sweep count) + must-not-fire (runs=10 exactly at the floor; a bare row with no count). `CLEAN`/`ISL_CLEAN` fixtures move to runs=20 so the clean fixtures sit at the floor they now assert (noted in the fixture comments).

## Verification

- `python3 .claude/skills/benchmark-results/test_scenario_check.py` → 35 cases pass (33 before + 2 new)
- `python3 .claude/skills/benchmark-results/test_stats.py` → 20 cases pass
- `ruff check` (0.16.0) clean; `check-mermaid.py .` clean

Docs + validation tooling only; no protocol behaviour touched, no A/B required.

Refs #293, #110, #21, #308, #61, #23, #73, #129. Part of the v1.3.0 release ladder (#298).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_