### PR TITLE
fix(bench): pin manet-baselines rng streams and extend the seed-independence gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,8 +372,11 @@ jobs:
         # on --runs, --firstRun and protocol order — i.e. campaign CSVs merged
         # across differently-shaped invocations silently compared unlike runs.
         # Checks both halves: the same seeds split across invocations, and the
-        # same seeds with --protocols reversed. 4 seeds x 30 simulated seconds
-        # on the 8-node smoke field, so it costs seconds; same
+        # same seeds with --protocols reversed. Covers anthocnet-compare (both
+        # halves) and manet-baselines (order half only — it exposes no
+        # --firstRun). isl-grid is excluded on purpose: its order case fails for
+        # a non-RNG reason no change here can fix (#362). 4 seeds x 30 simulated
+        # seconds on the 8-node smoke field, so it costs seconds; same
         # single-matrix-version placement as the gates above.
         if: matrix.version == '3.42'
         run: python3 ns3/tools/check-seed-independence.py /opt/ns-3 --seeds 4 --time 30

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -244,8 +244,9 @@ the run's **position in the process**, not on its seed
 stream-consuming helper — position allocator, mobility, wifi channel + devices,
 the IPv4 stack, the routing helper for the arm, the flow-start variable and the
 OnOff sources — is now pinned with `AssignStreams()` from a **seed-derived base**,
-`seed * kStreamStride` (`kStreamStride` = 10⁶ in `ns3/examples/anthocnet-compare.cc`
-and `ns3/examples/isl-grid.cc`, roughly three orders of magnitude above what a
+`seed * kStreamStride` (`kStreamStride` = 10⁶ in each of
+`ns3/examples/anthocnet-compare.cc`, `ns3/examples/isl-grid.cc` and
+`ns3/examples/manet-baselines.cc`, roughly three orders of magnitude above what a
 run actually consumes). The stride is enforced at runtime from the counts
 `AssignStreams()` returns, so a scenario that one day adds streams aborts loudly
 instead of wrapping into the next seed's block. The regression gate is
@@ -263,13 +264,50 @@ And the IPv4 stack is **not** stream-free: `ArpL3Protocol` owns a
 next-hop change resolves through ARP, so an unpinned stack alone kept the gate
 red after everything else was pinned.
 
-Scope: the pinning covers the two harnesses that publish per-seed rows —
-`anthocnet-compare` and `isl-grid`. `manet-baselines` (the anchor harness) has
-the same multi-run-in-one-process shape and is **not** pinned yet; it is invoked
-only with a fixed `--runs` per anchor (`ns3/tools/check-anchors.sh`), so every
-anchor comparison is between identically-shaped invocations and the anchor
-floors are unaffected — but do not merge its rows across differing `--runs`
-until it is pinned too.
+Scope: **all three ns-3 harnesses are pinned** — `anthocnet-compare`, `isl-grid`
+and `manet-baselines`. The last of these was the follow-up gap left open when
+#352 first landed; it is closed now, so its rows may be merged across differing
+`--runs` and `--protocols` orders like `anthocnet-compare`'s (`isl-grid` is
+pinned but has a separate, non-RNG order dependence — see the box below). That
+matters beyond tidiness:
+`manet-baselines` is both the anchor harness
+([`check-anchors.sh`](../../ns3/tools/check-anchors.sh)) and the #24
+stock-baseline control that links no AntHocNet code, and its whole purpose —
+deciding whether a low absolute PDR is a property of the scenario or an artefact
+of our harness — rests on its numbers meaning the same thing as
+`anthocnet-compare`'s for the same seed.
+
+How much of that the gate can actually check differs per harness, and the
+difference is worth stating rather than implying:
+
+| Harness | structure half | order half | compared over |
+|---|---|---|---|
+| `anthocnet-compare` | ✅ (`--firstRun`) | ✅ | `##RUN##` rows |
+| `manet-baselines` | ✗ — no `--firstRun` | ✅ | per-seed `[diag]` lines |
+| `isl-grid` | ✗ — no `--firstRun` | ❌ **fails** ([#362](https://github.com/danieljoppi/AntHocNet/issues/362)) | — |
+
+Neither of the last two exposes a first-run offset, so the structure half cannot
+be expressed against them.
+
+> **`isl-grid` rows are not safe to merge across differently-ordered
+> invocations.** An order case *was* written for `isl-grid` and it failed, on
+> ground the RNG pinning does not cover: both AntHocNet's routing protocol and
+> ns-3's own AODV key their per-interface socket tables on
+> `std::map<Ptr<Socket>, …>` — i.e. on **heap addresses** — and broadcast in
+> that iteration order. On `anthocnet-compare` every node has one wifi
+> interface, so those maps hold a single entry and the order cannot vary; on
+> `isl-grid` every satellite holds four ISLs, so it varies with whatever the
+> allocator did earlier in the process. Half the exposure is upstream, so no
+> change under `ns3/examples/` can close it. Measured effect at 4 seeds on a
+> 3×3 torus: AODV PDR 98.03 → 99.51 and mean delay 7.47 → 9.65 ms for the same
+> seed, purely from reversing `--protocols`. Until
+> [#362](https://github.com/danieljoppi/AntHocNet/issues/362) closes, keep every
+> satellite comparison inside one invocation with a fixed protocol order —
+> which is what `run-scenarios.py` and `check-sat-anchors.sh` already do, so no
+> published satellite number is affected. `isl-grid` keeps its own determinism
+> gate ([`check-determinism.sh`](../../ns3/tools/check-determinism.sh)), which
+> passes: identical invocations *are* reproducible, and that is precisely the
+> weaker property.
 
 > **Campaign data produced before #352 carries a structure dependence.** Within
 > one invocation it is internally consistent (and per-seed pairing across
@@ -418,7 +456,7 @@ flowchart TB
         C3["NS-2 patch round-trip · adapter e2e + valgrind"]
         C4["NS-3 build + module tests<br/>3.36 · 3.41 · 3.42 · 3.47 · 3.48"]
         C5["<b>check-determinism.sh</b><br/>same seed twice ⇒ byte-identical<br/>(wifi + isl-grid, #129)"]
-        C9["<b>check-seed-independence.py</b><br/>same seed ⇒ same row across split<br/>structures and protocol order (#352)"]
+        C9["<b>check-seed-independence.py</b><br/>same seed ⇒ same row across split<br/>structures and protocol order (#352)<br/>compare · manet-baselines"]
         C6["<b>check-anchors.sh single-hop</b><br/>single_hop_pdr_min 99.0 (#51 detector)"]
         C7["<b>check-sat-anchors.sh</b><br/>sat_single_isl_pdr_min 99.0 ·<br/>sat_hop_delay_slack_ms 1.5 (#237)"]
         C8["core coverage (gcov) — <b>report-only</b>, no threshold (#162)"]

--- a/ns3/examples/manet-baselines.cc
+++ b/ns3/examples/manet-baselines.cc
@@ -43,6 +43,59 @@ using namespace ns3;
 namespace {
 
 constexpr uint16_t kDataPort = 9;
+
+// --- RNG stream pinning (#352) ----------------------------------------------
+// The same fix, for the same reason, as ns3/examples/anthocnet-compare.cc and
+// ns3/examples/isl-grid.cc: ns-3 hands every RandomVariableStream its stream
+// index from a *global* counter at CONSTRUCTION time, and neither
+// RngSeedManager::SetSeed/SetRun nor Simulator::Destroy resets that counter.
+// This harness has the same shape as the other two — a whole scenario built per
+// run, many runs per process, in a protocol-major loop — so without pinning,
+// run N draws from whatever stream indices runs 1..N-1 left behind and a run's
+// realisation becomes a function of its *position* in the process (--runs, and
+// the --protocols order) rather than of its seed.
+//
+// manet-baselines is the anchor harness (ns3/tools/check-anchors.sh) and the
+// #24 stock-baseline control. Both uses compare across invocations, which is
+// exactly what position dependence breaks: the anchor floors happen to be safe
+// only because check-anchors.sh always passes a fixed --runs, and the #24
+// control is only meaningful if its DSDV/AODV/OLSR numbers mean the same thing
+// as the ones anthocnet-compare reports for the same seed. Leaving one of the
+// three harnesses unpinned would keep exactly that comparison unsound.
+//
+// Same stride and same runtime budget check as the other two — see the longer
+// derivation in anthocnet-compare.cc.
+constexpr int64_t kStreamStride = 1000000;
+
+// Advance `next` by the number of streams a helper's AssignStreams() reported,
+// and abort if this run has overrun its per-seed block.
+void TakeStreams(int64_t& next, int64_t base, int64_t used, const char* what) {
+    next += used;
+    NS_ABORT_MSG_IF(next - base >= kStreamStride,
+                    "RNG stream budget exhausted after assigning " << what
+                    << ": this run has consumed " << (next - base)
+                    << " streams but kStreamStride is " << kStreamStride
+                    << " — seed blocks would overlap (#352). Raise the stride.");
+}
+
+// #352: DsdvHelper is the one baseline helper with no AssignStreams() wrapper —
+// AodvHelper and OlsrHelper both have one, DsdvHelper has none anywhere in the
+// 3.36-3.48 CI matrix. dsdv::RoutingProtocol itself does declare
+// AssignStreams(int64_t) in every one of those versions, so reach the installed
+// protocol objects through the nodes and do what the missing wrapper would do.
+int64_t AssignDsdvStreams(const NodeContainer& nodes, int64_t stream) {
+    int64_t used = 0;
+    for (auto it = nodes.Begin(); it != nodes.End(); ++it) {
+        Ptr<Ipv4> ipv4 = (*it)->GetObject<Ipv4>();
+        NS_ABORT_MSG_IF(!ipv4, "node has no IPv4 stack; cannot pin dsdv streams");
+        Ptr<dsdv::RoutingProtocol> dsdv =
+            DynamicCast<dsdv::RoutingProtocol>(ipv4->GetRoutingProtocol());
+        NS_ABORT_MSG_IF(!dsdv, "expected dsdv::RoutingProtocol on this node (#352)");
+        used += dsdv->AssignStreams(stream + used);
+    }
+    return used;
+}
+
 uint64_t g_controlPkts = 0;
 void CountTx(Ptr<const Packet>, Ptr<Ipv4>, uint32_t) { ++g_controlPkts; }
 
@@ -173,6 +226,11 @@ struct Result {
 Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     RngSeedManager::SetSeed(1);
     RngSeedManager::SetRun(seed);
+    // #352: and pin the stream indices into this seed's own block, so the
+    // realisation depends on the seed alone and not on how many runs (or which
+    // protocols) preceded this one in the process. See kStreamStride.
+    const int64_t streamBase = static_cast<int64_t>(seed) * kStreamStride;
+    int64_t stream = streamBase;
     g_controlPkts = 0;
     g_appTx = 0;
     g_appRx = 0;
@@ -213,10 +271,21 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     } else {
         channel = YansWifiChannelHelper::Default();
     }
-    phy.SetChannel(channel.Create());
+    Ptr<YansWifiChannel> wifiChannel = channel.Create();
+    phy.SetChannel(wifiChannel);
     WifiMacHelper mac;
     mac.SetType("ns3::AdhocWifiMac");
     NetDeviceContainer devices = wifi.Install(phy, mac, nodes);
+    // #352: the propagation models configured above are all deterministic, so
+    // the channel normally reports 0 streams — pinned anyway so swapping in a
+    // fading model (Nakagami, ...) cannot reintroduce the position dependence.
+    // WifiHelper::AssignStreams covers the PHY's reception-error variable, the
+    // MAC/Txop backoff and the rate manager in one call — and this harness can
+    // select ArfWifiManager or IdealWifiManager via --rateManager, both of which
+    // are stateful, so that last one is not hypothetical here.
+    TakeStreams(stream, streamBase, channel.AssignStreams(wifiChannel, stream),
+                "wifi channel");
+    TakeStreams(stream, streamBase, wifi.AssignStreams(devices, stream), "wifi");
 
     MobilityHelper mobility;
     Ptr<UniformRandomVariable> ux = CreateObject<UniformRandomVariable>();
@@ -237,20 +306,52 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                               "Speed", StringValue(speedStr.str()),
                               "Pause", StringValue(pauseStr.str()),
                               "PositionAllocator", PointerValue(pos));
+    // #352: the initial positions are drawn during Install(), so the allocator
+    // has to be pinned BEFORE it — MobilityHelper::AssignStreams can only reach
+    // the models (and, through RandomWaypoint, the allocator's later waypoint
+    // draws) once they exist. Pinning `pos` covers both `ux` and `uy`.
+    TakeStreams(stream, streamBase, pos->AssignStreams(stream),
+                "position allocator");
     mobility.Install(nodes);
+    TakeStreams(stream, streamBase, mobility.AssignStreams(nodes, stream),
+                "mobility");
 
+    // #352: the three routing helpers are hoisted out of the branches so their
+    // AssignStreams() can run after Install() (SetRoutingHelper stores a Copy(),
+    // but AssignStreams reaches the *installed* protocols through the nodes, so
+    // the local helper is the right handle). Constructing all three is free —
+    // each is an ObjectFactory and instantiates nothing.
     InternetStackHelper internet;
+    AodvHelper aodvHelper;
+    OlsrHelper olsrHelper;
+    DsdvHelper dsdvHelper;
     if (proto == "aodv") {
-        AodvHelper h;
-        internet.SetRoutingHelper(h);
+        internet.SetRoutingHelper(aodvHelper);
     } else if (proto == "olsr") {
-        OlsrHelper h;
-        internet.SetRoutingHelper(h);
+        internet.SetRoutingHelper(olsrHelper);
     } else if (proto == "dsdv") {
-        DsdvHelper h;
-        internet.SetRoutingHelper(h);
+        internet.SetRoutingHelper(dsdvHelper);
     }
     internet.Install(nodes);
+    // The IPv4 stack is not stream-free: ArpL3Protocol owns m_requestJitter, a
+    // RandomVariableStream that de-syncs ARP requests, and on a wifi MANET every
+    // next-hop change resolves through ARP. This is the entry that kept the
+    // seed-independence gate red in anthocnet-compare after everything else was
+    // pinned; the same stack is installed here.
+    TakeStreams(stream, streamBase, internet.AssignStreams(nodes, stream),
+                "internet stack (arp request jitter)");
+    // Each of these protocols builds a UniformRandomVariable per node (RREQ
+    // jitter, hello jitter) at construction; pin them.
+    if (proto == "aodv") {
+        TakeStreams(stream, streamBase, aodvHelper.AssignStreams(nodes, stream),
+                    "aodv routing");
+    } else if (proto == "olsr") {
+        TakeStreams(stream, streamBase, olsrHelper.AssignStreams(nodes, stream),
+                    "olsr routing");
+    } else if (proto == "dsdv") {
+        TakeStreams(stream, streamBase, AssignDsdvStreams(nodes, stream),
+                    "dsdv routing");
+    }
 
     for (uint32_t i = 0; i < nodes.GetN(); ++i) {
         Ptr<Ipv4L3Protocol> l3 = nodes.Get(i)->GetObject<Ipv4L3Protocol>();
@@ -270,6 +371,10 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     Ptr<UniformRandomVariable> startVar = CreateObject<UniformRandomVariable>();
     startVar->SetAttribute("Min", DoubleValue(0.0));
     startVar->SetAttribute("Max", DoubleValue(std::min(P.startWindow, P.simTime * 0.5)));
+    // #352: pinned before the flow loop below reads it — the start times are
+    // drawn there, not at Simulator::Run().
+    startVar->SetStream(stream);
+    TakeStreams(stream, streamBase, 1, "flow start times");
     std::ostringstream rate;
     rate << static_cast<uint64_t>(P.cbrBps) << "bps";
     ApplicationContainer sinks;
@@ -282,6 +387,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         onoff.SetAttribute("StartTime", TimeValue(Seconds(startVar->GetValue())));
         onoff.SetAttribute("StopTime", TimeValue(Seconds(P.simTime - 1.0)));
         ApplicationContainer srcApp = onoff.Install(nodes.Get(src));
+        // #352: the OnOff source's on/off variables. They are
+        // ConstantRandomVariable in this harness (a CBR source is always on), so
+        // they consume streams without drawing from them — pinned regardless, so
+        // an on/off duty cycle added later cannot reintroduce the position
+        // dependence. PacketSink draws nothing. The DynamicCast is deliberate:
+        // AssignStreams only reached the Application base class in a later ns-3
+        // than 3.36, but OnOffApplication has declared it throughout the matrix.
+        Ptr<OnOffApplication> onoffApp = DynamicCast<OnOffApplication>(srcApp.Get(0));
+        NS_ABORT_MSG_IF(!onoffApp, "expected an OnOffApplication to pin (#352)");
+        TakeStreams(stream, streamBase, onoffApp->AssignStreams(stream),
+                    "onoff application");
         srcApp.Get(0)->TraceConnectWithoutContext("Tx", MakeCallback(&AppTx));
         PacketSinkHelper sink("ns3::UdpSocketFactory",
                               InetSocketAddress(Ipv4Address::GetAny(), kDataPort));
@@ -413,6 +529,16 @@ int main(int argc, char* argv[]) {
               << " rateManager=" << P.rateManager << "\n\n"
               << "protocol        PDR%  delay(ms)  delay99(ms)     NRL\n"
               << "--------------------------------------------------------\n";
+    // std::fixed / setprecision are STICKY on std::cout, and the summary row
+    // below sets them between one protocol's runs and the next's. RunOne's
+    // per-seed "[diag ...] TOTALS" line prints its packet counts as doubles
+    // (tx/rx are accumulators), so the first protocol printed "fmTx=405" and
+    // every later one "fmTx=405.00" for the identical value — the output, not
+    // the simulation, depended on the protocol's position in --protocols. The
+    // #352 seed-independence gate flagged it correctly on its first run against
+    // this harness. Save the state once and restore it after each row.
+    const std::ios_base::fmtflags coutFlags = std::cout.flags();
+    const std::streamsize coutPrec = std::cout.precision();
     for (const std::string& proto : list) {
         double pdr = 0, d = 0, d99 = 0, nrl = 0;
         for (uint32_t s = 1; s <= runs; ++s) {
@@ -425,6 +551,8 @@ int main(int argc, char* argv[]) {
                   << std::setw(11) << d / runs
                   << std::setw(13) << d99 / runs
                   << std::setw(9) << std::setprecision(2) << nrl / runs << "\n";
+        std::cout.flags(coutFlags);
+        std::cout.precision(coutPrec);
     }
     return 0;
 }

--- a/ns3/tools/check-seed-independence.py
+++ b/ns3/tools/check-seed-independence.py
@@ -39,9 +39,26 @@ non-first protocol. Hence two cases.
 Compares the harness's per-seed ##RUN## rows (#128), which carry the metrics
 downstream tooling actually consumes, keyed by (seed, protocol).
 
-isl-grid received the same pinning fix but exposes no --firstRun, so the
-structure half cannot be expressed against it; it is covered by the shared
-mechanism plus its own determinism gate (ns3/tools/check-determinism.sh).
+manet-baselines received the same pinning fix and is checked here too, but on
+the order half only: it exposes no --firstRun, so the structure half cannot be
+expressed against it. It has no ##RUN## rows either (it prints per-protocol
+means), so it is compared over its per-seed `[diag <proto> seed=N]` lines,
+which carry exact per-flow tx/rx/lost counts. Gating it matters more than its
+"control harness" status suggests: it is also the anchor harness
+(ns3/tools/check-anchors.sh), and its #24 verdict — "are the low absolute PDRs a
+property of the scenario, or an artefact of our harness?" — is only readable if
+its numbers mean the same thing as anthocnet-compare's for the same seed.
+
+isl-grid is deliberately NOT checked here, and the reason is a finding rather
+than an omission. An order case was written for it and it FAILED — see #362.
+The cause is not RNG and this gate's fix would not address it: both our routing
+protocol and ns-3's own AODV key their per-interface socket tables on
+`std::map<Ptr<Socket>, ...>`, i.e. on heap addresses, and broadcast in that
+iteration order. anthocnet-compare gives every node one wifi interface, so
+those maps hold one entry and the order cannot vary; isl-grid gives every
+satellite four ISLs, so it does vary — with whatever the allocator did earlier
+in the process. Half the exposure is upstream, so this gate cannot be made
+green by any change to ns3/examples/. Re-enable the case when #362 closes.
 
 Needs an ns-3 tree with the AntHocNet module installed, configured and built
 with examples enabled. Runs on stdlib only:
@@ -50,6 +67,7 @@ with examples enabled. Runs on stdlib only:
 """
 
 import argparse
+import re
 import subprocess
 import sys
 
@@ -59,14 +77,20 @@ import sys
 SCENARIO = "--nNodes=8 --area=150 --flows=2"
 PROTOCOLS = ["anthocnet", "aodv"]
 
+# manet-baselines links no AntHocNet code, so its arms are the stock protocols.
+# dsdv is deliberately in this list: it is the one whose streams are pinned by
+# hand (DsdvHelper has no AssignStreams() wrapper in any ns-3 of the matrix),
+# i.e. the entry with no upstream helper backing it up.
+BASELINE_PROTOCOLS = ["aodv", "dsdv"]
 
-def run_compare(ns3dir, protocols, first_run, runs, time_s):
-    """Run anthocnet-compare once; return {(seed, proto): row} from ##RUN##."""
-    cmd = (
-        f"anthocnet-compare {SCENARIO} --time={time_s} "
-        f"--protocols={','.join(protocols)} "
-        f"--firstRun={first_run} --runs={runs}"
-    )
+# manet-baselines prints per-seed diagnostics rather than ##RUN## rows:
+#   "  [diag aodv seed=3] flow 10.1.0.1:49153 -> ... tx=.. rx=.. lost=.."
+#   "  [diag aodv seed=3] TOTALS fmTx=.. fmRx=.. appTx=.. appRx=.."
+DIAG_RE = re.compile(r"^\s*\[diag (\S+) seed=(\d+)\] (.*)$")
+
+
+def run_ns3(ns3dir, cmd):
+    """Run one ./ns3 program invocation; return its stdout, or abort."""
     print(f"[seed-independence] ./ns3 run \"{cmd}\"")
     proc = subprocess.run(
         ["./ns3", "run", cmd],
@@ -79,9 +103,13 @@ def run_compare(ns3dir, protocols, first_run, runs, time_s):
     if proc.returncode != 0:
         print("\n".join(proc.stdout.splitlines()[-40:]), file=sys.stderr)
         raise SystemExit(f"FAIL [seed-independence]: '{cmd}' exited {proc.returncode}")
+    return proc.stdout
 
+
+def parse_run_rows(stdout, cmd):
+    """{(seed, proto): row} from the harness's ##RUN## lines (#128)."""
     rows = {}
-    for line in proc.stdout.splitlines():
+    for line in stdout.splitlines():
         if not line.startswith("##RUN##"):
             continue
         fields = line.split()[1:]  # drop the ##RUN## marker
@@ -93,6 +121,40 @@ def run_compare(ns3dir, protocols, first_run, runs, time_s):
             "(#28-style silent empty result)"
         )
     return rows
+
+
+def parse_diag_rows(stdout, cmd):
+    """{(seed, proto): joined diag lines} for harnesses with no ##RUN## rows."""
+    rows = {}
+    for line in stdout.splitlines():
+        m = DIAG_RE.match(line)
+        if m:
+            rows.setdefault((m.group(2), m.group(1)), []).append(m.group(3))
+    if not rows:
+        raise SystemExit(
+            f"FAIL [seed-independence]: '{cmd}' produced no [diag] lines "
+            "(#28-style silent empty result)"
+        )
+    return {key: " | ".join(lines) for key, lines in rows.items()}
+
+
+def run_compare(ns3dir, protocols, first_run, runs, time_s):
+    """Run anthocnet-compare once; return {(seed, proto): row} from ##RUN##."""
+    cmd = (
+        f"anthocnet-compare {SCENARIO} --time={time_s} "
+        f"--protocols={','.join(protocols)} "
+        f"--firstRun={first_run} --runs={runs}"
+    )
+    return parse_run_rows(run_ns3(ns3dir, cmd), cmd)
+
+
+def run_baselines(ns3dir, protocols, runs, time_s):
+    """Run manet-baselines once; return {(seed, proto): joined diag lines}."""
+    cmd = (
+        f"manet-baselines {SCENARIO} --time={time_s} "
+        f"--protocols={','.join(protocols)} --runs={runs}"
+    )
+    return parse_diag_rows(run_ns3(ns3dir, cmd), cmd)
 
 
 def compare(case, reference, other):
@@ -145,6 +207,18 @@ def main():
     problems = compare("structure", reference, split)
     problems += compare("order", reference, reversed_order)
 
+    # manet-baselines exposes no --firstRun, so only the order half applies, and
+    # it publishes per-seed [diag] lines rather than ##RUN## rows.
+    base_reference = run_baselines(
+        args.ns3dir, BASELINE_PROTOCOLS, args.seeds, args.time
+    )
+    base_reversed = run_baselines(
+        args.ns3dir, list(reversed(BASELINE_PROTOCOLS)), args.seeds, args.time
+    )
+    problems += compare("order/manet-baselines", base_reference, base_reversed)
+
+    checked = len(reference) + len(base_reference)
+
     if problems:
         print(
             f"\nFAIL [seed-independence]: {problems} row(s) depend on something "
@@ -161,8 +235,9 @@ def main():
         return 1
 
     print(
-        f"\nPASS [seed-independence]: {len(reference)} per-seed row(s) identical "
-        "across split structures and across protocol order"
+        f"\nPASS [seed-independence]: {checked} per-seed row(s) identical across "
+        "split structures (anthocnet-compare) and across protocol order "
+        "(anthocnet-compare, manet-baselines)"
     )
     return 0
 


### PR DESCRIPTION
Closes the follow-up gap left open when #352 landed. That fix pinned the two harnesses publishing per-seed rows — `anthocnet-compare` and `isl-grid` — and explicitly recorded `manet-baselines` as still unpinned in `docs/benchmarks/methodology.md`. It is pinned now, and `check-seed-independence.py` is extended to cover it.

> **This body was rewritten after the gate's first run.** The original claimed the gate now covered all three harnesses. It does not: an `isl-grid` order case was written, it **failed**, and the cause is not RNG. See *A second defect* below and #362. Leaving the original claim standing would have been the more comfortable edit and the wrong one.

## Why `manet-baselines` could not stay unpinned

Same shape as the other two: a whole scenario built per run, many runs executed in one process, protocol-major loop. So the same defect. ns-3 hands every `RandomVariableStream` its stream index from a **global counter at construction time**, and neither `RngSeedManager::SetSeed`/`SetRun` nor `Simulator::Destroy` resets it — run *N* drew from whatever indices runs 1…*N*−1 left behind, making a run's realisation a function of its **position in the process** (`--runs`, `--protocols` order) rather than of its seed.

The methodology note argued the **anchor floors** were unaffected, and that argument holds: `check-anchors.sh` always passes a fixed `--runs`, so every anchor comparison is between identically-shaped invocations. But it only covered the anchors. `manet-baselines` has a second job — it is the **#24 stock-baseline control**, the binary that deliberately links no AntHocNet code so we can ask whether a low absolute PDR is a property of the scenario+ns-3 or an artefact of our harness. That question is answered by comparing its AODV/OLSR/DSDV numbers against `anthocnet-compare`'s for the same seed — across two binaries, therefore across two differently-shaped invocations. That is exactly the comparison position dependence invalidates. The gap was not cosmetic.

## What is pinned

Same mechanism, stride and runtime budget check as the other two harnesses (`kStreamStride` = 10⁶, enforced from the counts `AssignStreams()` returns via `NS_ABORT_MSG_IF`, so it holds in optimized campaign builds too):

- **position allocator**, pinned *before* `mobility.Install()` — initial positions are drawn there. Pinning the shared `RandomRectanglePositionAllocator` covers both `ux` and `uy`.
- **mobility models**, after `Install()`.
- **wifi channel + devices.** The channel reports 0 streams under all three propagation models configured here, but `WifiHelper::AssignStreams` is *not* cosmetic in this harness: `--rateManager` can select `ArfWifiManager` or `IdealWifiManager`, both stateful.
- **the IPv4 stack.** Not stream-free — `ArpL3Protocol` owns `m_requestJitter`. This is the entry whose absence kept the gate red in `anthocnet-compare` after everything else was pinned. Same stack, same exposure.
- **the routing protocol for the arm.** The three helpers are hoisted out of the `if` branches so `AssignStreams()` can run after `Install()` (constructing all three is free — each is an `ObjectFactory` that instantiates nothing). DSDV again goes through the hand-rolled `AssignDsdvStreams()`: `DsdvHelper` has no `AssignStreams()` wrapper in any ns-3 from 3.36 to 3.48, while `dsdv::RoutingProtocol::AssignStreams(int64_t)` exists in all of them.
- **the flow-start variable**, before the loop that reads it.
- **the OnOff sources.** `ConstantRandomVariable` here (a CBR source is always on), so they consume streams without drawing from them — pinned anyway so a duty cycle added later cannot reintroduce the dependence. The `DynamicCast` to `OnOffApplication` is deliberate: `AssignStreams` only reached the `Application` base class in a later ns-3 than 3.36.

## A second, non-RNG order dependence — also in `manet-baselines`, fixed here

The gate's first run failed all 8 `manet-baselines` rows with every value identical and only the rendering different:

```
reference: ... | TOTALS fmTx=412 fmRx=351 appTx=412 appRx=351
this run : ... | TOTALS fmTx=412.00 fmRx=351.00 appTx=412 appRx=351
```

`std::fixed`/`setprecision` are sticky on `std::cout`, and the summary row printed between one protocol's runs and the next's sets them. `RunOne`'s per-seed `[diag] TOTALS` line prints its packet counts as doubles, so the first protocol in `--protocols` rendered `412` and every later one `412.00`. The *output*, not the simulation, depended on position. Fixed by saving and restoring the stream's format state around each summary row — which leaves the first protocol's rendering, the one every existing log shows, byte-identical.

## The gate's coverage, stated honestly

| Harness | structure half | order half | compared over |
|---|---|---|---|
| `anthocnet-compare` | ✅ (`--firstRun`) | ✅ | `##RUN##` rows |
| `manet-baselines` | ✗ — no `--firstRun` | ✅ | per-seed `[diag]` lines |
| `isl-grid` | ✗ — no `--firstRun` | ❌ **fails** (#362) | — |

`manet-baselines` prints per-protocol means rather than `##RUN##` rows, so the comparison keys on its `[diag <proto> seed=N]` lines — exact per-flow `tx`/`rx`/`lost` integers plus the app-level `TOTALS`. Its arm list is `aodv,dsdv` rather than the default three: **DSDV is the entry pinned by hand with no upstream helper backing it up**, so it is the one most worth gating.

**`anthocnet-compare` passed both halves** — worth stating, because it is the control that shows the two failures below are not regressions of #352.

### Why `isl-grid` is excluded rather than fixed

Its order case failed 7 of 8 rows: AODV's PDR moved 98.03 → 99.51 and its mean delay 7.47 → 9.65 ms *for the same seed*, under nothing but a reversed `--protocols`. Meanwhile AntHocNet's `pdr`/`delay`/`delay99`/`thrput` stayed byte-identical and only its control-packet counts moved. An unpinned stream shifts both protocols' whole realisation; this does not.

Both our routing protocol and ns-3's own AODV key their per-interface socket tables on `std::map<Ptr<Socket>, …>` — i.e. on **heap addresses** — and broadcast in that iteration order. The discriminating fact is *why `anthocnet-compare` passes*: one wifi interface per node means those maps hold a single entry and the order cannot vary. `isl-grid` gives every satellite four ISLs, so it does.

Half the exposure is upstream in ns-3, so **no change under `ns3/examples/` can make that case green.** Shipping it red, or softening the gate to let it pass, were both worse than excluding it and saying why. It is filed as #362 with the full evidence, the discriminating argument, and a pre-registered reading of the fix experiment. The exclusion is stated in the script docstring, the CI step comment and `methodology.md`.

**No published satellite number is affected**: `run-scenarios.py` and `check-sat-anchors.sh` each use one invocation with a fixed protocol order, so every satellite comparison to date is internally consistent. `methodology.md` now says plainly that `isl-grid` rows are *not* safe to merge across differently-ordered invocations — replacing the first push's wording, which claimed `isl-grid` rested safely on "the shared mechanism".

Cost of the extension: two more short invocations on the same 4 seeds × 30 simulated seconds. Seconds, on the existing ns-3.42 leg.

## Verification

No local ns-3 build in this environment, so CI is the first execution of both the pinning and the extended gate — the same posture as #352, where the six-version matrix supplied the cross-version evidence for the `DsdvHelper` gap. The gate is the acceptance criterion, and it has now failed once and passed once on real output rather than on a reading of the code.

No protocol behaviour changes: this touches `ns3/examples/manet-baselines.cc`, the gate script, its CI step and the methodology doc. No A/B is required — but note that, as with #352, this **changes stream assignment**, so `manet-baselines` numbers measured before this commit are not comparable to numbers measured after it.

Refs #352, #362

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_