### PR TITLE
feat(bench): emit ##CONFIG## so a run records the configuration it ran with

### DIFF
--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -260,6 +260,16 @@ jobs:
           # are different things.
           grep '^##HOLD##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #369: the run's own configuration — scenario knobs plus every
+          # AntHocNet attribute at its effective value, so an --extraArgs sweep
+          # records the lever it pulled. Added in the same commit that emits it,
+          # per the rule above. This marker exists because the alternative
+          # failed: three hold-cap ablation arms (#308) were cancelled before
+          # they produced output, their logs expired, and the cap values they
+          # were dispatched with are unrecoverable — the command echo lives
+          # ~900 lines above the cheap tail and dies with the run.
+          grep '^##CONFIG##' "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
           # the *only* place the #209/#212/#215/#217 metric families appear in a
           # single-point run — the fixed-width table cannot carry them (its field

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -196,6 +196,43 @@ all-delivered basis. What it cannot say is how the split looks on the packets
 both protocols carried, where the delay ratio is 1.44× rather than 1.68×. That
 is the question `hopsCommon` answers.
 
+### Run provenance (`##CONFIG##`, #369)
+
+```
+##CONFIG## scenario=<name> nNodes=.. time=.. runs=.. firstRun=.. areaX=.. \
+           areaY=.. speed=.. pause=.. range=.. propagation=.. flows=.. \
+           cbrBps=.. rateManager=.. protocols=..
+##CONFIG## attr <AttributeName>=<value>          # one line per AntHocNet attribute
+```
+
+Not a metric — the configuration the numbers were produced under, emitted into
+the compact block ahead of every result row.
+
+It exists because the alternative was tried and failed. The effective knobs
+used to live only in the workflow's command echo, which sits roughly 900 lines
+above the reachable log tail and disappears with the run: three hold-cap
+ablation arms ([#308](https://github.com/danieljoppi/AntHocNet/issues/308))
+were cancelled before producing output, their logs expired, and the
+`ReconvHoldCap`/`RepairHoldCap` values they were dispatched with are
+unrecoverable. A run that cannot state its own configuration is not
+reproducible, however many seeds stand behind it.
+
+The `attr` lines report each AntHocNet attribute at its **effective** value.
+ns-3 routes `--ns3::anthocnet::RoutingProtocol::X=Y` through
+`Config::SetDefault`, which rewrites the TypeId's stored initial value, so
+reading it back reports overrides and compiled defaults alike — and a lever
+added by a future sweep is carried automatically, with no change here.
+
+Two limits worth stating:
+
+- **Fields are `key=value`, not positional** — unlike `##RUN##`. A misread
+  position in a provenance row would misattribute an entire campaign, and
+  there is no `# stddev` cross-check to catch it the way there is for the
+  metric columns.
+- **Baseline protocols' attributes are not dumped.** Nothing in this repo
+  sweeps AODV/OLSR/DSDV attributes, so a `--ns3::aodv::…` override would *not*
+  be recorded. If that ever becomes a swept lever, this is the place to extend.
+
 ### Pending-queue hold time (`##HOLD##`, #308 phase 2 step 4)
 
 ```

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -1860,6 +1860,53 @@ int main(int argc, char* argv[]) {
         std::map<Address, std::map<uint32_t, double>> bySeq;  // #308
         std::map<Address, std::map<uint32_t, uint32_t>> hopsBySeq;  // #308 phase 2
     };
+    // #308/#369: record what this invocation actually ran, in the compact
+    // block, before any result row. A benchmark number is only reproducible if
+    // the configuration behind it is recoverable, and until now it was not:
+    // the effective knobs lived solely in the workflow's command echo, which
+    // sits ~900 lines above the cheap tail and vanishes entirely if the run is
+    // cancelled before it finishes. Three hold-cap ablation arms were lost
+    // exactly that way -- cancelled before pickup, logs since expired, and the
+    // `--ns3::...::ReconvHoldCap=` values they were dispatched with are simply
+    // gone. Emitting them here makes the run self-describing.
+    //
+    // Deliberately `key=value` rather than positional fields, unlike ##RUN##:
+    // a mis-read position in a provenance row would misattribute a whole
+    // campaign, and there is no `# stddev` cross-check to catch it the way
+    // there is for the metric columns.
+    std::cout << "##CONFIG## scenario=" << scenario
+              << " nNodes=" << P.nNodes << " time=" << P.simTime
+              << " runs=" << runs << " firstRun=" << firstRun
+              << " areaX=" << P.areaX << " areaY=" << P.areaY
+              << " speed=" << P.speed << " pause=" << P.pause
+              << " range=" << P.range << " propagation=" << P.propagation
+              << " flows=" << P.nFlows << " cbrBps=" << P.cbrBps
+              << " rateManager=" << P.rateManager
+              << " protocols=" << protocols << '\n';
+    // Every AntHocNet attribute at its *effective* value. ns-3 routes
+    // `--ns3::anthocnet::RoutingProtocol::X=Y` through Config::SetDefault,
+    // which rewrites the TypeId's stored initial value -- so reading it back
+    // here reports overrides and compiled defaults alike, and any lever a
+    // future sweep adds is carried without touching this code. Baseline
+    // protocols' attributes are not dumped: nothing in this repo sweeps them,
+    // and the row is provenance for our own knobs.
+    {
+        TypeId tid;
+        if (TypeId::LookupByNameFailSafe("ns3::anthocnet::RoutingProtocol", &tid)) {
+            // std::size_t rather than decltype(GetAttributeN()): the return
+            // type changed from uint32_t to std::size_t across the ns-3
+            // versions in the matrix, and both convert to std::size_t without
+            // a sign-compare warning.
+            const std::size_t nAttr = tid.GetAttributeN();
+            for (std::size_t a = 0; a < nAttr; ++a) {
+                const TypeId::AttributeInformation info = tid.GetAttribute(a);
+                if (!info.initialValue || !info.checker) continue;
+                std::cout << "##CONFIG## attr " << info.name << '='
+                          << info.initialValue->SerializeToString(info.checker)
+                          << '\n';
+            }
+        }
+    }
     std::vector<std::vector<MatchCell>> matchGrid(
         list.size(), std::vector<MatchCell>(runs));
     for (std::size_t i = 0; i < list.size(); ++i) {


### PR DESCRIPTION
Closes #369.

## What went wrong

Three hold-cap ablation arms for [#308](https://github.com/danieljoppi/AntHocNet/issues/308) were dispatched on 2026-08-06 — runs [31127688011](https://github.com/danieljoppi/AntHocNet/actions/runs/31127688011), [31127689553](https://github.com/danieljoppi/AntHocNet/actions/runs/31127689553), [31127691802](https://github.com/danieljoppi/AntHocNet/actions/runs/31127691802). All three were cancelled with `runner_id: 0` — never picked up, no step executed — and their logs now 404.

**The `ReconvHoldCap` / `RepairHoldCap` values they ran with are unrecoverable.** They were re-creatable only because the pre-registration comment happened to record the intended millisecond values. Had it not, the arms would have had to be re-designed rather than re-dispatched.

The effective configuration of a run lived in exactly one place: the workflow's command echo, at the *start* of the "Run paper scenario" step. That is ~900 lines above the end of a 20-seed job — outside the cheap `get_job_logs` tail results are read from — and it vanishes entirely if the run never gets that far.

This is the same shape as the [#367](https://github.com/danieljoppi/AntHocNet/issues/367) `##HOLD##` problem, and the same lesson that commit stated: **emitting a number and being able to reach it are different things.** Here the configuration was never emitted by the harness at all — only by the caller.

The consequence is wider than one lost experiment. Every published cell depends on its configuration being recoverable from its run ID, and for anything set through `extraArgs` that path runs through a log tail that expires. **#365 is about numbers whose *commit* is unstated; this is the same defect one level down, about numbers whose *knobs* are unstated.**

## What is added

```
##CONFIG## scenario=.. nNodes=.. time=.. runs=.. firstRun=.. areaX=.. areaY=.. \
           speed=.. pause=.. range=.. propagation=.. flows=.. cbrBps=.. \
           rateManager=.. protocols=..
##CONFIG## attr <AttributeName>=<value>        # one line per AntHocNet attribute
```

Emitted ahead of every result row, and re-emitted by `paper-benchmark.yml`'s compact block **in this commit**.

The `attr` lines come from `TypeId` introspection, so they report each attribute at its **effective** value: ns-3 routes `--ns3::anthocnet::RoutingProtocol::X=Y` through `Config::SetDefault`, which rewrites the TypeId's stored initial value. An `extraArgs` sweep therefore records the lever it pulled without anyone remembering to log it, and a lever a future sweep adds is carried with **no change here**. `LookupByNameFailSafe` is used so a build without the module linked degrades to emitting no `attr` lines rather than aborting.

## Three deliberate limits, all documented

| limit | why |
|---|---|
| Fields are **`key=value`, not positional** (unlike `##RUN##`) | a misread position in a provenance row misattributes an entire campaign, and there is **no `# stddev` cross-check** to catch it the way there is for the metric columns |
| **Baseline attributes are not dumped** | nothing here sweeps AODV/OLSR/DSDV attributes, so a `--ns3::aodv::…` override would **not** be recorded. Stated in `metrics.md` so the gap is known rather than discovered |
| Marker added to the workflow's re-emit grep **in this commit** | per the rule the `##MATCH##` omission established — emitting it is only half of shipping it |

## `--csv` is unaffected

`run-scenarios.py` keeps only the line starting `protocol,` plus lines whose first comma-token is a protocol name, so the `##CONFIG##` block is dropped downstream rather than corrupting machine-readable output. Checked at `ns3/tools/run-scenarios.py:231-234`.

## Verification

**No local ns-3 build here, so CI's five-version matrix (3.36/3.41/3.42/3.47/3.48) is the first compile of the C++ half.** The API surface used is deliberately conservative — `TypeId::LookupByNameFailSafe`, `GetAttributeN`, `GetAttribute`, `AttributeValue::SerializeToString` — and the loop counter is `decltype(nAttr)` so the `uint32_t` → `std::size_t` return-type change across ns-3 versions cannot produce a sign-compare warning under `-Werror`.

`check-mermaid.py`, `check-links.py` and `check-headers.py` all run clean locally (70 markdown files, 86 source files, 0 problems).

**Instrumentation only** — no protocol behaviour changes and no existing number moves, so no A/B is required. The four #308 ablation arms currently running were dispatched at `f608e71`; they predate this marker and will not carry it.

Refs #308, #367, #365, #128, #319

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_