### PR TITLE
ci: publish the core coverage number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,66 @@ jobs:
             --exclude 'core/tests/' \
             --txt --print-summary \
             --html-details coverage/index.html \
-            --xml-pretty --xml coverage/coverage.xml
+            --xml-pretty --xml coverage/coverage.xml \
+            --json-summary coverage/summary.json
       - name: Upload the detailed report (HTML + Cobertura XML)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: core-coverage-report
           path: coverage/
           retention-days: 14
+      - name: Publish the line-coverage number to the badge gist
+        # #333: the number existed only in a 14-day artifact, so a stranger
+        # judging the repo never saw it. This pushes it to a gist that
+        # shields.io renders as the README badge.
+        #
+        # Deliberately *not* Codecov, on trust footprint: Codecov needs a
+        # third-party GitHub App installed with read access to the whole
+        # repository, plus its uploader executing in this job with a token.
+        # This repo SHA-pins every action (#338) and states its trust boundary
+        # honestly (SECURITY.md), so the cheaper grant wins: a PAT with the
+        # `gist` scope *only*, which can write one gist and cannot read or
+        # write a single line of code. No new action either — a curl to the
+        # documented gist API, so no third-party JS ever sees the token.
+        #
+        # #162 is untouched: this publishes the number, it does not judge it.
+        # There is still no --fail-under anywhere in this job, and this step
+        # cannot turn CI red — it exits 0 when the credentials are absent
+        # (i.e. until the maintainer adds them) and is continue-on-error
+        # otherwise, so a gist/API/network hiccup is reported, never fatal.
+        #
+        # Only on pushes to the default branch: PR runs (forks especially) get
+        # no secrets, and the badge should track main, not a proposal.
+        if: github.event_name == 'push'
+        continue-on-error: true
+        env:
+          # Maintainer setup (#333): a `gist`-scoped PAT as the GIST_TOKEN
+          # secret, and the badge gist's id as the COVERAGE_GIST_ID variable.
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+          GIST_ID: ${{ vars.COVERAGE_GIST_ID }}
+        run: |
+          if [ -z "$GIST_TOKEN" ] || [ -z "$GIST_ID" ]; then
+            echo "GIST_TOKEN / COVERAGE_GIST_ID not configured — skipping the"
+            echo "badge publish (see #333). Coverage still reported above."
+            exit 0
+          fi
+          python3 - > payload.json <<'PY'
+          import json
+          pct = json.load(open("coverage/summary.json"))["line_percent"]
+          color = next(c for floor, c in (
+              (90, "brightgreen"), (80, "green"), (70, "yellowgreen"),
+              (60, "yellow"), (50, "orange"), (0, "red")) if pct >= floor)
+          badge = json.dumps({"schemaVersion": 1, "label": "coverage",
+                              "message": f"{pct:.1f}%", "color": color})
+          print(json.dumps({"files": {"anthocnet-coverage.json":
+                                      {"content": badge}}}))
+          PY
+          curl --fail-with-body -sS -X PATCH \
+            -H "Authorization: Bearer $GIST_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/gists/$GIST_ID" \
+            -d @payload.json > /dev/null
 
   codec-fuzz:
     name: codec fuzz (libFuzzer, 60s)


### PR DESCRIPTION
## What & why

[#328](https://github.com/danieljoppi/AntHocNet/issues/328) epic, implementing [#333](https://github.com/danieljoppi/AntHocNet/issues/333). The core coverage job (gcov/gcovr, report-only by #162's reasoned no-threshold policy) writes its number into a 14-day artifact and nowhere else — the quality bar is real, the signal never reaches a stranger. This publishes it.

### Mechanism: gist + shields.io endpoint, deliberately **not** Codecov

The ticket listed both. Both require a maintainer grant, so the deciding question is *what the grant buys an outsider*:

- **Codecov** — a third-party GitHub App with read access to the whole repository, plus its uploader running with a token in every coverage run. A standing grant.
- **Gist endpoint** — a PAT with the **`gist` scope only**. It can write one gist; it cannot read or write a line of code.

Granting an app repo-wide read access one commit after [#338](https://github.com/danieljoppi/AntHocNet/pull/338) pinned every action specifically to close that class of trust, in a repo whose `SECURITY.md` states its trust boundary honestly, would contradict the posture — for a badge percentage. So: gist.

A second consequence, which is the part I like: **no new action was added, so nothing needed pinning.** The publish step is `curl` against the documented `PATCH /gists/{id}` endpoint (api-version 2022-11-28), with `python3` (already present via `setup-python`) converting gcovr's summary to the shields endpoint schema. The token never reaches third-party JavaScript — strictly a smaller surface than even a correctly-pinned third-party action.

### #162 preserved

No `--fail-under` anywhere (the only two `fail-under` hits in the file are the original policy comment and a new one referencing it); the existing policy comment is untouched. The publish step is `continue-on-error: true` **and** exits 0 with a log message when `GIST_TOKEN`/`COVERAGE_GIST_ID` are unset — so CI is green today, before any maintainer setup, and stays green if the token is later revoked. Gated `if: github.event_name == 'push'` so fork PRs never touch it.

`gcovr` gains exactly one flag: `--json-summary coverage/summary.json`; top-level `line_percent` is the published number. All existing outputs unchanged.

## Verification

- Real coverage build + ctest (**25/25 passed**) + the exact CI gcovr command with the new flag: `lines: 95.3% (776 out of 814)` → `summary.json` `line_percent = 95.3`.
- Payload generator dry-run: `{"files": {"anthocnet-coverage.json": {"content": "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"…%\", \"color\": \"…\"}"}}}`.
- `ci.yml` parses; last `core-coverage` step is `Publish the line-coverage number to the badge gist | if: github.event_name == 'push' | continue-on-error: True`.
- `ruff` clean (untouched); `git diff --stat` → only `.github/workflows/ci.yml`.
- README intentionally **not** edited — three epic tickets in flight all want badge lines, so they are being collected into one follow-up commit to avoid conflicts.

## Record

- Refs #333, #328. **Maintainer action still required** before the badge renders (listed on #333): create a secret gist with `anthocnet-coverage.json`; a PAT with **`gist` scope only** → secret `GIST_TOKEN`; the gist id → repository *variable* `COVERAGE_GIST_ID` (variable, not secret — it is public in the badge URL); then the badge line.
- Until then this is inert and green, by construction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_