### PR TITLE
ci(bench): per-merge taxonomy at the 10-run publication floor

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,9 +6,15 @@ name: Benchmarks
 # in docs/benchmarks/scenarios/ AND the taxonomy chart in docs/benchmarks/. So
 # the published numbers + figures always track the code.
 #
-# Scope: this runs the *discrete* named scenarios (quick preset). The heavier
-# parameter sweeps (area/pause/scale) stay in the manual "Scenario matrix +
-# charts" workflow -- too expensive for a per-merge job.
+# Scope: this runs the *discrete* named scenarios at time=120 s but
+# runs=10 -- the #293/#314 published-point floor. It used to be the --quick
+# preset (runs=2), which was a cost choice from when Actions minutes were
+# believed billed; #121's answer (they are not) removed the reason, and #318
+# removed the excuse: at 2 runs the tables now render t(1)-wide intervals
+# their own methodology calls unpublishable. The 120 s duration stays -- the
+# floor is about dispersion, not duration, and absolute plausibility is the
+# anchor gate's job. The heavier parameter sweeps (area/pause/scale) stay in
+# the manual "Scenario matrix + charts" workflow at 900 s / 20 seeds.
 on:
   push:
     branches: [main, master]   # both, so it survives the default-branch rename
@@ -78,10 +84,11 @@ jobs:
         run: |
           bash ns3/tools/check-anchors.sh /opt/ns-3 single-hop
           bash ns3/tools/check-anchors.sh /opt/ns-3 broch-low-mobility
-      - name: Run scenario taxonomy (quick)
+      - name: Run scenario taxonomy (10 runs, 120 s — the #318 floor)
         run: |
           python3 ns3/tools/run-scenarios.py /opt/ns-3 \
-            --out "$GITHUB_WORKSPACE/scenarios.csv" --only discrete --quick
+            --out "$GITHUB_WORKSPACE/scenarios.csv" --only discrete \
+            --runs 10 --time 120
       - name: Render charts
         run: python3 ns3/tools/make-charts.py "$GITHUB_WORKSPACE/scenarios.csv" --outdir docs/benchmarks
       - name: Update results tables (index summary + per-scenario pages)

--- a/docs/benchmarks/satellite/isl-grid.md
+++ b/docs/benchmarks/satellite/isl-grid.md
@@ -162,7 +162,12 @@ excess tracked in [#250](https://github.com/danieljoppi/AntHocNet/issues/250)
 **No committed results yet**, but the pipeline that lands and gates them is
 real ([#259](https://github.com/danieljoppi/AntHocNet/issues/259)) — the same
 dispatch → rescue → validate → parse loop the MANET suite runs, so no
-satellite number is ever eyeball-only:
+satellite number is ever eyeball-only. When results do land here they fall
+under the [statistical policy](../methodology.md#statistical-policy-293):
+published points need ≥ 10 runs with 95% CIs, **except** the analytic anchor
+cells (`single-isl`, `hop-delay`), which are derivation checks on
+deterministic point-to-point links — those stay low-run and are read as
+**diagnostic identities, not estimates** (#318 wording pass):
 
 1. **Dispatch** `satellite-benchmark.yml` (above). The results file
    (`satellite-results.txt`: `##RUN##` per-seed rows plus the summary table)


### PR DESCRIPTION
## What

Implements **#318 option A** (the recommended branch). `benchmarks.yml`'s discrete-taxonomy step drops `--quick` (runs=2) for `--runs 10 --time 120`:

- run count rises to the **#293/#314 published-point floor**;
- the 120 s duration stays — the floor is about dispersion, not duration, and absolute plausibility is the anchor gate's job;
- `--quick` was a cost choice from when Actions minutes were believed billed. #121's maintainer answer (not billed) removed the reason, and #315's rendered intervals removed the excuse: at n=2 every per-merge table would display `t(1)`-wide half-widths (12.706·sd/√2) that the repo's own methodology classifies as unpublishable, with no marker saying so.

Also the #318 wording pass on the satellite page: `isl-grid.md`'s Results section now states the statistical policy applies to any committed satellite table, with the analytic anchor cells (`single-isl`, `hop-delay`) explicitly carved out as low-run **diagnostic identities** on deterministic p2p links — estimates need the floor, derivation checks do not.

## Cost / follow-through

The taxonomy step runs 5× more seeds; the job previously finished well inside an hour and has the 6 h platform kill as backstop. Per #318's acceptance, the **measured job-time delta gets recorded on the ticket after the first post-merge run** — the first refreshed tables also pick up the #315 `mean ± hw` rendering at honest 10-run widths, closing the "per-merge pages" row of the #293 exit-criterion audit.

Workflow + docs only; no protocol behaviour, no A/B required.

Refs #318, #293, #314, #315, #121, #298.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_