### PR TITLE
feat(bench): emit 95% ci columns from --export-sweeps

### DIFF
--- a/.claude/skills/benchmark-results/sweep_summary.py
+++ b/.claude/skills/benchmark-results/sweep_summary.py
@@ -228,9 +228,19 @@ def main():
               f"{dp:>+7.1f}{d99:>+8.1f}{dn:>+8.1f}  {tag}")
 
     if args.export_sweeps:
+        # #293: the papers schema's optional *_ci columns are 95% CI
+        # half-widths (t, n-1 df) from the aggregate *_sd/runs columns —
+        # plot_sweeps.py draws them as yerr. Blank for pre-#28 CSVs.
+        def hw(row, sd_col):
+            sd, runs = f(row, sd_col), f(row, "runs")
+            if sd is None or runs is None or runs < 2:
+                return ""
+            return f"{stats_util.t_halfwidth(sd, int(runs)):.3g}"
+
         with open(args.export_sweeps, "w", newline="") as fh:
             w = csv.writer(fh)
-            w.writerow(["sweep", "x", "proto", "pdr", "delay_ms", "delay99_ms"])
+            w.writerow(["sweep", "x", "proto", "pdr", "delay_ms", "delay99_ms",
+                        "pdr_ci", "delay_ci", "delay99_ci"])
             n = 0
             for k in sorted(cells):
                 kind, group, x = k
@@ -242,7 +252,8 @@ def main():
                         continue
                     w.writerow([group, f"{x:g}", proto,
                                 row["pdr_pct"], row["delay_ms"],
-                                row["delay99_ms"]])
+                                row["delay99_ms"], hw(row, "pdr_sd"),
+                                hw(row, "delay_sd"), hw(row, "delay99_sd")])
                     n += 1
         print(f"exported {n} sweep rows -> {args.export_sweeps}")
 


### PR DESCRIPTION
## What

Fills in the optional `pdr_ci`/`delay_ci`/`delay99_ci` columns that the papers repo's `plot_sweeps.py` schema already anticipates. Half-widths are the 95% t-CI (n−1 df) from the campaign CSV's aggregate `*_sd` + `runs` columns via `stats_util.py` (#293 item 2), blank for pre-#28 CSVs. `delay99_ci` carries the aggregate-data t-CI best-effort documented in the methodology (bootstrap needs per-run rows the classified CSVs don't carry, #126-adjacent).

The consuming half — `plot_sweeps.py` reading these as `yerr` — lands in the papers repo **in the same PR** as the first `sweeps.csv` carrying the columns, per the "_ci and yerr ship together" rule on #293. That PR follows once the 20-seed pause/area campaign (running now, 9/10 complete) is rescued and validated.

## Verification

Export of `docs/benchmarks/campaign/30031904151-pause-disk.csv` yields `pdr_ci 4.92` for anthocnet pause=0 — matches the grid's `±95` column and `update-benchmarks.py`'s `80.1 ± 4.9` (three independent code paths, one `stats_util`).

One-file tooling change; no protocol behaviour, no A/B required.

Refs #293, #28, #126. Part of the v1.3.0 release ladder (#298).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_