### PR TITLE
feat(bench): measure channel occupancy per run for the #308 per-hop hypothesis

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -100,6 +100,14 @@ DIAG_LINE = re.compile(r"^\s*#\s+(paths|energy|drops|reorder)\s+([a-z][\w-]*)\s+
 COMMON_LINE = re.compile(
     r"^\s*##COMMON##\s+\d+\s+([a-z][\w-]*)\s+\d+\s+(\d+)\s+\S+\s+\S+\s+\S+"
     r"(?:\s+(\S+)\s+\S+)?\s*$")
+# #308 phase 2 step 3: per-run channel occupancy.
+#   ##AIR## <run> <proto> <txS> <rxS> <ccaBusyS> <busyPct>
+# Absent entirely when --energyJ=0 leaves the PHY State trace unconnected, which
+# is why "row present but all-zero" is a failure rather than a configuration:
+# the harness prints no row at all in that case (see docs/benchmarks/metrics.md).
+AIR_LINE = re.compile(
+    r"^\s*##AIR##\s+\d+\s+([a-z][\w-]*)\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)"
+    r"\s+([-\d.]+)\s*$")
 DIAG_KEYS = {
     "paths":   {"hopsMean": "hops", "hopsMax": "hops_max", "divUsed": "div",
                 "divMax": "div_max", "entropyBits": "entropy",
@@ -398,6 +406,21 @@ def parse_results(path):
             row["hops_common_min"] = min(row.get("hops_common_min", v), v)
             row["hops_common_max"] = max(row.get("hops_common_max", v), v)
             continue
+        a = AIR_LINE.match(line)
+        if a:
+            row = by_proto.get(a.group(1))
+            if row is None:
+                continue  # ##AIR## with no table row above it
+            tx, rx, cca = (float(a.group(2)), float(a.group(3)),
+                           float(a.group(4)))
+            busy_pct = float(a.group(5))
+            if min(tx, rx, cca) < 0.0:
+                row["air_negative"] = row.get("air_negative", 0) + 1
+            if tx + rx + cca == 0.0:
+                row["air_zero_runs"] = row.get("air_zero_runs", 0) + 1
+            row["air_busy_max"] = max(row.get("air_busy_max", busy_pct),
+                                      busy_pct)
+            continue
         d = DIAG_LINE.match(line)
         if not d:
             continue
@@ -683,6 +706,27 @@ def cmd_results(a):
                                "did not fire, or the (source IP, source port) "
                                "flow key no longer matches the one the delays "
                                "use (#308 phase 2)")
+            # #308 phase 2 step 3 channel occupancy. Two a-priori facts: a node
+            # cannot see the medium busy for more than the whole run, and no
+            # component of the occupancy can be negative. The third rule is the
+            # harness-failure detector — a ##AIR## row is only printed when the
+            # PHY State trace is connected, so a row that IS present while
+            # reporting zero occupancy, in a run where packets were delivered,
+            # means the trace fired without recording. (--energyJ=0 prints no
+            # row at all; absence skips every rule here, as it should.)
+            if r.get("air_negative"):
+                report("FAIL", f"{tag}: {r['air_negative']} run(s) report a "
+                               "negative channel-occupancy component")
+            if r.get("air_zero_runs") and pdr:
+                report("FAIL", f"{tag}: {r['air_zero_runs']} run(s) report zero "
+                               f"channel occupancy with PDR {pdr} — packets "
+                               "were delivered, so the medium cannot have been "
+                               "idle throughout (#308 phase 2)")
+            busy_max = r.get("air_busy_max")
+            if busy_max is not None and busy_max > 100.0:
+                report("FAIL", f"{tag}: channel busy {busy_max}% of node-time — "
+                               "a node cannot see the medium occupied for more "
+                               "than the whole run")
             hc_min, hc_max = r.get("hops_common_min"), r.get("hops_common_max")
             if hc_min is not None and hc_min < 1.0:
                 report("FAIL", f"{tag}: hopsCommon {hc_min} < 1 hop — a "

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -411,6 +411,53 @@ def _cell_div_fires():
            f"planted divUsed=9.999 not flagged\n{out}")
 
 
+# --- #308 phase 2 step 3: channel occupancy on the ##AIR## rows --------------
+#
+# Two a-priori bounds (occupancy is non-negative; a node cannot see the medium
+# busy for more than the whole run) plus the harness-failure detector: an ##AIR##
+# row is only printed when the PHY State trace is connected, so a row that IS
+# present while reporting zero occupancy in a run that delivered packets means
+# the trace fired without recording. --energyJ=0 prints no row at all, and that
+# absence must skip every rule rather than read as a failure.
+AIR_CELL = """anthocnet 95.8 54.3 862.1 6.32 36.08
+##AIR## 1 anthocnet 1204.500 8931.250 3310.750 29.8811
+##AIR## 2 anthocnet 1198.125 8902.500 3288.375 29.7532
+"""
+
+
+@case("#308p2 channel occupancy stays quiet on plausible values")
+def _air_quiet():
+    levels, out = run_cell(AIR_CELL)
+    expect(levels == [], "air-quiet",
+           f"plausible ##AIR## rows must not report, got {levels}\n{out}")
+
+
+@case("#308p2 busy above 100% of node-time FAILs")
+def _air_over_hundred():
+    _levels, out = run_cell(AIR_CELL.replace("29.8811", "100.4000"))
+    expect("cannot see the medium occupied" in out, "air-over",
+           f"busyPct above 100 was not flagged\n{out}")
+
+
+@case("#308p2 a present-but-zero occupancy row with non-zero PDR FAILs")
+def _air_zero():
+    _levels, out = run_cell(AIR_CELL.replace(
+        "1204.500 8931.250 3310.750 29.8811", "0.000 0.000 0.000 0.0000"))
+    expect("medium cannot have been idle" in out, "air-zero",
+           f"zero occupancy with PDR 95.8 was not flagged\n{out}")
+
+
+@case("#308p2 negative occupancy FAILs, and an absent ##AIR## block skips")
+def _air_negative_and_absent():
+    _levels, out = run_cell(AIR_CELL.replace("8931.250", "-1.000"))
+    expect("negative channel-occupancy" in out, "air-negative",
+           f"negative component was not flagged\n{out}")
+    # --energyJ=0 emits no ##AIR## row at all; that must report nothing.
+    levels, out = run_cell("anthocnet 95.8 54.3 862.1 6.32 36.08\n")
+    expect(levels == [], "air-absent",
+           f"a cell with no ##AIR## rows must skip, got {levels}\n{out}")
+
+
 # --- #308 phase 2: hopsCommon on the ##COMMON## rows -------------------------
 #
 # The a-priori control: a delivered packet crosses at least one transmission

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -247,6 +247,10 @@ jobs:
           # them — see the ##MATCH## note above for what forgetting costs.
           grep '^##COMMON##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #308 phase 2 step 3: channel-occupancy rows, added here in the same
+          # commit that emits them — same rule, same reason as the two above.
+          grep '^##AIR##' "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
           # the *only* place the #209/#212/#215/#217 metric families appear in a
           # single-point run — the fixed-width table cannot carry them (its field

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -196,6 +196,46 @@ all-delivered basis. What it cannot say is how the split looks on the packets
 both protocols carried, where the delay ratio is 1.44× rather than 1.68×. That
 is the question `hopsCommon` answers.
 
+### Channel occupancy (`##AIR##`, #308 phase 2 step 3)
+
+```
+##AIR## <run> <proto> <txS> <rxS> <ccaBusyS> <busyPct>
+```
+
+The step-2 decomposition split the delay deficit into **36 % extra path length
+and 64 % extra cost per hop**, and left one hypothesis standing for the per-hop
+half: AntHocNet sends *fewer* control packets than AODV (NRL 36.08 vs 55.39) but
+substantially *more* control **bytes** (`nrl_bytes` 42.607 vs 29.133), so it may
+simply be putting more airtime on a shared 2 Mbit/s medium that data then queues
+behind. That would raise per-hop delay while causing neither MAC drops (0.44 %
+vs AODV's 10.43 %) nor queue overflow (`drop_queue` 0.00 for both) — which is
+exactly the observed signature, and exactly why it has to be measured rather
+than believed.
+
+`txS` / `rxS` / `ccaBusyS` are node-seconds summed over every node: what this
+network put on the air, what it decoded, and what it saw as busy-but-not-for-me.
+`busyPct` is their sum as a percentage of node-time (`nNodes × time`), i.e. the
+fraction of the run an average node saw the medium occupied — normalised so the
+number does not silently depend on `--nNodes` or `--time`.
+
+The PHY `"State"` trace is already connected for the energy accounting (#209)
+and already carries each state's duration, so this costs no new hook and no
+extra simulated work.
+
+**Coupled to the energy model, deliberately visible.** That trace is only
+connected when the energy model is on, so `--energyJ=0` (#270) leaves the
+occupancy unmeasured. In that case **no `##AIR##` row is printed at all**,
+rather than an all-zero row that would read as "the medium was never busy" — the
+absence is the signal. `scenario_check.py results` therefore treats a *present*
+row with all-zero occupancy and non-zero PDR as a FAIL: packets flew, so the
+medium cannot have been idle throughout.
+
+**Distinguishing what this can and cannot show.** It measures whether the
+airtime premise is true — is AntHocNet occupying more of the medium? It does
+**not** establish that the extra airtime *causes* the per-hop delay. A negative
+result kills the hypothesis; a positive one licenses the next measurement, not a
+conclusion.
+
 **The one assumption left, and it is checkable.** Cross-protocol keying needs a
 flow's `(source IP, source port)` to be identical across protocols in the same
 run. It is — topology, addressing and application construction are identical

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -399,7 +399,30 @@ double g_energyInitJ = 0.0;             // this run's --energyJ
 double g_energyVoltV = 0.0;
 double g_energyTxA = 0.0, g_energyRxA = 0.0, g_energyIdleA = 0.0;
 
+// #308 phase 2 step 3: channel-occupancy totals, summed over nodes (seconds).
+//
+// Step 2 measured the deficit as 36% extra path length and 64% extra cost per
+// hop, and left one hypothesis standing for the per-hop half: AntHocNet sends
+// fewer control PACKETS than AODV (NRL 36.08 vs 55.39) but substantially more
+// control BYTES (nrl_bytes 42.607 vs 29.133), so it may simply be putting more
+// airtime on a shared 2 Mbit/s medium that data then queues behind. That would
+// raise per-hop delay while causing neither MAC drops (0.44% vs AODV's 10.43%)
+// nor queue overflow (drop_queue 0.00 for both) — which is exactly the observed
+// signature, and exactly why it needs measuring rather than believing.
+//
+// The PHY "State" trace is already connected for the energy accounting and
+// already carries the duration of each state, so the occupancy totals are free:
+// no new hook, no extra simulated work. TX is what this node put on the air;
+// RX plus CCA_BUSY is what it saw others put there.
+double g_airTxS = 0.0, g_airRxS = 0.0, g_airCcaS = 0.0;
+
 void OnPhyState(uint32_t node, Time, Time duration, WifiPhyState state) {
+    switch (state) {
+        case WifiPhyState::TX: g_airTxS += duration.GetSeconds(); break;
+        case WifiPhyState::RX: g_airRxS += duration.GetSeconds(); break;
+        case WifiPhyState::CCA_BUSY: g_airCcaS += duration.GetSeconds(); break;
+        default: break;
+    }
     double currentA;
     switch (state) {
         case WifiPhyState::TX: currentA = g_energyTxA; break;
@@ -676,6 +699,10 @@ struct Result {
     // normalised by path length like-for-like.
     std::map<Address, std::map<uint32_t, uint32_t>> rxHopsBySeq;
     // #209 energy:
+    // #308 phase 2 step 3: channel occupancy summed over nodes (node-seconds).
+    // -1 = not measured (the PHY State trace is only connected when the energy
+    // model is on), which suppresses the ##AIR## row entirely.
+    double airTxS = -1.0, airRxS = -1.0, airCcaS = -1.0;
     double energyJ = 0.0;        // total consumed over all nodes (J)
     double energyPerPktJ = 0.0;  // energyJ / delivered data packets (J/pkt)
     double resMinJ = 0.0;        // residual energy across nodes: min / mean /
@@ -732,6 +759,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_qCount = g_qNonzero = g_qMax = 0;
     g_qSum = 0.0;
     g_firstDeathS = -1.0;
+    g_airTxS = g_airRxS = g_airCcaS = 0.0;  // #308 phase 2 step 3
     g_rxSeq.clear();
     g_rxArrival.clear();  // #89
     g_rxDelayBySeq.clear();  // #308
@@ -1227,6 +1255,16 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             }
         }
         r.energyJ = consumed;
+        // #308 phase 2 step 3: the occupancy totals are only meaningful when the
+        // PHY "State" trace is connected, which is the same condition the energy
+        // accounting uses — --energyJ=0 turns both off (#270). The -1 default
+        // survives in that case so no ##AIR## row is printed at all, rather than
+        // an all-zero one that would read as "the medium was never busy".
+        if (energyOn) {
+            r.airTxS = g_airTxS;
+            r.airRxS = g_airRxS;
+            r.airCcaS = g_airCcaS;
+        }
         // Efficiency figure: joules spent per data packet actually delivered.
         // Comparable across protocols sitting at different PDRs, which total
         // joules alone is not (every node's radio is on for the same wall time
@@ -1835,6 +1873,26 @@ int main(int argc, char* argv[]) {
             // paired per-seed statistics cover nrl_bytes too.
             std::cout << ' ' << std::setprecision(4) << r.nrlBytes;
             std::cout << "\n";
+            // #308 phase 2 step 3: channel occupancy, per run so it pairs on
+            // identical seeds like every other per-seed row. Its own marker
+            // rather than extra ##RUN## columns, for the reason ##MATCH## and
+            // ##COMMON## have their own: the ##RUN## field order is consumed
+            // positionally, so appending there would shift downstream mappings.
+            // Reported as a fraction of node-time rather than raw seconds so
+            // the number does not silently depend on --nNodes or --time:
+            // busyPct is what one node saw the medium occupied, on average.
+            if (r.airTxS >= 0.0) {
+                const double nodeSeconds =
+                    static_cast<double>(P.nNodes) * P.simTime;
+                const double busy = r.airTxS + r.airRxS + r.airCcaS;
+                std::cout << std::fixed << "##AIR## " << s << ' ' << list[i]
+                          << ' ' << std::setprecision(3) << r.airTxS
+                          << ' ' << std::setprecision(3) << r.airRxS
+                          << ' ' << std::setprecision(3) << r.airCcaS
+                          << ' ' << std::setprecision(4)
+                          << (nodeSeconds > 0.0 ? 100.0 * busy / nodeSeconds : 0.0)
+                          << "\n";
+            }
             agg[i].pdr += r.pdr;
             agg[i].delay += r.meanDelayMs;
             agg[i].delay99 += r.delay99Ms;


### PR DESCRIPTION
[Phase 2 step 2](https://github.com/danieljoppi/AntHocNet/issues/308#issuecomment-5199922249) decomposed the delay deficit on the common set into two real factors — **1.141× path length** and **1.259× cost per hop**, product 1.436× — with per-hop cost the larger contributor at **64 % of the log-deficit**. It left exactly one hypothesis standing for that half, and no way to test it.

## The hypothesis, and why it earns a measurement

AntHocNet sends **fewer** routing-control packets per delivered packet than AODV (NRL 36.08 vs 55.39) but substantially **more** control **bytes** (`nrl_bytes` 42.607 vs 29.133) — roughly 2.2× larger control messages, which is what an ant carrying its visited path looks like beside a fixed-size RREQ. On a shared 2 Mbit/s medium that is airtime, and data queues behind airtime.

What makes it more than a story is that it predicts the exact signature already measured, *including the parts that rule out the obvious alternatives*:

| observation | airtime hypothesis | contention-as-loss | queue overflow |
|---|---|---|---|
| per-hop delay ↑ | ✅ | ✅ | ✅ |
| MAC drops 0.44 % (vs AODV's 10.43 %) | ✅ | ❌ | — |
| `drop_queue` 0.00 both | ✅ | — | ❌ |

The protocol with the worse per-hop cost is the one **not** losing frames to contention and **not** overflowing queues. Contention that delays without dropping fits that; contention that drops does not.

It is still a hypothesis. This PR measures its **premise** — is AntHocNet actually occupying more of the medium? — and nothing more.

## What is added

```
##AIR## <run> <proto> <txS> <rxS> <ccaBusyS> <busyPct>
```

`txS`/`rxS`/`ccaBusyS` are node-seconds summed over every node: what the network put on the air, what it decoded, and what it saw as busy-but-not-for-me. `busyPct` is their sum as a percentage of node-time (`nNodes × time`), normalised so the number cannot silently depend on `--nNodes` or `--time`.

Per run, with its own marker, for the same two reasons `##MATCH##` and `##COMMON##` have theirs: per-run rows pair on identical seeds and so carry a paired CI, and the `##RUN##` field order is consumed positionally so appending there would shift downstream mappings.

**Cost is zero.** The PHY `"State"` trace is already connected for the energy accounting (#209) and already carries each state's duration; this adds three accumulators to the existing callback. No new hook, no extra simulated work, no existing number moves.

## The coupling, made visible rather than papered over

That trace is only connected when the energy model is on, so `--energyJ=0` (#270) leaves occupancy unmeasured. Rather than print an all-zero row — which would read as *"the medium was never busy"*, a plausible and completely wrong number — the harness prints **no `##AIR##` row at all**. The `Result` fields default to `-1` to carry that distinction out of `RunOne`.

That choice is what makes the third check below meaningful: **a row that IS present while reporting zero occupancy cannot be a configuration, only a failure.**

## Shipping discipline (#229/#230)

- `scenario_check.py results` parses `##AIR##` and **FAILs** on: a negative occupancy component; `busyPct` above 100 (a node cannot see the medium occupied for longer than the run); and a present-but-zero row in a run that delivered packets.
- `test_scenario_check.py` gains four cases — one proving the rules stay **quiet** on plausible values, three proving each failure mode **fires**, including that a cell with no `##AIR##` rows skips every rule as `--energyJ=0` requires. **43 cases pass**, ruff clean.
- `paper-benchmark.yml`'s compact re-emit gains `'^##AIR##'` **in this commit** — a new marker the workflow cannot see is a marker that costs 100+ `tail_lines` to read, which is the mistake `##MATCH##` made once already.

No preflight coherence rule: like `hopsCommon`, this metric depends on no scenario knob whose setting could make it meaningless.

## What this can and cannot show

It tests whether the airtime **premise** is true. It does **not** establish that extra airtime *causes* the per-hop delay. A negative result kills the hypothesis outright; a positive one licenses the next measurement, not a conclusion. That limit is stated in `docs/benchmarks/metrics.md` beside the metric so it travels with the number.

## Verification

No local ns-3 build here, so CI's five-version matrix is the first compile of the C++. The Python half is fully verified locally (43/43 + ruff). Instrumentation only — no protocol behaviour changes, so no A/B is required.

Refs #308, #209, #229, #230, #270

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_