### PR TITLE
feat(bench): seed-splitting — firstrun offset threaded end-to-end, exact pooling

### DIFF
--- a/.claude/skills/benchmark-results/pool_runs.py
+++ b/.claude/skills/benchmark-results/pool_runs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Pool seed-split campaign CSVs into one aggregate CSV (#126).
+
+A point too big for the 6 h hosted-runner ceiling at full seed count runs as
+several dispatches of the same point with different --run-first values
+(e.g. runs=10 firstRun=1, then runs=10 firstRun=11). Each dispatch produces
+an aggregate campaign CSV plus its #319 per-run sibling (<file>-runs.csv).
+This script merges the splits back into one publishable aggregate row per
+(kind, group, x, protocol):
+
+- pdr/delay/delay99/thrput/nrl/jitter/nrl_bytes and their *_sd columns are
+  recomputed EXACTLY from the pooled per-run sibling rows — no combined-
+  variance approximation, which is the reason the sibling file exists.
+- every other numeric column (energy_*, drop_*, path_*, ...) is the
+  runs-weighted mean of the split aggregates (those are means, so the
+  weighted mean is exact; their dispersion was never published).
+- context columns (scenario/class/nNodes/...) come from the first split row
+  and must agree across splits — a mismatch means the splits are not the
+  same point and the script FAILs.
+- `runs` becomes the pooled total; `run_first` the smallest. Duplicate seeds
+  across splits (two dispatches covering the same RNG run) FAIL: pooling
+  them would double-weight realisations.
+
+Usage:
+    pool_runs.py --out pooled.csv SPLIT_A.csv SPLIT_B.csv [...]
+
+The output is a standard classified CSV (same columns as the inputs), and a
+pooled -runs.csv sibling is written next to --out so downstream bootstrap /
+paired consumers (#319) keep working on the pooled point.
+"""
+import argparse
+import csv
+import os
+import sys
+
+import stats_util
+
+# metric -> per-run sibling column it is recomputed from
+EXACT = {"pdr_pct": "pdr_pct", "delay_ms": "delay_ms",
+         "delay99_ms": "delay99_ms", "throughput_kbps": "throughput_kbps",
+         "nrl": "nrl", "jitter_ms": "jitter_ms", "nrl_bytes": "nrl_bytes"}
+SD_OF = {"pdr_sd": "pdr_pct", "delay_sd": "delay_ms",
+         "delay99_sd": "delay99_ms", "nrl_sd": "nrl"}
+CONTEXT = ["scenario", "class", "nNodes", "areaX", "speed", "pause", "flows",
+           "propagation"]
+
+
+def fnum(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("files", nargs="+", help="split aggregate campaign CSVs "
+                    "(each with its -runs.csv sibling next to it)")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    agg = {}       # (kind, group, x, protocol) -> [aggregate rows]
+    per_run = {}   # same key -> {seed: sibling row}
+    header = None
+    run_header = None
+    for path in args.files:
+        with open(path, newline="") as fh:
+            r = csv.DictReader(fh)
+            header = header or r.fieldnames
+            for row in r:
+                k = (row["kind"], row["group"], row["x"], row["protocol"])
+                agg.setdefault(k, []).append(row)
+        sib = path.removesuffix(".csv") + "-runs.csv"
+        if not os.path.exists(sib):
+            sys.exit(f"FAIL: {sib} missing — pooling recomputes sd from the "
+                     "per-run rows (#319); a split without its sibling "
+                     "cannot be pooled exactly")
+        with open(sib, newline="") as fh:
+            r = csv.DictReader(fh)
+            run_header = run_header or r.fieldnames
+            for row in r:
+                k = (row["kind"], row["group"], row["x"], row["protocol"])
+                seed = int(row["run"])
+                if seed in per_run.setdefault(k, {}):
+                    sys.exit(f"FAIL: seed {seed} of {'/'.join(k)} appears in "
+                             "two splits — pooling would double-weight that "
+                             "realisation. Fix the dispatch plan.")
+                per_run[k][seed] = row
+
+    out_rows = []
+    pooled_runs = []
+    for k in sorted(agg, key=lambda k: (k[0], k[1], fnum(k[2]) or 0, k[3])):
+        splits = agg[k]
+        runs_per_split = [int(float(s.get("runs") or 0)) for s in splits]
+        total = sum(runs_per_split)
+        seeds = per_run.get(k, {})
+        if len(seeds) != total:
+            sys.exit(f"FAIL: {'/'.join(k)}: {total} runs claimed by the "
+                     f"aggregates but {len(seeds)} sibling rows — a split is "
+                     "truncated or mismatched")
+        for c in CONTEXT:
+            vals = {s.get(c, "") for s in splits}
+            if len(vals) > 1:
+                sys.exit(f"FAIL: {'/'.join(k)}: context column {c} differs "
+                         f"across splits ({sorted(vals)}) — not the same "
+                         "point")
+        out = dict(splits[0])
+        out["runs"] = str(total)
+        if "run_first" in out:
+            out["run_first"] = str(min(
+                int(float(s.get("run_first") or 1)) for s in splits))
+        for col, src in EXACT.items():
+            vals = [v for v in (fnum(r.get(src)) for r in seeds.values())
+                    if v is not None and v >= 0]
+            if vals and col in out:
+                out[col] = f"{sum(vals) / len(vals):.4f}"
+        for col, src in SD_OF.items():
+            vals = [v for v in (fnum(r.get(src)) for r in seeds.values())
+                    if v is not None and v >= 0]
+            if vals and col in out:
+                out[col] = f"{stats_util.sample_sd(vals):.4f}"
+        # runs-weighted mean for every other numeric column
+        for col in (header or []):
+            if col in EXACT or col in SD_OF or col == "runs" \
+                    or col == "run_first" or col in CONTEXT \
+                    or col in ("kind", "group", "x", "protocol"):
+                continue
+            pairs = [(fnum(s.get(col)), n)
+                     for s, n in zip(splits, runs_per_split)]
+            if any(v is None for v, _ in pairs):
+                continue  # blank/sentinel in any split -> keep first as-is
+            out[col] = f"{sum(v * n for v, n in pairs) / total:.4f}"
+        out_rows.append(out)
+        pooled_runs.extend(seeds[s] for s in sorted(seeds))
+
+    with open(args.out, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=header)
+        w.writeheader()
+        w.writerows(out_rows)
+    sib_out = args.out.removesuffix(".csv") + "-runs.csv"
+    with open(sib_out, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=run_header)
+        w.writeheader()
+        w.writerows(pooled_runs)
+    print(f"pooled {len(args.files)} split(s) -> {args.out} "
+          f"({len(out_rows)} row(s)) + {sib_out} ({len(pooled_runs)} run "
+          f"row(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/benchmark-results/test_stats.py
+++ b/.claude/skills/benchmark-results/test_stats.py
@@ -41,6 +41,7 @@ def _load(name):
 su = _load("stats_util")
 bp = _load("bench_parse")
 sw = _load("sweep_summary")
+pr = _load("pool_runs")
 
 CASES = []
 
@@ -305,6 +306,94 @@ def _():
         assert rows["aodv"]["delay99_ci"] == expect_t, rows
         assert expect_boot != expect_t
         assert "1 with bootstrap delay99_ci, 1 t-fallback" in out.getvalue()
+
+
+# ---- pool_runs (#126) --------------------------------------------------------
+
+AGG_COLS = ["kind", "group", "x", "scenario", "class", "protocol", "runs",
+            "pdr_pct", "delay_ms", "delay99_ms", "nrl", "pdr_sd",
+            "delay99_sd", "energy_j", "run_first"]
+RUN_COLS = ["kind", "group", "x", "scenario", "protocol", "run", "pdr_pct",
+            "delay_ms", "delay99_ms", "nrl"]
+
+
+def _write_split(td, name, first, pdrs, energy):
+    """One split: aggregate row + per-run sibling for scale/2.0/anthocnet."""
+    import csv as _csv
+    n = len(pdrs)
+    aggp = os.path.join(td, name)
+    with open(aggp, "w", newline="") as fh:
+        w = _csv.DictWriter(fh, fieldnames=AGG_COLS)
+        w.writeheader()
+        w.writerow({"kind": "sweep", "group": "scale", "x": "2.0",
+                    "scenario": "scale=2.0", "class": "scale factor",
+                    "protocol": "anthocnet", "runs": n,
+                    "pdr_pct": f"{sum(pdrs) / n:.4f}", "delay_ms": "50.0",
+                    "delay99_ms": "900.0", "nrl": "3.0",
+                    "pdr_sd": "9.99", "delay99_sd": "9.99",
+                    "energy_j": energy, "run_first": first})
+    with open(aggp.removesuffix(".csv") + "-runs.csv", "w", newline="") as fh:
+        w = _csv.DictWriter(fh, fieldnames=RUN_COLS)
+        w.writeheader()
+        for i, p in enumerate(pdrs):
+            w.writerow({"kind": "sweep", "group": "scale", "x": "2.0",
+                        "scenario": "scale=2.0", "protocol": "anthocnet",
+                        "run": first + i, "pdr_pct": p, "delay_ms": "50.0",
+                        "delay99_ms": "900.0", "nrl": "3.0"})
+    return aggp
+
+
+def _run_pool(argv):
+    out = io.StringIO()
+    old, sys.argv = sys.argv, ["pool_runs.py"] + argv
+    code = 0
+    try:
+        with contextlib.redirect_stdout(out):
+            try:
+                pr.main()
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 1
+    finally:
+        sys.argv = old
+    return code, out.getvalue()
+
+
+@case("#126 pooling recomputes mean/sd exactly from the pooled seeds")
+def _():
+    import csv as _csv
+    import tempfile
+    pdrs_a, pdrs_b = [80.0, 82.0, 84.0], [70.0, 72.0]
+    with tempfile.TemporaryDirectory() as td:
+        a = _write_split(td, "a.csv", 1, pdrs_a, "500.0")
+        b = _write_split(td, "b.csv", 4, pdrs_b, "600.0")
+        outp = os.path.join(td, "pooled.csv")
+        code, _txt = _run_pool([a, b, "--out", outp])
+        assert code == 0, _txt
+        with open(outp, newline="") as fh:
+            row = next(iter(_csv.DictReader(fh)))
+        allp = pdrs_a + pdrs_b
+        approx(float(row["pdr_pct"]), sum(allp) / len(allp), tol=1e-3)
+        approx(float(row["pdr_sd"]), su.sample_sd(allp), tol=1e-3)
+        assert row["runs"] == "5" and row["run_first"] == "1"
+        # aggregate-only column: runs-weighted mean (3*500 + 2*600)/5
+        approx(float(row["energy_j"]), 540.0, tol=1e-3)
+        with open(outp.removesuffix(".csv") + "-runs.csv", newline="") as fh:
+            seeds = [r["run"] for r in _csv.DictReader(fh)]
+        assert seeds == ["1", "2", "3", "4", "5"], seeds
+
+
+@case("#126 pooling FAILs on duplicate seeds and on a missing sibling")
+def _():
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        a = _write_split(td, "a.csv", 1, [80.0, 82.0], "500.0")
+        b = _write_split(td, "b.csv", 2, [70.0, 72.0], "600.0")  # seed 2 dup
+        code, _txt = _run_pool([a, b, "--out", os.path.join(td, "p.csv")])
+        assert code != 0, "duplicate seed must FAIL"
+        c = _write_split(td, "c.csv", 1, [80.0], "500.0")
+        os.unlink(c.removesuffix(".csv") + "-runs.csv")
+        code, _txt = _run_pool([c, "--out", os.path.join(td, "p2.csv")])
+        assert code != 0, "missing sibling must FAIL"
 
 
 # ---- end-to-end through main() ----------------------------------------------

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,8 @@ jobs:
             .claude/skills/benchmark-results/scenario_check.py \
             .claude/skills/benchmark-results/test_scenario_check.py \
             .claude/skills/benchmark-results/stats_util.py \
-            .claude/skills/benchmark-results/test_stats.py
+            .claude/skills/benchmark-results/test_stats.py \
+            .claude/skills/benchmark-results/pool_runs.py
       - name: Statistics self-test (#293)
         # stats_util.py computes the 95% CIs and paired tests every published
         # number will carry; bench_parse.py's column-mapping check decides

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -27,6 +27,9 @@ on:
       point:
         description: 'With only=<sweep name>: run just this one point (e.g. 1500 for area, 900 for pause, 1.4 for scale) instead of the whole sweep. Leave blank for the whole sweep.'
         default: ''
+      runFirst:
+        description: 'First RNG run (seed) of this dispatch (#126): seeds cover runFirst..runFirst+runs-1, so a point too big for the 6 h ceiling at full seed count splits across dispatches (e.g. runs=10 runFirst=1, then runs=10 runFirst=11). Pool the split CSVs with pool_runs.py. Leave blank for 1.'
+        default: ''
       propagation:
         description: 'Propagation model override for every point: range (disk) | tworay. Leave blank for anthocnet-compare''s default (range).'
         default: ''
@@ -129,6 +132,10 @@ jobs:
           if [ -n "${{ github.event.inputs.point }}" ]; then
             point="--point=${{ github.event.inputs.point }}"
           fi
+          runfirst=""
+          if [ -n "${{ github.event.inputs.runFirst }}" ]; then
+            runfirst="--run-first=${{ github.event.inputs.runFirst }}"
+          fi
           # #177: extraArgs must reach anthocnet-compare as ONE argv element
           # here, so it is quoted — unlike $quick/$propagation/$point above,
           # which are single tokens deliberately left unquoted to expand to
@@ -143,7 +150,7 @@ jobs:
             --time "${{ github.event.inputs.time }}" \
             --only "${{ github.event.inputs.only }}" \
             --extra-args "${{ github.event.inputs.extraArgs }}" \
-            $quick $propagation $point
+            $quick $propagation $point $runfirst
       - name: Render charts
         # always(): a mid-sweep failure (one anthocnet-compare invocation
         # raising SystemExit) still leaves a valid, closed CSV for whatever

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -98,7 +98,14 @@ published GHCR images (Actions → workflow → *Run workflow*):
   — the taxonomy + the area/pause/scale sweeps. A real (non-`quick`) whole
   sweep does **not** fit the 6 h hosted-runner ceiling
   ([#121](https://github.com/danieljoppi/AntHocNet/issues/121)) — dispatch it
-  one point per job via `only=<sweep>` + `point=<value>`. With `commit=true`
+  one point per job via `only=<sweep>` + `point=<value>`. A single point too
+  big for the ceiling at full seed count (measured: the 98/162/200-node
+  scale points at 20 seeds, [#126](https://github.com/danieljoppi/AntHocNet/issues/126))
+  splits across dispatches with `runFirst` — seeds cover
+  `runFirst..runFirst+runs-1`, and
+  [`pool_runs.py`](../../.claude/skills/benchmark-results/pool_runs.py)
+  merges the split CSVs back into one aggregate row per point, recomputing
+  mean/sd exactly from the pooled #319 per-run rows. With `commit=true`
   the classified CSV lands in `docs/benchmarks/campaign/` and the regenerated
   charts in `docs/benchmarks/`; otherwise everything stays in the run's
   artifacts.

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -1445,6 +1445,14 @@ int main(int argc, char* argv[]) {
     int32_t  nFlows = 0;
     int32_t  sink = -1;
     uint32_t runs = 0;  // 0 = unset; resolved below (preset-dependent, #58)
+    // #126: first RNG run of this invocation. Runs cover
+    // firstRun..firstRun+runs-1, so one point's 20 seeds can be split across
+    // dispatches that each fit the hosted-runner job ceiling (the 162/200-node
+    // scale points exceed it at 20 seeds even on the -opt image). SetRun(s)
+    // semantics are unchanged — the ##RUN##/##MATCH##/##COMMON## rows carry
+    // the TRUE seed, so downstream per-seed pairing keeps working across
+    // split dispatches. Default 1 keeps every existing invocation identical.
+    uint32_t firstRun = 1;
     bool csv = false;
     std::string protocols = "anthocnet,aodv,olsr,dsdv";
 
@@ -1466,6 +1474,10 @@ int main(int argc, char* argv[]) {
                          "hotspot, #71) instead of i->(n-1-i) pairing", sink);
     cmd.AddValue("runs", "Number of RNG runs to average (seeds 1..runs); unset "
                          "= 1, or 20 for --scenario=thesis (#58)", runs);
+    cmd.AddValue("firstRun", "First RNG run (seed) of this invocation; runs "
+                             "cover firstRun..firstRun+runs-1, so a point's "
+                             "seeds can split across dispatches (#126)",
+                 firstRun);
     cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
     cmd.AddValue("protocols", "Comma-separated list", protocols);
     cmd.AddValue("diag", "Emit per-run '# diag' lines (ant tallies, first delivery)", g_diag);
@@ -1626,9 +1638,9 @@ int main(int argc, char* argv[]) {
     std::vector<std::vector<MatchCell>> matchGrid(
         list.size(), std::vector<MatchCell>(runs));
     for (std::size_t i = 0; i < list.size(); ++i) {
-        for (uint32_t s = 1; s <= runs; ++s) {
+        for (uint32_t s = firstRun; s < firstRun + runs; ++s) {
             Result r = RunOne(list[i], P, s);
-            MatchCell& mc = matchGrid[i][s - 1];
+            MatchCell& mc = matchGrid[i][s - firstRun];
             mc.hist = r.delayHist;
             mc.binWidth = r.delayBinWidth;
             mc.rx = r.rxPackets;
@@ -1797,17 +1809,17 @@ int main(int argc, char* argv[]) {
             }
             return -1.0;  // fewer deliveries than the target: undefined here
         };
-        for (uint32_t s = 1; s <= runs; ++s) {
+        for (uint32_t s = firstRun; s < firstRun + runs; ++s) {
             uint64_t rxMin = 0;
             bool have = false;
             for (std::size_t i = 0; i < list.size(); ++i) {
-                const uint64_t rx = matchGrid[i][s - 1].rx;
+                const uint64_t rx = matchGrid[i][s - firstRun].rx;
                 if (!have || rx < rxMin) { rxMin = rx; have = true; }
             }
             if (!have || rxMin == 0) continue;
             const uint64_t target = static_cast<uint64_t>(0.99 * rxMin);
             for (std::size_t i = 0; i < list.size(); ++i) {
-                const MatchCell& c = matchGrid[i][s - 1];
+                const MatchCell& c = matchGrid[i][s - firstRun];
                 const double matched = quantileAt(c, target);
                 std::cout << std::fixed << "##MATCH## " << s << ' ' << list[i]
                           << ' ' << c.rx << ' ' << rxMin
@@ -1848,13 +1860,13 @@ int main(int argc, char* argv[]) {
             if (i >= v.size()) i = v.size() - 1;
             return 1000.0 * v[i];
         };
-        for (uint32_t s = 1; s <= runs; ++s) {
+        for (uint32_t s = firstRun; s < firstRun + runs; ++s) {
             // Keys delivered by every protocol this run.
             std::set<std::pair<Address, uint32_t>> common;
             bool first = true;
             for (std::size_t i = 0; i < list.size(); ++i) {
                 std::set<std::pair<Address, uint32_t>> mine;
-                for (const auto& f : matchGrid[i][s - 1].bySeq)
+                for (const auto& f : matchGrid[i][s - firstRun].bySeq)
                     for (const auto& kv : f.second) mine.insert({f.first, kv.first});
                 if (first) { common = mine; first = false; continue; }
                 std::set<std::pair<Address, uint32_t>> both;
@@ -1867,7 +1879,7 @@ int main(int argc, char* argv[]) {
             for (std::size_t i = 0; i < list.size(); ++i) {
                 std::vector<double> inCommon, surplus;
                 std::size_t nSelf = 0;
-                for (const auto& f : matchGrid[i][s - 1].bySeq) {
+                for (const auto& f : matchGrid[i][s - firstRun].bySeq) {
                     for (const auto& kv : f.second) {
                         ++nSelf;
                         if (common.count({f.first, kv.first})) inCommon.push_back(kv.second);

--- a/ns3/tools/run-scenarios.py
+++ b/ns3/tools/run-scenarios.py
@@ -144,7 +144,10 @@ METRICS = ["pdr_pct", "delay_ms", "delay99_ms", "throughput_kbps", "nrl",
 PARAMS = ["runs", "nNodes", "area", "speed", "flows"]
 OUT_COLUMNS = (["kind", "group", "x", "scenario", "class", "protocol"]
                + ["runs", "nNodes", "areaX", "speed", "pause", "flows", "propagation"]
-               + METRICS)
+               + METRICS
+               # #126: first seed of this dispatch (1 unless seed-split);
+               # APPEND ONLY, like every column above.
+               + ["run_first"])
 
 # #319: the sibling per-run CSV (<out minus .csv>-runs.csv). The aggregate CSV
 # above carries mean+sd only, which makes the #293 policy's stronger branches
@@ -160,10 +163,13 @@ RUN_COLUMNS = (["kind", "group", "x", "scenario", "protocol", "run"]
                + RUN_METRICS)
 
 
-def build_args(flags, runs, time, protocols, propagation, extra_args=""):
+def build_args(flags, runs, time, protocols, propagation, extra_args="",
+               run_first=1):
     """Turn a flags dict into an anthocnet-compare argument string."""
     merged = dict(flags)
     merged.setdefault("runs", runs)
+    if run_first != 1:  # #126: default stays byte-identical to pre-#126 lines
+        merged.setdefault("firstRun", run_first)
     if time is not None:
         merged.setdefault("time", time)
     merged.setdefault("protocols", protocols)
@@ -241,7 +247,8 @@ def run_compare(ns3dir, arg_str, dry_run, label=""):
     return list(csv.DictReader(io.StringIO("\n".join(keep)))), run_rows
 
 
-def emit(writer, kind, group, x, scenario, klass, pause, propagation, rows):
+def emit(writer, kind, group, x, scenario, klass, pause, propagation, rows,
+         run_first=1):
     for r in rows:
         out = {
             "kind": kind, "group": group, "x": x, "scenario": scenario,
@@ -250,6 +257,7 @@ def emit(writer, kind, group, x, scenario, klass, pause, propagation, rows):
             "areaX": r.get("area", ""), "speed": r.get("speed", ""),
             "pause": pause, "flows": r.get("flows", ""),
             "propagation": propagation or "range",
+            "run_first": run_first,
         }
         for m in METRICS:
             out[m] = r.get(m, "")
@@ -268,6 +276,12 @@ def main():
     ap.add_argument("ns3dir", help="configured ns-3 tree with the anthocnet module")
     ap.add_argument("--out", default="scenarios.csv", help="output CSV path")
     ap.add_argument("--runs", type=int, default=5, help="RNG runs to average per point")
+    ap.add_argument("--run-first", type=int, default=1,
+                    help="first RNG run (seed) of this invocation; runs cover "
+                         "run-first..run-first+runs-1, so one point's seeds "
+                         "can split across dispatches that each fit the job "
+                         "ceiling (#126). Pool the split CSVs with "
+                         ".claude/skills/benchmark-results/pool_runs.py")
     ap.add_argument("--time", type=int, default=None,
                     help="sim time (s) override; default uses each scenario's own")
     ap.add_argument("--protocols", default="anthocnet,aodv,olsr,dsdv")
@@ -326,10 +340,11 @@ def main():
                 rows, run_rows = run_compare(
                     args.ns3dir,
                     build_args(flags, runs, sim_time, args.protocols,
-                               args.propagation, args.extra_args),
+                               args.propagation, args.extra_args,
+                               args.run_first),
                     args.dry_run, label=name)
                 emit(w, "discrete", name, "", name, klass, flags.get("pause", ""),
-                     args.propagation, rows)
+                     args.propagation, rows, args.run_first)
                 emit_runs(wr, "discrete", name, "", name, run_rows)
                 f.flush()
                 fr.flush()
@@ -352,10 +367,12 @@ def main():
                     rows, run_rows = run_compare(
                         args.ns3dir,
                         build_args(flags, runs, sim_time, args.protocols,
-                                   args.propagation, args.extra_args),
+                                   args.propagation, args.extra_args,
+                                   args.run_first),
                         args.dry_run, label=f"{name}={x}")
                     emit(w, "sweep", name, x, f"{name}={x}", xlabel,
-                         flags.get("pause", ""), args.propagation, rows)
+                         flags.get("pause", ""), args.propagation, rows,
+                         args.run_first)
                     emit_runs(wr, "sweep", name, x, f"{name}={x}", run_rows)
                     f.flush()
                     fr.flush()


### PR DESCRIPTION
## Why now — the measured trigger

2026-08-04 scale-sweep campaign (`3.42-opt`, 900 s, 20 seeds, disk, one point per job):

| point | nodes | outcome |
|---|---|---|
| f=1.0 | 50 | ✅ 99 min (run 30854990473) |
| f=1.4 | 98 | ❌ killed at the **340-min step timeout** (30854998767) |
| f=1.8 | 162 | ❌ killed at 340 min (30855007367) |
| f=2.0 | 200 | ❌ killed at 340 min (30855017185) |

Per-seed cost scales ~quadratically with node count (≈4.6 min/seed at 50 nodes; >17 at 98), so the larger scale points cannot fit 20 seeds in any single hosted-runner job — #126 stops being contingency. Implements the issue's spec.

## What

- **`anthocnet-compare.cc`**: new `firstRun` arg (default 1 — existing invocations byte-identical). The three per-run loops cover `firstRun..firstRun+runs-1`, `matchGrid` indexed by `s−firstRun`; `SetRun(s)` semantics unchanged, and `##RUN##`/`##MATCH##`/`##COMMON##` rows carry the **true seed**, so per-seed pairing works across split dispatches. Harness only — no core/wire/protocol change; the determinism gate's property (same (seed,run) ⇒ same realisation) is exactly what splitting leans on.
- **`run-scenarios.py`**: `--run-first` passthrough (emits `--firstRun` only when ≠1) + `run_first` column appended to `OUT_COLUMNS`.
- **`scenario-matrix.yml`**: `runFirst` dispatch input, threaded like `point`.
- **`pool_runs.py`** (new skill script): merges split CSVs into one row per point — headline metrics + `*_sd` recomputed **exactly** from the pooled #319 per-run sibling rows (no combined-variance approximation), runs-weighted mean for the rest, context columns must agree, duplicate seeds and missing siblings FAIL loudly. Writes a pooled `-runs.csv` so #319 consumers work on pooled points.

## Verification

- `test_stats.py` → 23 cases (pooled mean/sd match direct computation over the seed union; duplicate-seed + missing-sibling FAILs fire); `test_scenario_check.py` → 35; `make test` → 25/25.
- Dry-run threading: `--only scale --point 2.0 --runs 3 --run-first 19` emits `--runs=3 --firstRun=19`.
- ruff (0.16.0) + mermaid + default-parity gates clean. The CI matrix compiles the modified example across ns-3.36–3.48.

## After merge

Dispatch the dead points as splits sized from measured per-seed cost with margin under the 340-min step timeout: **f=1.4 2×10, f=1.8 4×5, f=2.0 6×3+1×2**, then `pool_runs.py` → scale publication (#110).

Refs #126, #121, #319, #293, #110, #298.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_