### PR TITLE
feat(bench): emit hopsCommon/hopsSurplus for the #308 phase-2 decomposition

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -89,6 +89,17 @@ ISL_RUN = re.compile(r"^\s*##RUN##\s+(\d+)\s+([a-z][\w-]*)"
 # family here: no results-mode rule reads dispersion, so parsing it would be
 # dead weight.
 DIAG_LINE = re.compile(r"^\s*#\s+(paths|energy|drops|reorder)\s+([a-z][\w-]*)\s+(.+)$")
+# #308 phase 2: the per-run common-set rows. Unlike the diagnostic lines above
+# there is one per (run, protocol), so they are folded into the protocol's row
+# as an extremum rather than merged field-by-field — the rules below ask "did
+# ANY run produce an impossible hopsCommon", which is what a broken flow key or
+# an unconnected TTL hook would show up as.
+#   ##COMMON## <run> <proto> <nSelf> <nCommon> <p99C> <meanC> <p99S> [<hopsC> <hopsS>]
+# The two hop fields are absent on inputs predating the instrumentation; those
+# skip, exactly like an absent CSV column.
+COMMON_LINE = re.compile(
+    r"^\s*##COMMON##\s+\d+\s+([a-z][\w-]*)\s+\d+\s+(\d+)\s+\S+\s+\S+\s+\S+"
+    r"(?:\s+(\S+)\s+\S+)?\s*$")
 DIAG_KEYS = {
     "paths":   {"hopsMean": "hops", "hopsMax": "hops_max", "divUsed": "div",
                 "divMax": "div_max", "entropyBits": "entropy",
@@ -370,6 +381,23 @@ def parse_results(path):
             rows.append(row)
             by_proto[proto] = row
             continue
+        c = COMMON_LINE.match(line)
+        if c:
+            row = by_proto.get(c.group(1))
+            if row is None:
+                continue  # ##COMMON## with no table row above it
+            n_common, hops_c = int(c.group(2)), c.group(3)
+            if hops_c is None:
+                continue  # predates the hop instrumentation
+            if hops_c == "na" or float(hops_c) == 0.0:
+                if n_common:
+                    row["hops_common_missing"] = \
+                        row.get("hops_common_missing", 0) + 1
+                continue
+            v = float(hops_c)
+            row["hops_common_min"] = min(row.get("hops_common_min", v), v)
+            row["hops_common_max"] = max(row.get("hops_common_max", v), v)
+            continue
         d = DIAG_LINE.match(line)
         if not d:
             continue
@@ -638,6 +666,31 @@ def cmd_results(a):
             if div_max is not None and div is not None and div_max and div_max < div:
                 report("FAIL", f"{tag}: max path diversity {div_max} < mean "
                                f"path diversity {div}")
+            # #308 phase 2 hopsCommon. Same three a-priori facts as `hops`
+            # above — a delivered packet crosses at least one transmission and
+            # at most maxPathLength — plus the one that only this metric can
+            # get wrong: it is derived from the IP TTL under a flow key rebuilt
+            # from (source IP, UDP source port), which must match the key
+            # PacketSink reports for the delays. If that ever diverges, every
+            # hop lands under a key the common set does not contain and
+            # hopsCommon reads absent while nCommon stays large. Without this
+            # rule that failure is silent and the per-hop decomposition is
+            # simply wrong; with it the run FAILs.
+            missing = r.get("hops_common_missing")
+            if missing:
+                report("FAIL", f"{tag}: {missing} run(s) report a non-empty "
+                               "common set with no hopsCommon — the TTL hook "
+                               "did not fire, or the (source IP, source port) "
+                               "flow key no longer matches the one the delays "
+                               "use (#308 phase 2)")
+            hc_min, hc_max = r.get("hops_common_min"), r.get("hops_common_max")
+            if hc_min is not None and hc_min < 1.0:
+                report("FAIL", f"{tag}: hopsCommon {hc_min} < 1 hop — a "
+                               "delivered packet traverses at least one "
+                               "transmission")
+            if hc_max is not None and hc_max > MAX_PATH_LENGTH:
+                report("FAIL", f"{tag}: hopsCommon {hc_max} exceeds "
+                               f"maxPathLength ({MAX_PATH_LENGTH})")
             if entropy is not None:
                 if entropy < 0.0:
                     report("FAIL", f"{tag}: negative path entropy ({entropy})")

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -411,6 +411,64 @@ def _cell_div_fires():
            f"planted divUsed=9.999 not flagged\n{out}")
 
 
+# --- #308 phase 2: hopsCommon on the ##COMMON## rows -------------------------
+#
+# The a-priori control: a delivered packet crosses at least one transmission
+# and at most maxPathLength, so hopsCommon is in [1, 100] on any real run. The
+# value that matters most is the one only this metric can get wrong — hops are
+# keyed by a flow address rebuilt from (source IP, UDP source port), and if that
+# ever stops matching the key the delays use, hopsCommon vanishes while nCommon
+# stays large. Fixture values are the real phase-2 re-measure (run 31042812548):
+# nCommon 6605, hopsCommon 2.73 for anthocnet against 2.19 for aodv.
+COMMON_CELL = """anthocnet 95.8 54.3 862.1 6.32 36.08
+##COMMON## 1 anthocnet 7775 6605 784.5 37.0 1008.9 2.730 3.410
+##COMMON## 2 anthocnet 7859 6584 944.0 59.5 1146.0 2.744 3.502
+"""
+
+
+@case("#308p2 hopsCommon stays quiet on real phase-2 values")
+def _hops_common_quiet():
+    levels, out = run_cell(COMMON_CELL)
+    expect(levels == [], "hops-common-quiet",
+           f"real hopsCommon values must not report, got {levels}\n{out}")
+
+
+@case("#308p2 a missing hopsCommon with a non-empty common set FAILs")
+def _hops_common_missing_fires():
+    # The flow-key divergence this rule exists for: nCommon large, no hops.
+    _levels, out = run_cell(COMMON_CELL.replace("1008.9 2.730 3.410",
+                                                "1008.9 na na"))
+    expect("no hopsCommon" in out, "hops-common-missing",
+           f"absent hopsCommon on a non-empty common set was not flagged\n{out}")
+
+
+@case("#308p2 hopsCommon below one hop, and above maxPathLength, FAIL")
+def _hops_common_bounds_fire():
+    _levels, out = run_cell(COMMON_CELL.replace("2.730", "0.500"))
+    expect("hopsCommon 0.5 < 1 hop" in out, "hops-common-low",
+           f"hopsCommon below one hop was not flagged\n{out}")
+    _levels, out = run_cell(COMMON_CELL.replace("2.730", "101.000"))
+    expect("exceeds maxPathLength" in out, "hops-common-high",
+           f"hopsCommon above maxPathLength was not flagged\n{out}")
+
+
+@case("#308p2 rows predating the hop fields, and an empty common set, skip")
+def _hops_common_skips():
+    # Seven-field ##COMMON## lines are what every run before this metric
+    # emitted; they must parse and report nothing rather than read as missing.
+    old = """anthocnet 95.8 54.3 862.1 6.32 36.08
+##COMMON## 1 anthocnet 7775 6605 784.5 37.0 1008.9
+"""
+    levels, out = run_cell(old)
+    expect(levels == [], "hops-common-old",
+           f"pre-instrumentation ##COMMON## row must skip, got {levels}\n{out}")
+    # nCommon 0 with no hop data is arithmetic, not a harness failure.
+    levels, out = run_cell(COMMON_CELL.replace(
+        "7775 6605 784.5 37.0 1008.9 2.730 3.410", "7775 0 -1.0 -1.0 na na na"))
+    expect(levels == [], "hops-common-empty",
+           f"empty common set must not FAIL, got {levels}\n{out}")
+
+
 @case("cell: broken drop identity on a '# drops' line fires")
 def _cell_drops_fire():
     _levels, out = run_cell(CELL.replace("chan=24.01", "chan=90.00"))

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -147,7 +147,7 @@ rank still assumes the surplus deliveries are the slowest ones. Keying by
 packet **identity** removes the assumption:
 
 ```
-##COMMON## <run> <proto> <nSelf> <nCommon> <p99Common> <meanCommon> <p99Surplus>
+##COMMON## <run> <proto> <nSelf> <nCommon> <p99Common> <meanCommon> <p99Surplus> <hopsCommon> <hopsSurplus>
 ```
 
 `nCommon` is the number of `(flow, seq)` pairs **every** protocol in the run
@@ -166,6 +166,35 @@ comparison disagreed.
 Per-packet delay comes from `SeqTsSizeHeader`'s send timestamp, which the
 reordering trace (#212) already peeks for the sequence number, so this costs
 one subtraction per delivered packet.
+
+**`hopsCommon` / `hopsSurplus` (#308 phase 2)** are the same two splits measured
+in hops instead of milliseconds, from the IP TTL each delivered packet carried.
+They exist because the obvious decomposition of the delay deficit — *is it more
+hops, or slower hops?* — was not expressible without them. `hopsMean` (#217)
+averages over each protocol's **own** deliveries while `meanCommon` averages
+over the **intersection**, so `meanCommon / hopsMean` silently divides one
+population by another: the same survivorship confound phase 1 was about,
+reappearing in the denominator. `meanCommon / hopsCommon` is a genuine per-hop
+cost over one population.
+
+Both are appended at the end of the line, never inserted: the earlier fields are
+read positionally.
+
+Worked example, from the phase-2 re-measure ([run
+31042812548](https://github.com/danieljoppi/AntHocNet/actions/runs/31042812548),
+paper base, disk, 20 seeds) — using the all-delivered basis, which was the only
+one available then:
+
+| factor | AntHocNet ÷ AODV |
+|---|---|
+| hop count | 1.247× |
+| ms per hop | 1.35× |
+| product | 1.68× (observed mean-delay ratio: 1.68×) |
+
+The decomposition is internally consistent there because both terms use the same
+all-delivered basis. What it cannot say is how the split looks on the packets
+both protocols carried, where the delay ratio is 1.44× rather than 1.68×. That
+is the question `hopsCommon` answers.
 
 **The one assumption left, and it is checkable.** Cross-protocol keying needs a
 flow's `(source IP, source port)` to be identical across protocols in the same

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -223,6 +223,20 @@ std::map<Address, std::vector<double>> g_rxArrival;
 // subtraction per delivered packet and no extra instrumentation.
 std::map<Address, std::map<uint32_t, double>> g_rxDelayBySeq;
 
+// #308 phase 2: (flow, seq) -> hop count, the same key as the delays above.
+//
+// The phase-2 decomposition needs delay and path length over the SAME packets.
+// `hopsMean` (#217) averages over each protocol's own deliveries while
+// `meanCommon` averages over the intersection, so dividing one by the other
+// mixes two populations — the exact survivorship confound phase 1 was about,
+// reappearing in the denominator. With hops keyed by identity, the common-set
+// per-hop cost is a like-for-like quotient: is AntHocNet's extra delay more
+// hops, or slower hops, on packets both protocols carried?
+//
+// Filled by CountDeliveredHops below rather than here, because the hop count
+// comes from the IP TTL and the sink's Rx trace has no IP header left to read.
+std::map<Address, std::map<uint32_t, uint32_t>> g_rxHopsBySeq;
+
 void RecordRxSeq(Ptr<const Packet> p, const Address& from) {
     SeqTsSizeHeader h;
     p->PeekHeader(h);
@@ -577,6 +591,21 @@ void CountDeliveredHops(const Ipv4Header& ip, Ptr<const Packet> p, uint32_t) {
     g_hopSum += hops;
     ++g_hopCount;
     if (hops > g_hopMax) g_hopMax = hops;
+
+    // #308 phase 2: also record this packet's hop count under the same
+    // (flow, seq) key the delays use, so the common set can be measured in hops
+    // as well as in milliseconds. The flow key must be byte-identical to the one
+    // PacketSink reports to RecordRxSeq, which is an InetSocketAddress built
+    // from the sender's IP and UDP source port — exactly the two fields
+    // available here. If that ever stopped matching, hopsCommon would read zero
+    // while PDR stayed positive, which scenario_check.py results treats as a
+    // FAIL rather than as "no hop data" (the #229/#230 rule).
+    Ptr<Packet> body = p->Copy();
+    body->RemoveHeader(udp);
+    SeqTsSizeHeader seqTs;
+    if (body->PeekHeader(seqTs) == 0) return;
+    const Address flow = InetSocketAddress(ip.GetSource(), udp.GetSourcePort());
+    g_rxHopsBySeq[flow][seqTs.GetSeq()] = hops;
 }
 
 void SampleQueues(NodeContainer nodes, double period, double until) {
@@ -643,6 +672,9 @@ struct Result {
     // can be compared over the packets *every* protocol delivered rather than
     // over each protocol's own differently-sized delivered set.
     std::map<Address, std::map<uint32_t, double>> rxDelayBySeq;
+    // #308 phase 2: the same keys carrying hop counts, so the common set can be
+    // normalised by path length like-for-like.
+    std::map<Address, std::map<uint32_t, uint32_t>> rxHopsBySeq;
     // #209 energy:
     double energyJ = 0.0;        // total consumed over all nodes (J)
     double energyPerPktJ = 0.0;  // energyJ / delivered data packets (J/pkt)
@@ -703,6 +735,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_rxSeq.clear();
     g_rxArrival.clear();  // #89
     g_rxDelayBySeq.clear();  // #308
+    g_rxHopsBySeq.clear();   // #308 phase 2
     g_dataHopTx = g_dataHopRx = g_macDataDrops = 0;  // #215
     // #217
     g_hopSum = g_hopCount = 0;
@@ -1155,6 +1188,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     r.delayHist = delayBins;
     r.delayBinWidth = binWidth;
     r.rxDelayBySeq = g_rxDelayBySeq;
+    r.rxHopsBySeq = g_rxHopsBySeq;
 
     // #57 offered-load delay percentiles: the q-th percentile over *sent*
     // packets, treating undelivered as infinite delay. Monotone-honest — a
@@ -1765,6 +1799,7 @@ int main(int argc, char* argv[]) {
         uint64_t rx = 0;
         double   delay99Ms = 0.0;
         std::map<Address, std::map<uint32_t, double>> bySeq;  // #308
+        std::map<Address, std::map<uint32_t, uint32_t>> hopsBySeq;  // #308 phase 2
     };
     std::vector<std::vector<MatchCell>> matchGrid(
         list.size(), std::vector<MatchCell>(runs));
@@ -1777,6 +1812,7 @@ int main(int argc, char* argv[]) {
             mc.rx = r.rxPackets;
             mc.delay99Ms = r.delay99Ms;
             mc.bySeq = r.rxDelayBySeq;
+            mc.hopsBySeq = r.rxHopsBySeq;
             // #128: per-run (per-seed) row for paired statistics. Every
             // protocol sees the identical RNG realisation per run, so
             // downstream can pair rows by run number (per-seed deltas, sign
@@ -2017,17 +2053,43 @@ int main(int argc, char* argv[]) {
                         else surplus.push_back(kv.second);
                     }
                 }
+                // #308 phase 2: the same split over hop counts. Averaged over
+                // exactly the packets whose delays produced meanCommon, so
+                // meanCommon / hopsCommon is a per-hop cost on one population
+                // instead of a quotient of two differently-sized ones.
+                uint64_t hopSumC = 0, hopNC = 0, hopSumS = 0, hopNS = 0;
+                for (const auto& f : matchGrid[i][s - firstRun].hopsBySeq) {
+                    for (const auto& kv : f.second) {
+                        if (common.count({f.first, kv.first})) {
+                            hopSumC += kv.second;
+                            ++hopNC;
+                        } else {
+                            hopSumS += kv.second;
+                            ++hopNS;
+                        }
+                    }
+                }
                 const double p99c = pct(inCommon, 0.99);
                 const double meanc = inCommon.empty() ? -1.0 :
                     1000.0 * std::accumulate(inCommon.begin(), inCommon.end(), 0.0)
                     / inCommon.size();
                 const double p99s = pct(surplus, 0.99);
+                const double hopsc = hopNC ? static_cast<double>(hopSumC) / hopNC : -1.0;
+                const double hopss = hopNS ? static_cast<double>(hopSumS) / hopNS : -1.0;
                 std::cout << std::fixed << "##COMMON## " << s << ' ' << list[i]
                           << ' ' << nSelf << ' ' << common.size()
                           << ' ' << std::setprecision(1) << p99c
                           << ' ' << std::setprecision(1) << meanc << ' ';
                 if (p99s < 0) std::cout << "na";
                 else std::cout << std::setprecision(1) << p99s;
+                // Appended, never inserted: the fields above are consumed
+                // positionally by the issue-thread tooling and docs/benchmarks.
+                std::cout << ' ';
+                if (hopsc < 0) std::cout << "na";
+                else std::cout << std::setprecision(3) << hopsc;
+                std::cout << ' ';
+                if (hopss < 0) std::cout << "na";
+                else std::cout << std::setprecision(3) << hopss;
                 std::cout << "\n";
             }
         }


### PR DESCRIPTION
Phase 2 step 1 of #308 [answered NO](https://github.com/danieljoppi/AntHocNet/issues/308#issuecomment-5197783678): the delay-tail deficit survives #179/#180 at a paired `p99Common` difference of **+354.23 ms**, boot95 [+313.66, +393.33], with PDR unregressed (**+11.87 ± 0.62 pp**) and `nCommon` up 6242 → 6546. Step 2 is therefore due, and the epic is explicit that it starts with measurement:

> Only if a deficit survives: attack the per-hop factor **with evidence** […] a decomposition comes before any patch, as in phase 1.

The first thing that decomposition needs is a hop count over the right packets, and the harness could not produce one.

## The gap

The obvious split is `delay = hops × cost-per-hop`. Both terms exist — on **incompatible populations**:

| term | averaged over |
|---|---|
| `hopsMean` (#217) | each protocol's **own** delivered packets |
| `meanCommon` (#308) | the **intersection** of the delivered sets |

Dividing one by the other divides one population by another — the survivorship confound this epic was filed about, reappearing in the denominator. And it matters quantitatively: the delay ratio is **1.68×** on the all-delivered basis and **1.44×** on the common set.

To be clear about what was already sound: the all-delivered decomposition reported on the issue *is* internally consistent, because both its terms use that basis (1.247 × 1.35 = 1.68, matching the observed mean-delay ratio). What could not be computed is the same split on the packets both protocols actually carried — which is where the headline metric lives.

## What this adds

```
##COMMON## <run> <proto> <nSelf> <nCommon> <p99Common> <meanCommon> <p99Surplus> <hopsCommon> <hopsSurplus>
```

- **`hopsCommon`** — mean hop count over exactly the packets whose delays produced `meanCommon`, so `meanCommon / hopsCommon` is a per-hop cost over **one** population.
- **`hopsSurplus`** — the hop-count analogue of `p99Surplus`, newly interesting because the re-measure found the surplus *is* systematically slower now (+233.54 ms for AntHocNet, where phase 1 measured no difference).

Appended, never inserted — the earlier fields are read positionally. `na` where a protocol has no surplus, matching `p99Surplus`.

Implementation is one map and one trace change. `CountDeliveredHops` already fires per delivered data packet at `Ipv4L3Protocol` `"LocalDeliver"` with the IP header, so it already has the TTL; it now also peeks past the UDP header for the `SeqTsSizeHeader` sequence number and files the hop count under the same `(flow, seq)` key the delays use. **No new trace hook, no extra simulated work, and no change to any existing number.**

## The one thing this metric can get wrong — asserted, not described

The flow key is rebuilt from `(source IP, UDP source port)`, because the sink's Rx trace (where delays are recorded) has no IP header left to read. That must produce the byte-identical `Address` `PacketSink` reports. If it ever diverges, every hop lands under a key the common set does not contain: **`hopsCommon` reads absent while `nCommon` stays large, and the per-hop decomposition is silently wrong.**

Per the #229/#230 discipline:

- `scenario_check.py results` now parses `##COMMON##` rows and **FAILs** on (a) any run with a non-empty common set and no `hopsCommon` — exactly the divergence above, (b) `hopsCommon` < 1 hop, (c) `hopsCommon` > `maxPathLength`.
- `test_scenario_check.py` gains four cases: one proving the rules stay **quiet** on the real phase-2 values (`nCommon` 6605, `hopsCommon` 2.730), and three proving each failure mode **fires** — including that seven-field `##COMMON##` rows from every pre-existing run still parse and report nothing, and that an empty common set is arithmetic rather than a harness failure.

**39 cases pass**, ruff clean.

No preflight coherence rule: this metric depends on no scenario knob. Unlike #230's `--pathWindowS`, there is no parameter whose setting could make it meaningless — stated explicitly so the omission is a decision rather than a gap.

`paper-benchmark.yml` needs no change — `##COMMON##` is already in the compact re-emit allow-list, and this adds fields to it rather than a new marker.

## Verification

No local ns-3 build in this environment, so CI's five-version matrix is the first compile of the C++. The Python half is fully verified here (39/39 + ruff).

This is instrumentation only — no protocol behaviour changes, so no A/B is required. The next dispatch after it lands supplies the actual decomposition.

Refs #308, #217, #229, #230

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_