### PR TITLE
ci: cancel superseded pr runs, lint the whole skills dir, gate relative links

### DIFF
--- a/.claude/skills/benchmark-results/sweep_summary.py
+++ b/.claude/skills/benchmark-results/sweep_summary.py
@@ -114,9 +114,13 @@ def verdict(a, b):
         tag = "MIXED"
     # stddev gate on the PDR delta: material but within joint dispersion?
     sda, sdb = f(a, "pdr_sd"), f(b, "pdr_sd")
-    if abs(dp) >= 1.0 and sda is not None and sdb is not None:
-        if abs(dp) < 2 * math.hypot(sda, sdb):
-            tag += " ~sd"
+    if (
+        abs(dp) >= 1.0
+        and sda is not None
+        and sdb is not None
+        and abs(dp) < 2 * math.hypot(sda, sdb)
+    ):
+        tag += " ~sd"
     return tag, dp, d99, dn
 
 
@@ -138,7 +142,7 @@ def collect_runs(paths, metric="delay99_ms"):
     producing run predates the sibling."""
     vals = {}
     for path in paths:
-        sib = (path[:-4] if path.endswith(".csv") else path) + "-runs.csv"
+        sib = path.removesuffix(".csv") + "-runs.csv"
         if not os.path.exists(sib):
             continue
         with open(sib, newline="") as fh:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+# A force-push to a PR branch obsoletes the in-flight run — cancel it instead
+# of paying for the full matrix twice. Main-branch runs are never cancelled
+# (cancel-in-progress is false there): every merge keeps its own complete run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # packages:read lets the container jobs pull the pre-built simulator images
 # from GHCR; contents:read is for checkout.
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,13 @@ on:
     branches: [main, master]
   pull_request:
 
+# A force-push to a PR branch obsoletes the in-flight run — cancel it instead
+# of paying for it twice. Main-branch runs are never cancelled
+# (cancel-in-progress is false there): every merge keeps its own complete run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -26,16 +33,12 @@ jobs:
         # deliberately, fixing new findings in the same PR.
         run: pip install 'ruff==0.16.0'
       - name: Lint
-        # The skill dir is listed file-by-file on purpose: bench_parse.py and
-        # sweep_summary.py predate this and carry E701s that are not this
-        # change's to fix. Add new skill scripts here as they land.
-        run: |
-          ruff check ns3/tools docs/tools \
-            .claude/skills/benchmark-results/scenario_check.py \
-            .claude/skills/benchmark-results/test_scenario_check.py \
-            .claude/skills/benchmark-results/stats_util.py \
-            .claude/skills/benchmark-results/test_stats.py \
-            .claude/skills/benchmark-results/pool_runs.py
+        # The whole skill dir is linted: the per-file list this replaces (#336)
+        # existed only because bench_parse.py and sweep_summary.py carried
+        # pre-existing findings, and a list that must be extended by hand is
+        # how a new script ships unlinted. Those findings are fixed; new skill
+        # scripts are covered the moment they land.
+        run: ruff check ns3/tools docs/tools .claude/skills/benchmark-results/
       - name: Statistics self-test (#293)
         # stats_util.py computes the 95% CIs and paired tests every published
         # number will carry; bench_parse.py's column-mapping check decides
@@ -59,6 +62,16 @@ jobs:
         run: |
           python3 docs/tools/check-mermaid.py --self-test
           python3 docs/tools/check-mermaid.py .
+      - name: Relative-link gate (docs)
+        # The docs lean on relative links — ADRs cite source files, benchmark
+        # pages cite campaign CSVs — and a rename silently strands every
+        # inbound link: the page still renders, the link just 404s when a
+        # reader follows the cross-session trail (ADR-0013). External and
+        # pure-#anchor targets are skipped so the gate cannot flake (#336).
+        # Stdlib-only, <1 s, runs on every PR.
+        run: |
+          python3 docs/tools/check-links.py --self-test
+          python3 docs/tools/check-links.py .
       - name: Config default parity (core vs ns-2 vs ns-3)
         # A Config default that drifts in one tree only is the #252/#254
         # failure mode: proactiveInterval leaked 10 -> 2 in a PR that claimed

--- a/docs/tools/check-links.py
+++ b/docs/tools/check-links.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Reject markdown links whose relative target does not exist.
+
+Why this exists
+---------------
+This repo's docs lean hard on relative links — ADRs cite source files,
+benchmark pages cite campaign CSVs, AGENTS.md cites everything — and a rename
+or move silently strands every inbound link. Nothing catches that today: the
+page still renders, the link just 404s when a reader (or an agent following
+the cross-session trail, ADR-0013) clicks it. So make it a gate: every inline
+``](target)`` whose target is a relative path must resolve to a file or
+directory in the tree.
+
+The rule enforced here is deliberately narrow, because a check that fires on
+innocent input gets ignored and then is not a gate (#229's lesson): external
+``http(s)://`` and ``mailto:`` targets are skipped (checking them needs a
+network and flakes), pure ``#anchor`` self-links are skipped (heading anchors
+are a rendering concern, not a filesystem one), and ``#fragment`` suffixes on
+path targets are stripped before the existence check. Fenced code blocks and
+inline code spans are skipped too — a ``](...)`` inside an example is prose,
+not a link.
+
+Usage:
+    python3 docs/tools/check-links.py            # scan git-tracked markdown
+    python3 docs/tools/check-links.py --self-test
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+LINK = re.compile(r"\]\(([^)\s]+)\)")
+FENCE = re.compile(r"^(```|~~~).*?^\1[^\n]*$", re.DOTALL | re.MULTILINE)
+CODESPAN = re.compile(r"`[^`\n]*`")
+EXTERNAL = ("http://", "https://", "mailto:")
+
+
+def findings(text: str, md_path: pathlib.Path, display: str | None = None) -> list[str]:
+    """Return one message per dangling target; empty list means clean."""
+    display = display or str(md_path)
+    stripped = CODESPAN.sub("", FENCE.sub(lambda m: "\n" * m.group(0).count("\n"), text))
+    out = []
+    for lineno, line in enumerate(stripped.split("\n"), start=1):
+        for hit in LINK.finditer(line):
+            target = hit.group(1)
+            if target.startswith(EXTERNAL) or target.startswith("#"):
+                continue
+            path_part = target.split("#", 1)[0]
+            if not path_part:
+                continue
+            if not (md_path.parent / path_part).exists():
+                out.append(
+                    f"{display}:{lineno}: link target {target!r} does not exist "
+                    f"(resolved against the file's own directory)"
+                )
+    return out
+
+
+def scan(root: pathlib.Path) -> int:
+    tracked = subprocess.run(
+        ["git", "ls-files", "*.md"],
+        cwd=root, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    problems = []
+    for rel in sorted(tracked):
+        md = root / rel
+        problems += findings(md.read_text(encoding="utf-8"), md, rel)
+    for line in problems:
+        print(f"FAIL: {line}")
+    print(f"checked {len(tracked)} tracked markdown file(s) under {root}; {len(problems)} problem(s)")
+    return 1 if problems else 0
+
+
+def self_test() -> int:
+    """Every rule gets a case that must fire and one that must stay quiet."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        (root / "docs").mkdir()
+        (root / "docs" / "real.md").write_text("# here\n", encoding="utf-8")
+        md = root / "docs" / "page.md"
+        must_fire = [
+            # The rename failure mode this gate exists for.
+            "See [gone](missing.md) for detail.\n",
+            # A fragment does not excuse a dangling path.
+            "See [gone](missing.md#section).\n",
+            # Image links are links too.
+            "![chart](../assets/nope.png)\n",
+        ]
+        must_not_fire = [
+            # Sibling file, with and without a fragment; parent dir; external.
+            (
+                "[ok](real.md) [ok](real.md#here) [up](../docs) "
+                "[web](https://example.com/missing.md) [mail](mailto:x@y.z) [anchor](#here)\n"
+            ),
+            # Inside a code fence or code span it is an example, not a link.
+            "```\n[ex](missing.md)\n```\n",
+            "Use `[ex](missing.md)` syntax.\n",
+        ]
+        failures = 0
+        for case in must_fire:
+            if not findings(case, md):
+                failures += 1
+                print("SELF-TEST FAIL: expected a finding, got none for:\n" + case)
+        for case in must_not_fire:
+            got = findings(case, md)
+            if got:
+                failures += 1
+                print(f"SELF-TEST FAIL: expected silence, got {got} for:\n" + case)
+    print("self-test:", "PASS" if not failures else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="run the rule's own cases")
+    ap.add_argument("root", nargs="?", default=".", help="repo root to scan")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    return scan(pathlib.Path(args.root))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

Third PR of the [#328](https://github.com/danieljoppi/AntHocNet/issues/328) epic, implementing [#336](https://github.com/danieljoppi/AntHocNet/issues/336) — three CI-hygiene changes, each separately revertable:

1. **Concurrency groups on `ci.yml` and `lint.yml`** — rapid pushes to a PR were re-running the full 5-version ns-3 matrix redundantly. `group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, so PR pushes cancel their superseded runs while `main` runs are never cancelled. The manually-dispatched benchmark workflows keep their own battle-tested groups — untouched.
2. **The whole skills dir is now linted.** `lint.yml` listed `.claude/skills/benchmark-results` files individually and admitted in-file that `sweep_summary.py`/`bench_parse.py` were omitted for pre-existing findings. Findings fixed (all in `sweep_summary.py`; `bench_parse.py` was already clean — the audit's claim was stale on that file): `EXE001` (chmod +x), `SIM102` (nested ifs merged, same short-circuit order), `FURB188` (slice → `removesuffix`). The per-file list is replaced by the directory, so new scripts are covered by default.
3. **Relative-link gate**: new `docs/tools/check-links.py` (stdlib-only, structured after `check-mermaid.py`, with a `--self-test` mode carrying must-pass and must-fail fixtures) — scans git-tracked `*.md`, resolves inline `](target)` links/images against the containing file, fails listing every missing target; code fences/spans blanked to avoid false positives; http(s)/mailto/#anchor skipped. Wired into `lint.yml` beside the mermaid gate. Docs currently have 0 broken links by discipline alone; this makes it permanent.

## Verification

- Lint-fix edits to `sweep_summary.py` are behavior-preserving, proven three ways: `test_stats.py` → **all 25 cases passed**; `test_scenario_check.py` → **35 cases passed**; and a real-data smoke — the #179 heavy-load paired comparison re-run post-edit reproduces **byte-identical** numbers: `dPDR +3.23 [+2.94,+3.52]pp p=9.53e-05  d_d99 -192.50 [-210.65,-174.40]ms p=1.91e-06  d_NRL -1.04 [-1.15,-0.94] p=9.54e-05 -> PAIRED-IMPROVED` plus the attributability control line.
- `python3 -m ruff check ns3/tools docs/tools .claude/skills/benchmark-results/` (ruff 0.16.0, CI's pin) → clean.
- Link gate: `--self-test` passes; real run: **checked 69 tracked markdown file(s); 0 problem(s)**.
- No `uses:` lines touched anywhere — this PR's hunks are disjoint from #338's SHA pins by construction, and the clean rebase onto post-#338 main confirms it.
- This PR is itself the first exercise of the new concurrency groups and the widened ruff scope.

## Record

- Refs #336, #328.
- The lint.yml comment that documented the omission is gone with the omission itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_