### PR TITLE
feat(bench): emit ##HOLD## so pending-queue hold time is reachable, not just measured

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -46,6 +46,10 @@ ANCHOR_KEY = {"single-hop": "single_hop_pdr_min",
 # and therefore on any path the protocol can lay. A delivered data packet
 # reported above it is an instrumentation error, not a long route.
 MAX_PATH_LENGTH = 100
+# #308 phase 2: a pending-queue hold is bounded by QueueTimeout (3 s default);
+# 5 s leaves headroom for a raised attribute while still catching an accounting
+# error, which is what this rule is for.
+HOLD_CEILING_MS = 5000.0
 
 # #230: the baselines all install exactly one route per destination at a time,
 # so their path_div_used is 1.0 by construction. Anything materially above that
@@ -105,6 +109,12 @@ COMMON_LINE = re.compile(
 # Absent entirely when --energyJ=0 leaves the PHY State trace unconnected, which
 # is why "row present but all-zero" is a failure rather than a configuration:
 # the harness prints no row at all in that case (see docs/benchmarks/metrics.md).
+# #308 phase 2 step 4: per-run pending-queue hold rows, AntHocNet only.
+#   ##HOLD## <run> <proto> <setupN> <setupMean> <setupMax> <reconvN> ... <repairMax>
+# Absent for every protocol without the instrumentation, deliberately: a zero row
+# would assert "never held a packet" where the truth is "nobody looked".
+HOLD_LINE = re.compile(
+    r"^\s*##HOLD##\s+\d+\s+([a-z][\w-]*)((?:\s+[-\d.]+){9})\s*$")
 AIR_LINE = re.compile(
     r"^\s*##AIR##\s+\d+\s+([a-z][\w-]*)\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)"
     r"\s+([-\d.]+)\s*$")
@@ -406,6 +416,22 @@ def parse_results(path):
             row["hops_common_min"] = min(row.get("hops_common_min", v), v)
             row["hops_common_max"] = max(row.get("hops_common_max", v), v)
             continue
+        h = HOLD_LINE.match(line)
+        if h:
+            row = by_proto.get(h.group(1))
+            if row is None:
+                continue
+            f = [float(x) for x in h.group(2).split()]
+            # (count, mean, max) x (setup, reconv, repair)
+            if min(f) < 0.0:
+                row["hold_negative"] = row.get("hold_negative", 0) + 1
+            worst = max(f[2], f[5], f[8])          # the three max fields
+            row["hold_max_ms"] = max(row.get("hold_max_ms", worst), worst)
+            for base in (0, 3, 6):
+                if f[base] == 0.0 and f[base + 1] > 0.0:
+                    row["hold_mean_no_count"] = \
+                        row.get("hold_mean_no_count", 0) + 1
+            continue
         a = AIR_LINE.match(line)
         if a:
             row = by_proto.get(a.group(1))
@@ -699,6 +725,25 @@ def cmd_results(a):
             # hopsCommon reads absent while nCommon stays large. Without this
             # rule that failure is silent and the per-hop decomposition is
             # simply wrong; with it the run FAILs.
+            # #308 phase 2 step 4 pending-queue hold time. Three a-priori
+            # facts: no component is negative; a hold cannot outlast the
+            # QueueTimeout that bounds it (3 s by default, so a generous 5 s
+            # ceiling catches an accounting error without policing the
+            # attribute); and a non-zero mean with a zero count is arithmetic
+            # that cannot happen, which is what a mis-ordered field mapping
+            # would look like.
+            if r.get("hold_negative"):
+                report("FAIL", f"{tag}: {r['hold_negative']} ##HOLD## row(s) "
+                               "with a negative hold count/mean/max")
+            if r.get("hold_mean_no_count"):
+                report("FAIL", f"{tag}: {r['hold_mean_no_count']} ##HOLD## "
+                               "reason(s) report a non-zero mean hold with a "
+                               "zero hold count — the fields are mis-mapped")
+            hold_max = r.get("hold_max_ms")
+            if hold_max is not None and hold_max > HOLD_CEILING_MS:
+                report("FAIL", f"{tag}: max hold {hold_max} ms exceeds "
+                               f"{HOLD_CEILING_MS} ms — a pending-queue hold is "
+                               "bounded by QueueTimeout (#308 phase 2)")
             missing = r.get("hops_common_missing")
             if missing:
                 report("FAIL", f"{tag}: {missing} run(s) report a non-empty "

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -411,6 +411,52 @@ def _cell_div_fires():
            f"planted divUsed=9.999 not flagged\n{out}")
 
 
+# --- #308 phase 2 step 4: pending-queue hold on the ##HOLD## rows -------------
+#
+# Fixture values are the real step-4 readings (run 31069667952): setup
+# 21/428.7ms/max2752.9ms, reconv 1677/87.3ms, repair ~1959/24.0ms. The rules are
+# arithmetic impossibilities, not thresholds: negative components, a mean with
+# no count behind it, and a hold outlasting the QueueTimeout that bounds it.
+HOLD_CELL = """anthocnet 95.8 54.3 862.1 6.32 36.08
+##HOLD## 1 anthocnet 21 428.70 2752.90 1677 87.30 994.50 1959 24.00 1945.90
+##HOLD## 2 anthocnet 27 331.40 2074.80 1849 104.90 981.20 1902 23.10 1877.40
+"""
+
+
+@case("#308p2 hold rows stay quiet on real step-4 values")
+def _hold_quiet():
+    levels, out = run_cell(HOLD_CELL)
+    expect(levels == [], "hold-quiet",
+           f"real ##HOLD## values must not report, got {levels}\n{out}")
+
+
+@case("#308p2 a hold outlasting QueueTimeout FAILs")
+def _hold_ceiling():
+    _levels, out = run_cell(HOLD_CELL.replace("2752.90", "5200.00"))
+    expect("exceeds 5000.0 ms" in out, "hold-ceiling",
+           f"a 5.2 s hold was not flagged\n{out}")
+
+
+@case("#308p2 a non-zero mean hold with a zero count FAILs")
+def _hold_mean_no_count():
+    # What a mis-ordered field mapping looks like: a mean with nothing behind it.
+    _levels, out = run_cell(HOLD_CELL.replace("21 428.70", "0 428.70"))
+    expect("zero hold count" in out, "hold-mean-no-count",
+           f"mean-without-count was not flagged\n{out}")
+
+
+@case("#308p2 negative hold FAILs, and a cell with no ##HOLD## rows skips")
+def _hold_negative_and_absent():
+    _levels, out = run_cell(HOLD_CELL.replace("1677 87.30", "1677 -87.30"))
+    expect("negative hold" in out, "hold-negative",
+           f"negative mean hold was not flagged\n{out}")
+    # AODV/OLSR/DSDV emit no ##HOLD## row at all — absence must report nothing,
+    # never "this protocol never held a packet".
+    levels, out = run_cell("aodv 83.9 32.4 472.6 5.54 55.39\n")
+    expect(levels == [], "hold-absent",
+           f"a protocol with no ##HOLD## rows must skip, got {levels}\n{out}")
+
+
 # --- #308 phase 2 step 3: channel occupancy on the ##AIR## rows --------------
 #
 # Two a-priori bounds (occupancy is non-negative; a node cannot see the medium

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -251,6 +251,15 @@ jobs:
           # commit that emits them — same rule, same reason as the two above.
           grep '^##AIR##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #308 phase 2 step 4: pending-queue hold rows. Added in the same
+          # commit that emits them — and this marker exists BECAUSE the rule was
+          # only half-followed before: the hold numbers were measured from #104
+          # and printed inside the '# diag' line, which this block never
+          # re-emitted, so the step-4 read cost a 900-line tail and still lost
+          # three of twenty seeds. Emitting a number and being able to reach it
+          # are different things.
+          grep '^##HOLD##' "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
           # the *only* place the #209/#212/#215/#217 metric families appear in a
           # single-point run — the fixed-width table cannot carry them (its field

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -196,6 +196,48 @@ all-delivered basis. What it cannot say is how the split looks on the packets
 both protocols carried, where the delay ratio is 1.44× rather than 1.68×. That
 is the question `hopsCommon` answers.
 
+### Pending-queue hold time (`##HOLD##`, #308 phase 2 step 4)
+
+```
+##HOLD## <run> <proto> <setupN> <setupMeanMs> <setupMaxMs> \
+                       <reconvN> <reconvMeanMs> <reconvMaxMs> \
+                       <repairN> <repairMeanMs> <repairMaxMs>
+```
+
+How long delivered data packets waited in AntHocNet's pending queue, split by
+why they were waiting: `setup` (first discovery for a destination), `reconv`
+(re-discovery after a known route was lost) and `repair` (re-injected after a
+MAC transmit failure while a local repair runs). Summed over nodes, per run.
+
+**The measurement is not new — reaching it is.** `HoldStats` has recorded these
+since #21/#104, but they were printed only inside the `--diag` line, which the
+workflow's compact re-emit never carried. Reading them for the phase-2
+decomposition therefore cost a 900-line log tail and still lost three of twenty
+seeds. Emitting a number and being able to reach it are different things; this
+marker closes the second half.
+
+Measured at the paper base scenario (disk, 900 s, 20 seeds): `reconv` holds
+1703 events per run at 93.0 ms mean, `repair` 1959 at 24.0 ms, `setup` 18 at
+406.5 ms — together **27.61 ± 1.72 ms per delivered packet**, against an
+all-delivered mean-delay gap to AODV of 21.9 ms.
+
+**Two limits, both load-bearing.**
+
+*Counts are hold **events**, not packets.* The pending queue is per node, so a
+packet crossing several hops can be held more than once. `setupN + reconvN +
+repairN` divided by delivered packets gives **hold events per delivered
+packet** (0.476 at the paper base), which is *either* ~48 % of packets held
+once *or* fewer packets held repeatedly. These counters cannot tell the two
+apart, and the distinction matters for the protocol story.
+
+*Rows appear for AntHocNet only.* AODV also queues during route discovery
+(`aodv::RequestQueue`) and OLSR/DSDV do not queue at all, but **none of them is
+instrumented**, so no row is printed for them. A row of zeros would assert
+"this protocol never held a packet" when the truth is "nobody looked" — the
+same reason `##AIR##` prints nothing under `--energyJ=0`. Consequently
+`##HOLD##` supports statements about AntHocNet's own delay composition, and
+**not** cross-protocol hold comparisons, until the AODV side is measured.
+
 ### Channel occupancy (`##AIR##`, #308 phase 2 step 3)
 
 ```

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -698,6 +698,12 @@ struct Result {
     // #308 phase 2: the same keys carrying hop counts, so the common set can be
     // normalised by path length like-for-like.
     std::map<Address, std::map<uint32_t, uint32_t>> rxHopsBySeq;
+    // #308 phase 2 step 4: pending-queue hold-time attribution, summed over
+    // nodes. `holdValid` is false for every protocol that is not AntHocNet —
+    // see the ##HOLD## emission for why absence, not zero, is the right
+    // representation there.
+    ns3::anthocnet::HoldStats hold;
+    bool holdValid = false;
     // #209 energy:
     // #308 phase 2 step 3: channel occupancy summed over nodes (node-seconds).
     // -1 = not measured (the PHY State trace is only connected when the energy
@@ -1477,6 +1483,30 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             ? (sum * sum) / (static_cast<double>(x.size()) * sumSq) : 0.0;
     }
 
+    // #308 phase 2 step 4: gather the pending-queue hold-time attribution
+    // UNCONDITIONALLY, not just under --diag. It has been measured since #104
+    // but only ever printed inside the --diag line, where it sat outside the
+    // workflow's compact re-emit — so reading it for the phase-2 decomposition
+    // needed a 900-line log tail and still lost three of twenty seeds. The
+    // measurement was never the missing piece; reaching it was.
+    for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+        Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
+        if (!ip) continue;
+        Ptr<ns3::anthocnet::RoutingProtocol> ahn =
+            DynamicCast<ns3::anthocnet::RoutingProtocol>(ip->GetRoutingProtocol());
+        if (!ahn) continue;
+        r.holdValid = true;
+        const ns3::anthocnet::HoldStats& s = ahn->HoldTimeStats();
+        for (uint8_t hr = 0; hr < ns3::anthocnet::kHoldReasons; ++hr) {
+            r.hold.deliveredCount[hr] += s.deliveredCount[hr];
+            r.hold.deliveredSumS[hr] += s.deliveredSumS[hr];
+            if (s.deliveredMaxS[hr] > r.hold.deliveredMaxS[hr])
+                r.hold.deliveredMaxS[hr] = s.deliveredMaxS[hr];
+            r.hold.droppedCount[hr] += s.droppedCount[hr];
+            r.hold.droppedSumS[hr] += s.droppedSumS[hr];
+        }
+    }
+
     // Diagnostics line (prefixed "# " so CSV consumers ignore it). Shows whether
     // routes form (reactive ants sent vs received elsewhere; back-ant arrivals)
     // and when the first packet is delivered.
@@ -1575,7 +1605,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             // packets; this splits the delivered hold time (and the aged-out
             // drops) across the setup / reconvergence / repair hold paths so
             // the dominant one can be attacked. Summed across nodes.
-            ns3::anthocnet::HoldStats hs;
+            const ns3::anthocnet::HoldStats& hs = r.hold;  // gathered above (#308)
             // #215: the repair-discard cause from both sides — the core's
             // simulator-agnostic event count (how many local repairs expired)
             // and the adapter's packet count (how much data each released).
@@ -1589,15 +1619,6 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                 repairEvents += ahn->RepairDiscards();
                 repairPkts += ahn->RepairDiscardedPackets();
                 macReinjected += ahn->MacReinjectedPackets();
-                const ns3::anthocnet::HoldStats& s = ahn->HoldTimeStats();
-                for (uint8_t r = 0; r < ns3::anthocnet::kHoldReasons; ++r) {
-                    hs.deliveredCount[r] += s.deliveredCount[r];
-                    hs.deliveredSumS[r] += s.deliveredSumS[r];
-                    if (s.deliveredMaxS[r] > hs.deliveredMaxS[r])
-                        hs.deliveredMaxS[r] = s.deliveredMaxS[r];
-                    hs.droppedCount[r] += s.droppedCount[r];
-                    hs.droppedSumS[r] += s.droppedSumS[r];
-                }
             }
             static const char* kReasonName[3] = {"setup", "reconv", "repair"};
             std::cout << " hold[";
@@ -1881,6 +1902,27 @@ int main(int argc, char* argv[]) {
             // Reported as a fraction of node-time rather than raw seconds so
             // the number does not silently depend on --nNodes or --time:
             // busyPct is what one node saw the medium occupied, on average.
+            // #308 phase 2 step 4: pending-queue hold time, per run so it pairs
+            // on identical seeds. Emitted ONLY for a protocol that actually has
+            // the instrumentation — i.e. AntHocNet. AODV also queues packets
+            // during route discovery (aodv::RequestQueue) and OLSR/DSDV do not
+            // queue at all, but none of them is measured here, so printing a row
+            // of zeros for them would assert "this protocol never held a packet"
+            // when the truth is "nobody looked". Absence is the honest encoding,
+            // and it is the same rule ##AIR## follows for --energyJ=0.
+            if (r.holdValid) {
+                std::cout << std::fixed << "##HOLD## " << s << ' ' << list[i];
+                for (uint8_t hr = 0; hr < ns3::anthocnet::kHoldReasons; ++hr) {
+                    const double meanMs = r.hold.deliveredCount[hr]
+                        ? 1000.0 * r.hold.deliveredSumS[hr] / r.hold.deliveredCount[hr]
+                        : 0.0;
+                    std::cout << ' ' << r.hold.deliveredCount[hr]
+                              << ' ' << std::setprecision(2) << meanMs
+                              << ' ' << std::setprecision(2)
+                              << 1000.0 * r.hold.deliveredMaxS[hr];
+                }
+                std::cout << "\n";
+            }
             if (r.airTxS >= 0.0) {
                 const double nodeSeconds =
                     static_cast<double>(P.nNodes) * P.simTime;


### PR DESCRIPTION
[Step 4 of #308](https://github.com/danieljoppi/AntHocNet/issues/308#issuecomment-5204997273) produced the closest thing yet to an answer for that epic — hold time contributes **27.61 ± 1.72 ms** per delivered packet against an all-delivered mean-delay gap to AODV of **21.9 ms** — and it needed **no new instrumentation at all**. `HoldStats` has recorded exactly these numbers since #21/#104, and `paper-benchmark.yml` has passed `--diag` since it was written. They had been in every campaign log for months.

They went unused because they were printed only inside the `# diag` line, which the compact re-emit block never carried. Reading them cost a **900-line log tail** and *still lost three of twenty seeds*, because the earliest `anthocnet` diag lines fall outside the reachable tail.

**The measurement was never the missing piece. Reaching it was.**

## What is added

```
##HOLD## <run> <proto> <setupN> <setupMeanMs> <setupMaxMs> \
                       <reconvN> <reconvMeanMs> <reconvMaxMs> \
                       <repairN> <repairMeanMs> <repairMaxMs>
```

Per run, so it pairs on identical seeds and carries a paired CI like every other per-seed row — and re-emitted by `paper-benchmark.yml` **in this commit**.

The gather moves out of the `# diag` block and runs unconditionally, so rows appear with or without `--diag`; the diag line now formats the already-gathered stats instead of walking the nodes a second time.

## Absence is the encoding, and here it carries a real caveat

`##HOLD##` is emitted **only** for a protocol that actually has the instrumentation — in practice AntHocNet. AODV also queues during route discovery (`aodv::RequestQueue`); OLSR/DSDV do not queue at all. **None of them is measured.**

A row of zeros for those arms would assert *"this protocol never held a packet"* when the truth is *"nobody looked"* — and that distinction is exactly what stops step 4's accounting from being a cross-protocol claim today. So the honest representation is no row, the same rule `##AIR##` follows under `--energyJ=0`.

`docs/benchmarks/metrics.md` states the consequence outright: **`##HOLD##` supports statements about AntHocNet's own delay composition and *not* cross-protocol hold comparisons** until the AODV side is measured.

The docs also record the second limit step 4 hit: these are hold **events**, not packets. The pending queue is per node, so a packet crossing several hops can be held more than once — 0.476 events per delivered packet is *either* ~48 % of packets held once *or* fewer packets held repeatedly, and these counters cannot tell those apart.

## Shipping discipline (#229/#230)

`scenario_check.py results` parses `##HOLD##` and FAILs on three **arithmetic impossibilities** rather than thresholds:

| rule | what it catches |
|---|---|
| negative count / mean / max | accounting corruption |
| non-zero mean with **zero** count | a mis-ordered field mapping, seen from outside |
| hold outlasting `QueueTimeout` (5 s ceiling vs the 3 s default) | an accounting error, without policing the attribute |

`test_scenario_check.py` gains four cases — one proving the rules stay **quiet** on the real step-4 readings (`setup 21/428.7ms/max2752.9ms`, `reconv 1677/87.3ms`), three proving each mode **fires**, including that a protocol emitting no `##HOLD##` row skips every rule. **47 cases pass**, ruff clean.

No preflight coherence rule: like `hopsCommon` and `##AIR##`, this depends on no scenario knob whose setting could make it meaningless.

## Verification

No local ns-3 build here, so CI's five-version matrix is the first compile. Python half fully verified locally (47/47 + ruff).

Instrumentation only — no protocol behaviour changes and no existing number moves, so no A/B is required. The three hold-cap ablation arms currently running were dispatched at `e3d2ade` and are unaffected.

Refs #308, #21, #103, #104, #229, #230

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dit6Yi8Tig4J6Vi5cMzYhv)_