### PR TITLE
feat(bench): persist per-run rows in a sibling campaign csv

### DIFF
--- a/.claude/skills/benchmark-results/sweep_summary.py
+++ b/.claude/skills/benchmark-results/sweep_summary.py
@@ -39,6 +39,7 @@ change (a #51-class finding).
 import argparse
 import csv
 import math
+import os
 import sys
 
 import stats_util
@@ -121,6 +122,26 @@ def collect(paths, group=None):
                 continue
             cells.setdefault(key(row), {})[row["protocol"]] = row
     return cells
+
+
+def collect_runs(paths, metric="delay99_ms"):
+    """#319: per-run values from the sibling <file minus .csv>-runs.csv files
+    (written by run-scenarios.py, rescued alongside the aggregate CSV).
+    Returns {(kind, group, x, protocol): [values]}; empty for inputs whose
+    producing run predates the sibling."""
+    vals = {}
+    for path in paths:
+        sib = (path[:-4] if path.endswith(".csv") else path) + "-runs.csv"
+        if not os.path.exists(sib):
+            continue
+        with open(sib, newline="") as fh:
+            for row in csv.DictReader(fh):
+                v = f(row, metric)
+                if v is None or v < 0:
+                    continue
+                vals.setdefault((row["kind"], row["group"], f(row, "x", 0.0),
+                                 row["protocol"]), []).append(v)
+    return vals
 
 
 CONTROL_COLS = ["pdr_pct", "delay_ms", "delay99_ms", "nrl"]
@@ -229,19 +250,36 @@ def main():
 
     if args.export_sweeps:
         # #293: the papers schema's optional *_ci columns are 95% CI
-        # half-widths (t, n-1 df) from the aggregate *_sd/runs columns —
-        # plot_sweeps.py draws them as yerr. Blank for pre-#28 CSVs.
+        # half-widths — plot_sweeps.py draws them as yerr. pdr/delay use the
+        # t-CI from the aggregate *_sd/runs columns; blank for pre-#28 CSVs.
         def hw(row, sd_col):
             sd, runs = f(row, sd_col), f(row, "runs")
             if sd is None or runs is None or runs < 2:
                 return ""
             return f"{stats_util.t_halfwidth(sd, int(runs)):.3g}"
 
+        # #319: delay99 is a per-run p99, so when the sibling -runs.csv is
+        # present its interval is the percentile BOOTSTRAP over the per-run
+        # values (methodology: a t-CI on a p99 is not defensible), collapsed
+        # to the conservative symmetric envelope max(mean-lo, hi-mean) since
+        # the schema carries one half-width. t-CI remains the fallback for
+        # aggregate-only inputs.
+        run_vals = collect_runs(args.files)
+
+        def hw99(row, k, proto):
+            vals = run_vals.get((k[0], k[1], k[2], proto), ())
+            if len(vals) >= 2:
+                lo, hi = stats_util.bootstrap_ci_mean(list(vals))
+                mean = sum(vals) / len(vals)
+                return f"{max(mean - lo, hi - mean):.3g}"
+            return hw(row, "delay99_sd")
+
         with open(args.export_sweeps, "w", newline="") as fh:
             w = csv.writer(fh)
             w.writerow(["sweep", "x", "proto", "pdr", "delay_ms", "delay99_ms",
                         "pdr_ci", "delay_ci", "delay99_ci"])
             n = 0
+            boot = 0
             for k in sorted(cells):
                 kind, group, x = k
                 if kind != "sweep":
@@ -250,12 +288,15 @@ def main():
                     row = cells[k].get(proto)
                     if row is None:
                         continue
+                    if (kind, group, x, proto) in run_vals:
+                        boot += 1
                     w.writerow([group, f"{x:g}", proto,
                                 row["pdr_pct"], row["delay_ms"],
                                 row["delay99_ms"], hw(row, "pdr_sd"),
-                                hw(row, "delay_sd"), hw(row, "delay99_sd")])
+                                hw(row, "delay_sd"), hw99(row, k, proto)])
                     n += 1
-        print(f"exported {n} sweep rows -> {args.export_sweeps}")
+        print(f"exported {n} sweep rows -> {args.export_sweeps} "
+              f"({boot} with bootstrap delay99_ci, {n - boot} t-fallback)")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/benchmark-results/test_stats.py
+++ b/.claude/skills/benchmark-results/test_stats.py
@@ -256,6 +256,57 @@ def _():
     assert sw.pdr_hw({"pdr_sd": "1.0", "runs": "1"}) == ""
 
 
+@case("#319 export: bootstrap delay99_ci with the -runs sibling, t without")
+def _():
+    import csv as _csv
+    import tempfile
+    cols = ["kind", "group", "x", "protocol", "runs", "pdr_pct", "delay_ms",
+            "delay99_ms", "nrl", "pdr_sd", "delay_sd", "delay99_sd"]
+    agg = [
+        {"kind": "sweep", "group": "pause", "x": "0", "protocol": p,
+         "runs": "10", "pdr_pct": "80.0", "delay_ms": "50.0",
+         "delay99_ms": "900.0", "nrl": "3.0", "pdr_sd": "1.0",
+         "delay_sd": "5.0", "delay99_sd": "100.0"}
+        for p in ("anthocnet", "aodv")]
+    # skewed per-run p99s for anthocnet ONLY -> bootstrap path fires for it,
+    # aodv (no sibling rows) falls back to the aggregate t-CI.
+    d99 = [850.0] * 9 + [1350.0]
+    with tempfile.TemporaryDirectory() as td:
+        aggp = os.path.join(td, "camp.csv")
+        with open(aggp, "w", newline="") as fh:
+            w = _csv.DictWriter(fh, fieldnames=cols)
+            w.writeheader()
+            w.writerows(agg)
+        with open(os.path.join(td, "camp-runs.csv"), "w", newline="") as fh:
+            w = _csv.DictWriter(fh, fieldnames=["kind", "group", "x",
+                                                "scenario", "protocol", "run",
+                                                "delay99_ms"])
+            w.writeheader()
+            for i, v in enumerate(d99, 1):
+                w.writerow({"kind": "sweep", "group": "pause", "x": "0",
+                            "scenario": "pause=0", "protocol": "anthocnet",
+                            "run": i, "delay99_ms": v})
+        outp = os.path.join(td, "sweeps.csv")
+        argv, sys.argv = sys.argv, ["sweep_summary.py", aggp,
+                                    "--export-sweeps", outp]
+        out = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(out):
+                sw.main()
+        finally:
+            sys.argv = argv
+        with open(outp, newline="") as fh:
+            rows = {r["proto"]: r for r in _csv.DictReader(fh)}
+        lo, hi = su.bootstrap_ci_mean(d99)
+        mean = sum(d99) / len(d99)
+        expect_boot = f"{max(mean - lo, hi - mean):.3g}"
+        expect_t = f"{su.t_halfwidth(100.0, 10):.3g}"
+        assert rows["anthocnet"]["delay99_ci"] == expect_boot, rows
+        assert rows["aodv"]["delay99_ci"] == expect_t, rows
+        assert expect_boot != expect_t
+        assert "1 with bootstrap delay99_ci, 1 t-fallback" in out.getvalue()
+
+
 # ---- end-to-end through main() ----------------------------------------------
 
 @case("bench_parse main: paired verdict replaces materiality verdict")

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -99,6 +99,7 @@ jobs:
           name: benchmark-results
           path: |
             scenarios.csv
+            scenarios-runs.csv
             docs/benchmarks/*.png
           retention-days: 7
       - name: Commit refreshed results (if changed)

--- a/.github/workflows/rescue-artifacts.yml
+++ b/.github/workflows/rescue-artifacts.yml
@@ -59,6 +59,12 @@ jobs:
             fi
             echo "run $id ($label): $rows data rows"
             cp "$dir/scenarios.csv" "docs/benchmarks/campaign/${id}-${label}.csv"
+            # #319: the per-run sibling rides along when the producing run is
+            # new enough to have written it; absent for older runs.
+            if [ -f "$dir/scenarios-runs.csv" ]; then
+              cp "$dir/scenarios-runs.csv" \
+                 "docs/benchmarks/campaign/${id}-${label}-runs.csv"
+            fi
           done
           rm -rf rescue-tmp
       - name: Download satellite artifacts and stage results (#259)

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -165,6 +165,7 @@ jobs:
           name: scenario-matrix
           path: |
             scenarios.csv
+            scenarios-runs.csv
             docs/benchmarks/*.png
           retention-days: 7
           if-no-files-found: warn

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -179,7 +179,12 @@ computation lives in
 
 Significance in an A/B is "the difference CI excludes zero" — when per-seed
 `##RUN##` rows are present, this **replaces** `bench_parse.py`'s materiality
-thresholds (which remain the fallback for aggregate-only cells). Sweeps that
+thresholds (which remain the fallback for aggregate-only cells). Campaigns
+persist the per-run values in a sibling `<out>-runs.csv`
+([#319](https://github.com/danieljoppi/AntHocNet/issues/319), rescued
+alongside the aggregate CSV), so sweep `delay99` intervals use the bootstrap
+once that file exists for a campaign; older aggregate-only CSVs fall back to
+the t-CI, which is then a documented approximation. Sweeps that
 produce many comparisons get a multiple-comparison note (at α = 0.05, expect
 ~1 false positive per 20 cells); treat isolated marginal p-values accordingly.
 

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -146,6 +146,19 @@ OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + ["runs", "nNodes", "areaX", "speed", "pause", "flows", "propagation"]
                + METRICS)
 
+# #319: the sibling per-run CSV (<out minus .csv>-runs.csv). The aggregate CSV
+# above carries mean+sd only, which makes the #293 policy's stronger branches
+# (bootstrap CIs for tail metrics, paired per-seed A/B) unreachable for
+# sweeps; this file persists the harness's ##RUN## rows (#128) by NAME so
+# downstream never depends on the positional ##RUN## contract. Field order of
+# a ##RUN## line: run proto pdr delay delay99 thrput nrl jitter off50 off90
+# nrl_bytes; "inf" offered-load percentiles are written as -1, matching the
+# aggregate CSV's delay_off*_ms encoding.
+RUN_METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
+               "jitter_ms", "delay_off50_ms", "delay_off90_ms", "nrl_bytes"]
+RUN_COLUMNS = (["kind", "group", "x", "scenario", "protocol", "run"]
+               + RUN_METRICS)
+
 
 def build_args(flags, runs, time, protocols, propagation, extra_args=""):
     """Turn a flags dict into an anthocnet-compare argument string."""
@@ -174,7 +187,7 @@ def run_compare(ns3dir, arg_str, dry_run, label=""):
     cmd = f'cd "{ns3dir}" && ./ns3 run "anthocnet-compare {arg_str}"'
     if dry_run:
         print(f"[dry-run] {cmd}", file=sys.stderr)
-        return []
+        return [], []
     print(f"[run] anthocnet-compare {arg_str}", file=sys.stderr)
     # #131: sim cost per point — wall clock always; peak RSS via
     # `/usr/bin/time -v` into a temp file when available (getrusage's
@@ -212,7 +225,20 @@ def run_compare(ns3dir, arg_str, dry_run, label=""):
             or ln.split(",", 1)[0] in ("anthocnet", "aodv", "olsr", "dsdv", "dsr")]
     if not keep or not keep[0].startswith("protocol,"):
         raise SystemExit(f"no CSV parsed from anthocnet-compare for: {arg_str}")
-    return list(csv.DictReader(io.StringIO("\n".join(keep))))
+    # #319: the per-run ##RUN## rows ride along, parsed by position here so
+    # every consumer downstream reads them by name from the sibling CSV.
+    run_rows = []
+    for ln in proc.stdout.splitlines():
+        if not ln.startswith("##RUN##"):
+            continue
+        toks = ln.split()
+        if len(toks) < 4:
+            continue
+        vals = {"run": toks[1], "protocol": toks[2]}
+        for name, tok in zip(RUN_METRICS, toks[3:]):
+            vals[name] = "-1" if tok == "inf" else tok
+        run_rows.append(vals)
+    return list(csv.DictReader(io.StringIO("\n".join(keep)))), run_rows
 
 
 def emit(writer, kind, group, x, scenario, klass, pause, propagation, rows):
@@ -228,6 +254,13 @@ def emit(writer, kind, group, x, scenario, klass, pause, propagation, rows):
         for m in METRICS:
             out[m] = r.get(m, "")
         writer.writerow(out)
+
+
+def emit_runs(writer, kind, group, x, scenario, run_rows):
+    """#319: one sibling-CSV row per (protocol, RNG run) of this point."""
+    for r in run_rows:
+        writer.writerow({"kind": kind, "group": group, "x": x,
+                         "scenario": scenario, **r})
 
 
 def main():
@@ -275,21 +308,31 @@ def main():
     want_discrete = args.only in ("all", "discrete") or args.only in DISCRETE
     want_sweeps = args.only in ("all", "sweeps") or args.only in SWEEPS
 
-    with open(args.out, "w", newline="") as f:
+    # #319: per-run rows land in a sibling file, flushed per point like the
+    # aggregate CSV (#119), so a killed job still leaves both consistent.
+    runs_out = args.out.removesuffix(".csv") + "-runs.csv"
+
+    with open(args.out, "w", newline="") as f, \
+         open(runs_out, "w", newline="") as fr:
         w = csv.DictWriter(f, fieldnames=OUT_COLUMNS)
         w.writeheader()
+        wr = csv.DictWriter(fr, fieldnames=RUN_COLUMNS)
+        wr.writeheader()
 
         if want_discrete:
             for name, (klass, flags) in DISCRETE.items():
                 if args.only in DISCRETE and args.only != name:
                     continue
-                rows = run_compare(args.ns3dir,
-                                   build_args(flags, runs, sim_time, args.protocols,
-                                              args.propagation, args.extra_args),
-                                   args.dry_run, label=name)
+                rows, run_rows = run_compare(
+                    args.ns3dir,
+                    build_args(flags, runs, sim_time, args.protocols,
+                               args.propagation, args.extra_args),
+                    args.dry_run, label=name)
                 emit(w, "discrete", name, "", name, klass, flags.get("pause", ""),
                      args.propagation, rows)
+                emit_runs(wr, "discrete", name, "", name, run_rows)
                 f.flush()
+                fr.flush()
 
         if want_sweeps:
             for name, (xlabel, base, points) in sweeps.items():
@@ -306,16 +349,19 @@ def main():
                 for x, extra in points:
                     flags = dict(base)
                     flags.update(extra)
-                    rows = run_compare(args.ns3dir,
-                                       build_args(flags, runs, sim_time, args.protocols,
-                                                  args.propagation, args.extra_args),
-                                       args.dry_run, label=f"{name}={x}")
+                    rows, run_rows = run_compare(
+                        args.ns3dir,
+                        build_args(flags, runs, sim_time, args.protocols,
+                                   args.propagation, args.extra_args),
+                        args.dry_run, label=f"{name}={x}")
                     emit(w, "sweep", name, x, f"{name}={x}", xlabel,
                          flags.get("pause", ""), args.propagation, rows)
+                    emit_runs(wr, "sweep", name, x, f"{name}={x}", run_rows)
                     f.flush()
+                    fr.flush()
 
     if not args.dry_run:
-        print(f"wrote {args.out}", file=sys.stderr)
+        print(f"wrote {args.out} + {runs_out}", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Implements **#319**. Campaign CSVs carried aggregates only, making the #293 policy's stronger branches unreachable for sweeps (bootstrap CIs for `delay99`, paired per-seed A/B). Now:

- **Producer**: `run-scenarios.py` writes `<out>-runs.csv` beside the aggregate CSV — one row per (point, protocol, RNG run), parsed from the `##RUN##` lines once at the source and persisted **by name**, so no downstream consumer depends on the positional contract again. `inf` → `-1` (the existing `delay_off*_ms` convention); per-point flush (#119).
- **Plumbing**: both workflow artifacts carry the sibling; `rescue-artifacts.yml` lands it as `<id>-<label>-runs.csv` when present (non-fatal for older runs).
- **Consumer**: `sweep_summary.py --export-sweeps` uses the **percentile bootstrap** for `delay99_ci` when the sibling exists (symmetric envelope `max(mean−lo, hi−mean)` — the papers schema carries one half-width), t-CI fallback otherwise; the export line reports the split. A CSV nothing consumes is half-shipped — this makes the file falsifiable on its first real campaign.
- **Docs**: methodology records where per-run values live and that the sweep-delay99 t-CI is now a pre-#319 fallback only.

## Verification

- `test_stats.py` gains a must-differ case: synthetic aggregate + sibling with skewed per-run p99s → bootstrap envelope for the protocol with sibling rows, t value for the one without, provably different values. 21 + 35 cases pass.
- `run-scenarios.py --dry-run` writes both headers and threads args unchanged (verified for `--only discrete` and `--only pause --point 0`).
- ruff (0.16.0) clean; mermaid gate clean.

Deliberately not here: sweep-level paired `--vs` verdicts from sibling rows — that consumer lands when the first campaign producing the file exists (tracked on #319). Harness/tooling only; no protocol behaviour, no A/B required.

Refs #319, #293, #128, #119, #126, #298.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_