### PR TITLE
docs: correct the ns-2 support claim, and consolidate ns-2 into one document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ which gates packet compatibility independently.
 ## Unreleased
 
 ### Deprecated
-- **NS-2 support.** `v1.2.0` is the **last release that ships the NS-2
-  adapter**; it is removed at `v2.0.0`
+- **NS-2 support.** `v1.2.0` is the **last release in which the NS-2 adapter
+  was actively supported** — it is frozen (no new NS-2 work) but still ships
+  through the rest of the `v1.x` line, and is removed at `v2.0.0`
   ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)). Nothing already
   published is withdrawn — pin the `v1.2.0` tag or its immutable images
   (`ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` / `:2.35-v1.2.0`), which stay

--- a/README.md
+++ b/README.md
@@ -17,15 +17,18 @@ for **NS-2** and **NS-3**.
 The repository no longer bundles a copy of any simulator. You install AntHocNet
 onto *your own* NS-2 or NS-3 tree:
 
-- **NS-2** — installed as an idempotent, version-independent source patch
-  (`ns-2.34` / `ns-2.35`). **Deprecated:
-  [v1.2.0](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.2.0) is the
-  last release that ships NS-2 support** — see
-  [#307](https://github.com/danieljoppi/AntHocNet/issues/307). Pin that tag (or
-  its immutable images `ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` /
-  `:2.35-v1.2.0`) if you need it; published tags are not withdrawn.
 - **NS-3** — installed as an additive `contrib/` module (ns-3.36+, with a
   `wscript` for older waf builds).
+- **NS-2** — installed as an idempotent source patch (`ns-2.34` / `ns-2.35`).
+
+> [!NOTE]
+> **NS-2 is deprecated and frozen at
+> [v1.2.0](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.2.0)** — it
+> still ships through the rest of `v1.x` and is removed at v2.0.0
+> ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)). Everything
+> NS-2 — status, install, images, rationale — lives in
+> **[docs/ns2-support.md](docs/ns2-support.md)**. ns-3 is the supported target
+> and is what the rest of this README describes.
 
 ```
 core/   simulator-agnostic C++ (no NS-2/NS-3 dependency) + unit tests
@@ -34,20 +37,15 @@ ns3/    native Ipv4RoutingProtocol module
 docs/   architecture, configuration, benchmarks, fidelity, ADRs — map in docs/README.md
 ```
 
-## Why one core, two adapters
+## Why one core, thin adapters
 
-NS-2 and NS-3 are different architectures, so there is no single universal
-patch. The algorithm (pheromone table, evaporation/reinforcement, ant
-construction, routing decisions) lives in [`core/`](core) and is shared
-verbatim. Each simulator gets only a thin adapter:
-
-| | NS-2 | NS-3 |
-|---|---|---|
-| Integration | OTcl + `Agent`, pooled packet headers, **core-tree edits** | additive module subclassing `Ipv4RoutingProtocol` |
-| Install | patch + recompile | drop-in + build |
-| Packet header | POD `PacketHeaderClass` | `ns3::Header` |
-
-See [docs/architecture.md](docs/architecture.md).
+Simulators differ in architecture, so there is no single universal patch. The
+algorithm (pheromone table, evaporation/reinforcement, ant construction,
+routing decisions) lives in [`core/`](core) and is shared verbatim; each
+simulator gets only a thin adapter that converts packets and executes the
+decisions the core returns. See [docs/architecture.md](docs/architecture.md)
+(and [docs/ns2-support.md](docs/ns2-support.md) for how the NS-2 adapter
+differs).
 
 ## Quick start
 
@@ -58,16 +56,6 @@ make test
 ```
 
 (Builds `core/` with CMake and runs the ctest suite — no simulator needed.)
-
-### Install on NS-2
-
-```bash
-make install-ns2 NS2DIR=/path/to/ns-allinone-2.3x/ns-2.3x
-cd /path/to/ns-allinone-2.3x/ns-2.3x && make
-```
-
-Uninstall: `make uninstall-ns2 NS2DIR=...` (reverts the patch cleanly). Details
-in [ns2/README.md](ns2/README.md).
 
 ### Install on NS-3
 
@@ -108,7 +96,6 @@ clean baseline):
 
 ```bash
 docker run --rm ghcr.io/danieljoppi/anthocnet-ns3:3.42 ./ns3 run anthocnet-example
-docker run --rm -it ghcr.io/danieljoppi/anthocnet-ns2:2.35   # `ns` with the agent
 ```
 
 Each image has three tag tiers: `:<sim-version>` (e.g. `:3.42`, latest build for
@@ -122,16 +109,16 @@ track the default branch; the `-<release>` tier is fixed to a release.
 | Image | Versions | Contents |
 |-------|----------|----------|
 | `ghcr.io/danieljoppi/anthocnet-ns3` | `3.36`, `3.41`, `3.42`, `3.47`, `3.48` | ns-3 + the AntHocNet module |
-| `ghcr.io/danieljoppi/anthocnet-ns2` | `2.34`, `2.35` | ns-2 + the AntHocNet patch (compiled) |
 
 **Plain images** — a clean simulator (no AntHocNet) for baseline comparisons:
 
 | Image | Versions | Contents |
 |-------|----------|----------|
 | `ghcr.io/danieljoppi/ns3` | `3.36`, `3.41`, `3.42`, `3.47`, `3.48` | plain ns-3 with the comparison protocols (AODV/OLSR/DSDV/…) |
-| `ghcr.io/danieljoppi/ns2` | `2.34`, `2.35` | plain ns-allinone-2.3x built from source |
 
-Build them yourself or see the full matrix in [docker/README.md](docker/README.md).
+NS-2 images (`anthocnet-ns2`, `ns2`) are listed in
+[docs/ns2-support.md](docs/ns2-support.md). Build them yourself or see the full
+matrix in [docker/README.md](docker/README.md).
 
 ## Supported network regimes
 
@@ -204,7 +191,7 @@ History of the work is in the per-phase commits; design rationale is in
 - [porting-notes.md](docs/porting-notes.md) — bug fixes, NS-2 anchors, caveats
 - [configuration.md](docs/configuration.md) — every parameter, its provenance, how to calibrate
 - [benchmarks.md](docs/benchmarks.md) — AntHocNet vs AODV/OLSR/DSDV (auto-updated)
-- [cross-validation.md](docs/cross-validation.md) — NS-2 vs NS-3 behaviour check
+- [ns2-support.md](docs/ns2-support.md) — the deprecated NS-2 target: status, install, images, rationale
 
 ## Documentation
 
@@ -227,6 +214,7 @@ History of the work is in the per-phase commits; design rationale is in
 | [paper/](paper/) | JOSS software-paper draft (`paper.md`/`paper.bib`), for submission against this repo. |
 | [CONTEXT.md](CONTEXT.md) | Project orientation: domain background, repo map, current state, glossary, open questions. |
 | [AGENTS.md](AGENTS.md) | Build/verify/conventions and invariants for contributors and AI agents. |
+| [docs/ns2-support.md](docs/ns2-support.md) | **The deprecated NS-2 target, end to end** — status and what "frozen" means, install, images, why it is retired. |
 | [ns2/README.md](ns2/README.md) · [ns3/README.md](ns3/README.md) | Per-adapter install/run details. |
 | [docker/README.md](docker/README.md) | Pre-built container images (plain vs. AntHocNet, per simulator version). |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,8 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 | Page | What it is |
 |---|---|
-| [porting-notes.md](porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, version caveats. **NS-2 is deprecated — v1.2.0 is the last release shipping it ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)).** |
+| [porting-notes.md](porting-notes.md) | Bugs fixed in extraction, NS-2 patch anchors, version caveats. |
+| [ns2-support.md](ns2-support.md) | **The deprecated NS-2 target in one place** — frozen at v1.2.0, still ships through `v1.x`, removed at v2.0.0 ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)); install, images, rationale. |
 | [wire-format.md](wire-format.md) | Canonical on-wire ant layout and the `kWireVersion` rules (golden rule 4). |
 | [configuration.md](configuration.md) | Every tunable, its default's **provenance**, the ns-3/NS-2 surface for it, and the calibration loop. |
 | [cross-validation.md](cross-validation.md) | NS-2 vs NS-3 behaviour re-validation (not bit-for-bit parity). |

--- a/docs/ns2-support.md
+++ b/docs/ns2-support.md
@@ -1,0 +1,104 @@
+# NS-2 support (deprecated)
+
+Everything about the NS-2 target in one place: its status, how to install and
+run it while it lasts, the images, and what happens when it goes away. The
+[README](../README.md) carries a single pointer here rather than repeating any
+of it.
+
+**Status in one line:** NS-2 is **deprecated and frozen at
+[v1.2.0](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.2.0)** — no
+new NS-2 work lands, the adapter still ships through the rest of the `v1.x`
+line, and it is **removed at v2.0.0**
+([#307](https://github.com/danieljoppi/AntHocNet/issues/307)).
+
+## What "frozen" means, precisely
+
+| | |
+|---|---|
+| **Last actively-supported release** | `v1.2.0` — the last release NS-2 work was done *for* |
+| **Still ships the adapter** | every `v1.x` release, including the current one |
+| **First release without it** | `v2.0.0` (dropping a platform is breaking, so it needs a major) |
+| **What still runs in CI today** | adapter compile + e2e smoke on real ns-2.34 / ns-2.35 trees, patch apply/revert round-trip, a valgrind leg |
+| **What does not happen** | new features, a benchmark harness ([#25](https://github.com/danieljoppi/AntHocNet/issues/25) is closed as not-planned), parity investigations |
+
+Nothing already published is withdrawn. Pin `v1.2.0` or its immutable images
+for the last actively-supported state; that release stays citable at its own
+version DOI.
+
+## Why it is being retired
+
+The full reasoning is on [#307](https://github.com/danieljoppi/AntHocNet/issues/307);
+the short version:
+
+- It is the **only target that requires edits inside the simulator's own
+  tree**. ns-3 installs as an additive `contrib/` module; NS-2 needs an
+  idempotent anchor-based source patch ([ADR-0005](adr/0005-ns2-idempotent-anchor-patch.md))
+  that breaks — loudly, by design — whenever upstream moves a text anchor.
+- It **never got a benchmark harness**. The NS-2 leg runs a CI smoke asserting
+  non-zero delivery over a forced 2-hop route and nothing else, so the
+  "cross-simulator validation" it was meant to provide was never actually
+  built.
+- Contemporary reviewers read NS-2 in a 2026 paper as a **reproducibility red
+  flag rather than a credential** (the survey work behind
+  [#298](https://github.com/danieljoppi/AntHocNet/issues/298)).
+- It consumes real CI and packaging budget: two adapter-compile jobs against
+  real ns-2.34/2.35 trees, a valgrind leg, a patch round-trip job, and four
+  published container images.
+
+What removal does **not** change: the simulator-agnostic [`core/`](../core),
+the ports seam, and the "no NS headers in `core/`" golden rule all stay. See
+[ADR-0002](adr/0002-one-core-two-adapters.md).
+
+## Install
+
+```bash
+make install-ns2 NS2DIR=/path/to/ns-allinone-2.3x/ns-2.3x
+cd /path/to/ns-allinone-2.3x/ns-2.3x && make
+```
+
+Uninstall: `make uninstall-ns2 NS2DIR=...` — reverts the patch cleanly and
+byte-for-byte. Per-adapter detail (patch anchors, TCL bindings, example
+scenarios) is in [`ns2/README.md`](../ns2/README.md).
+
+## Docker images
+
+```bash
+docker run --rm -it ghcr.io/danieljoppi/anthocnet-ns2:2.35   # `ns` with the agent
+docker run --rm -it ghcr.io/danieljoppi/ns2:2.35             # plain ns-allinone
+```
+
+| Image | Versions | Contents |
+|-------|----------|----------|
+| `ghcr.io/danieljoppi/anthocnet-ns2` | `2.34`, `2.35` | ns-2 + the AntHocNet patch (compiled) |
+| `ghcr.io/danieljoppi/ns2` | `2.34`, `2.35` | plain ns-allinone-2.3x built from source |
+
+The `-<release>` tier is **immutable** — `anthocnet-ns2:2.34-v1.2.0` and
+`:2.35-v1.2.0` are the pins for reproducible NS-2 runs, and they stay pullable
+after removal. Full tag-tier explanation in [docker/README.md](../docker/README.md).
+
+## Why the architecture is the way it is
+
+NS-2 and NS-3 are different architectures, so there is no single universal
+patch. The algorithm (pheromone table, evaporation/reinforcement, ant
+construction, routing decisions) lives in [`core/`](../core) and is shared
+verbatim; each simulator gets only a thin adapter:
+
+| | NS-2 | NS-3 |
+|---|---|---|
+| Integration | OTcl + `Agent`, pooled packet headers, **core-tree edits** | additive module subclassing `Ipv4RoutingProtocol` |
+| Install | patch + recompile | drop-in + build |
+| Packet header | POD `PacketHeaderClass` | `ns3::Header` |
+
+Design detail in [architecture.md](architecture.md).
+
+## See also
+
+- [`ns2/README.md`](../ns2/README.md) — per-adapter install/run details.
+- [porting-notes.md](porting-notes.md) — NS-2 patch anchors, the bugs fixed
+  during extraction, wire-format and version caveats.
+- [cross-validation.md](cross-validation.md) — the NS-2 vs NS-3 behaviour
+  check (retired or re-scoped with the removal, per #307 phase 3).
+- [ADR-0005](adr/0005-ns2-idempotent-anchor-patch.md) — why the patch is
+  anchor-based and idempotent rather than line-numbered.
+- [#307](https://github.com/danieljoppi/AntHocNet/issues/307) — the removal
+  epic: decision, scope, phases, acceptance.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,7 +74,7 @@ flowchart TB
     E301["<b>#301</b> VANET"]
     E297["<b>#297</b> satellite credibility<br/>handover metrics · calibration"]
     E302["<b>#302</b> security<br/>default-off profile"]
-    E307["<b>#307</b> remove NS-2<br/>v1.2.0 is the last release with it"]
+    E307["<b>#307</b> remove NS-2<br/>frozen at v1.2.0, removed at v2.0.0"]
     E32["<b>#32</b> OMNeT++/INET adapter<br/>the Veins entry ticket"]
 
     SATBUILD["satellite build epics<br/>#192 #193 #194 #195 #196<br/>#208 #210 #211"]
@@ -124,9 +124,11 @@ otherwise independent of the epic chain.
 
 ## Platform support
 
-**NS-2 is being retired.** `v1.2.0` is the **last release that ships the NS-2
-adapter** ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)); removal
-lands at v2.0.0. Anyone who needs NS-2 should pin the `v1.2.0` tag or its
+**NS-2 is being retired.** `v1.2.0` is the **last release in which NS-2 was
+actively supported** ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)):
+the adapter is frozen — no new NS-2 work lands — but it still ships through the
+rest of the `v1.x` line, and the **removal itself lands at v2.0.0** (dropping a
+platform is breaking, so it needs a major). Anyone who needs NS-2 should pin the `v1.2.0` tag or its
 immutable images (`ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` /
 `:2.35-v1.2.0`) — already-published tags are not withdrawn, and v1.2.0 stays
 citable at its version DOI.

--- a/ns2/README.md
+++ b/ns2/README.md
@@ -8,9 +8,10 @@ nothing here ships a copy of NS-2.
 Validated targets: **ns-2.34** and **ns-2.35**.
 
 > [!WARNING]
-> **NS-2 support is deprecated.**
+> **NS-2 support is deprecated and frozen.**
 > [v1.2.0](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.2.0) is the
-> **last release that ships this adapter**; it is removed at v2.0.0
+> **last release in which this adapter was actively supported** — it still ships
+> through the rest of `v1.x`, and is removed at v2.0.0
 > ([#307](https://github.com/danieljoppi/AntHocNet/issues/307)). Nothing already
 > published is withdrawn — pin the `v1.2.0` tag, or its immutable images
 > `ghcr.io/danieljoppi/anthocnet-ns2:2.34-v1.2.0` / `:2.35-v1.2.0`, and that


### PR DESCRIPTION
Two related fixes, both surfaced by preparing the v1.3.0 release cut.

## 1. The "last release that ships NS-2" claim was about to become false

Five documents (README, `docs/README`, `docs/roadmap`, `ns2/README`, CHANGELOG) said **v1.2.0 is the last release that ships the NS-2 adapter**. True when written — v1.2.0 was current — but **wrong the moment any v1.x release is cut**, because `ns2/` is still in the tree and still compiled + smoke-tested in CI against real ns-2.34/2.35 trees. v1.3.0 ships the adapter exactly as v1.2.0 did.

This is the tension #307's Scope section flagged ("if the notice says v1.2.0 was the last release with NS-2 but v1.3.0–v1.6.0 still contain the adapter, the notice is misleading"), now forced by an actual release. Corrected everywhere to the accurate statement, preserving the original intent:

> v1.2.0 is the last release in which NS-2 was actively **supported** — the adapter is **frozen** (no new NS-2 work) but still **ships** through the rest of the `v1.x` line, and is **removed at v2.0.0**.

v1.2.0 stays the recommended pin (last actively-supported state, DOI-pinned, immutable images). The removal plan is unchanged; only the wording, which now matches the tree.

## 2. NS-2 was scattered across the README — now one note + one document

New **`docs/ns2-support.md`** holds everything NS-2: status and what "frozen" means (including what still runs in CI and what no longer happens), why it's being retired, install/uninstall, image tables and immutable pins, the NS-2 vs NS-3 architecture comparison, and see-also links into `ns2/README`, porting-notes, cross-validation and ADR-0005.

The README now carries a **single NS-2 note** — a callout pointing there — with ns-3 leading the adapter list. Removed as duplication: the install-on-NS-2 section, the NS-2 `docker run` example, both NS-2 image rows, and the NS-2 column of the adapter comparison table. Structural references stay where they're accurate (repo map, refactor history, docs tables) — those aren't status claims.

Registered in both maps so the page isn't orphaned.

## Verification

`check-mermaid.py .` clean; every relative link in the touched map/document files resolves (checked programmatically). Docs only.

Refs #307, #298.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_