### PR TITLE
docs: record the v1.3.0 zenodo doi

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ identifiers:
     value: "10.5281/zenodo.20981979"
     description: "Concept DOI — always resolves to the latest released version."
   - type: doi
-    value: "10.5281/zenodo.21762983"
-    description: "Version DOI — v1.2.0, the release this file describes."
+    value: "10.5281/zenodo.21795253"
+    description: "Version DOI — v1.3.0, the release this file describes."
 keywords:
   - MANET
   - ad hoc networks

--- a/docs/ns2-support.md
+++ b/docs/ns2-support.md
@@ -23,7 +23,8 @@ line, and it is **removed at v2.0.0**
 
 Nothing already published is withdrawn. Pin `v1.2.0` or its immutable images
 for the last actively-supported state; that release stays citable at its own
-version DOI.
+version DOI, [`10.5281/zenodo.21762983`](https://doi.org/10.5281/zenodo.21762983),
+which keeps resolving after the adapter is removed from `main`.
 
 ## Why it is being retired
 


### PR DESCRIPTION
Zenodo minted the v1.3.0 archive after publish ([record 21795253](https://zenodo.org/records/21795253)); the maintainer supplied the DOI, per the post-release runbook — zenodo.org is proxy-blocked from the agent environment and the DOI is minted asynchronously, so it can only come from a human and must never be guessed.

**`CITATION.cff`**: version-DOI identifier moves from v1.2.0's `10.5281/zenodo.21762983` → v1.3.0's **`10.5281/zenodo.21795253`**, description updated to name the release the file describes. (`version: 1.3.0` and `date-released: 2026-08-04` were already stamped by the Commitizen bump in `19009be`.)

**Deliberately unchanged**: the concept DOI (`10.5281/zenodo.20981979`) in the `doi:` field, the first identifier, and the README badge. A concept DOI always resolves to the latest version by design — re-pointing it per release would be the #116 mistake in reverse.

**Also**: records v1.2.0's version DOI in `docs/ns2-support.md`, right next to the existing advice to pin that release for NS-2. That page tells NS-2 users to pin v1.2.0 and says it "stays citable at its own version DOI" without giving it — an omission that matters more once the adapter leaves `main` at v2.0.0 and the tag is the only way to cite a working NS-2 build.

Validated: `CITATION.cff` parses as YAML with the expected version, date and both DOIs. Docs only.

Refs #307.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_