### PR TITLE
ci: pin all workflow actions to commit shas and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot — keeps the supply chain pinned in workflows/images fresh (#330).
+#
+# Scope decisions:
+#   - github-actions: workflow `uses:` lines are pinned to full commit SHAs
+#     (tags can be repointed); Dependabot bumps the SHA and the trailing
+#     `# vX.Y.Z` comment together.
+#   - docker: both images live under docker/ (Dockerfile.ns2, Dockerfile.ns3).
+#   - pip is deliberately absent: there is no requirements manifest in the
+#     repo — the ruff==0.16.0 and gcovr==8.6 pins are inline `pip install`
+#     lines in workflow yaml, which Dependabot cannot see. Those stay manual;
+#     bump them deliberately, fixing new findings in the same PR.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: monthly

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,7 +62,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
       - name: Configure + build
@@ -94,7 +94,7 @@ jobs:
       - name: Update results tables (index summary + per-scenario pages)
         run: python3 ns3/tools/update-benchmarks.py "$GITHUB_WORKSPACE/scenarios.csv" docs/benchmarks.md
       - name: Upload CSV + charts artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-results
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: core library + unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install toolchain
         run: sudo apt-get update && sudo apt-get install -y cmake g++
       - name: Build and test core
@@ -30,7 +30,7 @@ jobs:
     name: core under ASan + UBSan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install toolchain
         run: sudo apt-get update && sudo apt-get install -y cmake g++
       - name: Build core with sanitizers and run tests
@@ -58,8 +58,8 @@ jobs:
     # Adapter coverage would mean instrumenting a containerized ns-3 build and is
     # out of scope.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
       - name: Install toolchain
@@ -91,7 +91,7 @@ jobs:
             --html-details coverage/index.html \
             --xml-pretty --xml coverage/coverage.xml
       - name: Upload the detailed report (HTML + Cobertura XML)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: core-coverage-report
           path: coverage/
@@ -104,7 +104,7 @@ jobs:
     # its decode path against a small seed corpus. ubuntu-latest's clang ships
     # the libFuzzer/ASan runtimes; a crash/UB/over-read fails the job.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Build the codec fuzz target (clang + libFuzzer/ASan)
         run: |
           cmake -S core -B core/build-fuzz -DANTHOCNET_FUZZ=ON -DCMAKE_CXX_COMPILER=clang++
@@ -118,7 +118,7 @@ jobs:
     name: NS-2 patch round-trip (synthetic tree)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Validate apply/revert against a synthetic ns-2 tree
         run: bash ns2/patch/selftest.sh
 
@@ -141,9 +141,9 @@ jobs:
       matrix:
         version: ['2.34', '2.35']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -225,7 +225,7 @@ jobs:
         # API drift across the whole supported range.
         version: ['3.36', '3.41', '3.42', '3.47', '3.48']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
       - name: Configure (scope examples/tests to AntHocNet)
@@ -353,7 +353,7 @@ jobs:
       # runner/docker update.
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
       - name: Configure with ASan/LSan

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -84,24 +84,24 @@ jobs:
         # prior pins, 3.47/3.48 = current releases.
         version: ['3.36', '3.41', '3.42', '3.47', '3.48']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ inputs.release || '' }}   # release tag, else the triggering ref
       - name: Log in to GHCR
         if: ${{ env.PUSH == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
         if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Plain ns-3 (no AntHocNet)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns3
@@ -131,7 +131,7 @@ jobs:
       - name: Mirror plain ns-3 to Docker Hub (non-fatal)
         if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns3
@@ -151,7 +151,7 @@ jobs:
         # AntHocNet module inside the job, so a release-profile `anthocnet-ns3` image
         # would cost a second full compile that nothing consumes.
         if: ${{ matrix.version == env.NS_OPT }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns3
@@ -166,7 +166,7 @@ jobs:
       - name: Mirror release-profile ns-3 to Docker Hub (non-fatal)
         if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' && matrix.version == env.NS_OPT }}
         continue-on-error: true
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns3
@@ -179,7 +179,7 @@ jobs:
             ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/ns3:{1}-opt-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: ns-3 + AntHocNet
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns3
@@ -193,7 +193,7 @@ jobs:
       - name: Mirror ns-3 + AntHocNet to Docker Hub (non-fatal)
         if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns3
@@ -216,24 +216,24 @@ jobs:
       matrix:
         version: ['2.34', '2.35']   # supported ns-2 releases
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ inputs.release || '' }}   # release tag, else the triggering ref
       - name: Log in to GHCR
         if: ${{ env.PUSH == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
         if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Plain ns-2 (no AntHocNet)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns2
@@ -247,7 +247,7 @@ jobs:
       - name: Mirror plain ns-2 to Docker Hub (non-fatal)
         if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns2
@@ -258,7 +258,7 @@ jobs:
             ${{ env.DOCKERHUB_USERNAME != '' && (inputs.release || '') != '' && format('docker.io/{0}/ns2:{1}-{2}', env.DOCKERHUB_USERNAME, matrix.version, inputs.release) || '' }}
           push: ${{ env.PUSH == 'true' }}
       - name: ns-2 + AntHocNet
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns2
@@ -272,7 +272,7 @@ jobs:
       - name: Mirror ns-2 + AntHocNet to Docker Hub (non-fatal)
         if: ${{ env.PUSH == 'true' && env.MIRROR_DOCKERHUB == 'true' && env.DOCKERHUB_USERNAME != '' }}
         continue-on-error: true
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: docker/Dockerfile.ns2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
     name: Python tools (ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
       - name: Install ruff

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -61,7 +61,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
       - name: Resolve ns-3 build profile (#123)
@@ -204,7 +204,7 @@ jobs:
         # exactly when the forensics are needed (#256), and skipping upload on
         # failure discarded them three times.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: paper-benchmark
           path: |

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
   lint-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
     outputs:
       tag: ${{ steps.compute.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0   # full history + tags for cz to compute the bump
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
       - name: Install tools
@@ -86,7 +86,7 @@ jobs:
           ls -lh "dist/${name}.zip"
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ env.TAG }}
           files: dist/anthocnet-${{ env.VER }}.zip

--- a/.github/workflows/rescue-artifacts.yml
+++ b/.github/workflows/rescue-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Download artifacts and stage CSVs
         if: github.event.inputs.run_ids != ''
         shell: bash

--- a/.github/workflows/satellite-benchmark.yml
+++ b/.github/workflows/satellite-benchmark.yml
@@ -68,7 +68,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
       - name: Resolve ns-3 build profile (#123)
@@ -142,7 +142,7 @@ jobs:
         # forensics are needed (#256's lesson — three SIGKILLed paper runs
         # lost their peak-RSS evidence to a skipped upload).
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: satellite-benchmark
           path: |

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -68,7 +68,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install AntHocNet module
         run: make install-ns3 NS3DIR=/opt/ns-3
       - name: Resolve ns-3 build profile (#123)
@@ -167,7 +167,7 @@ jobs:
         # (A *job*-level timeout, ours or the platform's hard 360-min one,
         # kills everything with no further steps; that is what we avoid.)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: scenario-matrix
           path: |


### PR DESCRIPTION
## What & why

First PR of the [#328](https://github.com/danieljoppi/AntHocNet/issues/328) 5-star-repo epic, implementing [#330](https://github.com/danieljoppi/AntHocNet/issues/330): every `uses:` across all 10 workflows moves from a floating tag to a full commit SHA (version kept as a trailing comment), plus a `.github/dependabot.yml` so the pins don't rot.

Why: a tag can be re-pointed by a compromised action repository; a full-length SHA cannot. `release.yml` was the priority case — it combines `contents: write` with a third-party action (`softprops/action-gh-release`), the classic supply-chain compromise shape. This is also the largest single deduction in the OpenSSF Scorecard enrollment planned in #337.

### Pin table (resolved via `git ls-remote`, peeled tags — never guessed)

| Action | SHA | Version |
|---|---|---|
| actions/checkout | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 |
| actions/setup-python | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| docker/login-action | `c94ce9fb468520275223c153574b00df6fe4bcc9` | v3.7.0 |
| docker/build-push-action | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` | v6.19.2 |
| softprops/action-gh-release | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |
| amannn/action-semantic-pull-request | `0723387faaf9b38adef4775cd42cfd5155ed6017` | v5.5.3 |

One deviation, recorded in the commit body: amannn's `v5` major tag points at a commit no full-version tag matches (the major tag moved past the release), so it is pinned to the latest tagged release v5.5.3 instead. `release.yml`'s `uses: ./.github/workflows/images.yml` is a local reusable workflow — unchanged, nothing to pin.

### Dependabot scope

`github-actions` (monthly, `/`) and `docker` (monthly, `/docker` — `Dockerfile.ns2`, `Dockerfile.ns3`). `pip` deliberately omitted: no requirements manifest exists — the `ruff==0.16.0` / `gcovr==8.6` pins live inline in workflow yaml and stay manually maintained, noted in a comment in the file. Monthly + PR-based matches the repo's deliberate-pinning philosophy: dependabot proposes, a human decides.

## Verification

- Independent spot-check of two pins from the main session (fresh `ls-remote`): `actions/checkout@v4.4.0 → 11d5960a…`, `softprops/action-gh-release@v2.6.2 → 3bb12739…` — both match.
- All 10 workflows + dependabot.yml parse (pyyaml).
- `grep -rn "uses:.*@v[0-9]" .github/workflows/` → no matches; no floating refs remain.
- Diff is confined to `uses:` lines + the new file (42 line-pairs), by design — the #336 concurrency/lint changes touch disjoint hunks of the same workflows and will rebase cleanly.
- Behavior-neutral: same action versions execute as before, now immutable. CI on this PR is itself the end-to-end proof the pinned SHAs resolve.

## Record

- Refs #330, #328. #337 (Scorecard) is sequenced after this.
- No docs/ADR changes: this is CI plumbing with rationale carried in workflow comments and the dependabot file itself, per the repo's annotated-workflow convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_