### PR TITLE
feat(bench): add a mobility-model knob — steady-state RWP and Gauss-Markov

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -199,6 +199,24 @@ def cmd_preflight(a):
         report("WARN", "pause >= sim time — the field is static; that is "
                        "the sparse-static regime (a known AntHocNet weak "
                        "spot), not the paper's mobile one")
+    # #61 mobility-model coherence. Same shape as the #230 pathWindowS rule:
+    # a knob that the selected model ignores costs nothing to check here and,
+    # unchecked, produces a sweep that believes it varied something it did not.
+    if a.mobility == "gaussmarkov" and a.pause != 0:
+        report("FAIL", f"--pause={a.pause}s with --mobility=gaussmarkov: "
+                       "Gauss-Markov nodes never stop, so pause is inert. A "
+                       "pause sweep under this model would produce N identical "
+                       "cells and read as 'pause has no effect' (#61); pass "
+                       "--pause=0 to state that explicitly")
+    if a.mobility == "ssrwp" and a.speed <= 0:
+        report("FAIL", "--mobility=ssrwp needs a positive speed: the "
+                       "steady-state distribution divides by speed and is "
+                       "undefined at zero (#61)")
+    if a.mobility != "rwp":
+        report("WARN", f"--mobility={a.mobility} is not the model the "
+                       "published corpus was measured under (rwp); its "
+                       "anchor floors do not apply and results are not "
+                       "comparable to the published cells (#59, #61)")
     # #230: the diversity window must be short relative to how fast the
     # topology changes, or a route being *replaced* inside one window reads as
     # two concurrent paths and path_div_used stops meaning multipath. Two nodes
@@ -880,6 +898,8 @@ def main():
     p.add_argument("--rateMbps", type=float, default=2)
     # kDefaultPathWindowS in ns3/examples/anthocnet-compare.cc (#217).
     p.add_argument("--pathWindowS", type=float, default=10)
+    p.add_argument("--mobility", choices=("rwp", "ssrwp", "gaussmarkov"),
+                   default="rwp")
     r = sub.add_parser("results")
     r.add_argument("files", nargs="+")
     r.add_argument("--anchor", choices=sorted(ANCHOR_KEY))

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -114,7 +114,7 @@ def run_preflight(**overrides):
     kw = {"nodes": 50, "areaX": 1500.0, "areaY": 300.0, "range": 300.0,
           "time": 300.0, "pause": 30.0, "speed": 20.0, "flows": 20,
           "pktBytes": 64, "pktPerSec": 1.0, "rateMbps": 2.0,
-          "pathWindowS": 10.0}
+          "pathWindowS": 10.0, "mobility": "rwp"}
     kw.update(overrides)
     sc.issues = []
     with contextlib.redirect_stdout(io.StringIO()) as out:
@@ -287,6 +287,53 @@ def _absent_columns():
     levels, out = run_results(**blank)
     expect(levels == [], "absent-columns",
            f"a rule fired on a pre-instrumentation row\n{out}")
+
+
+# --- #61 mobility-model preflight --------------------------------------------
+
+@case("#61 preflight FAILs pause>0 under gaussmarkov (inert knob)")
+def _mobility_pause_fires():
+    levels, out = run_preflight(mobility="gaussmarkov", pathWindowS=2.0)
+    expect("FAIL" in levels, "mobility-pause-fires",
+           f"pause=30 under gaussmarkov did not FAIL\n{out}")
+    expect("inert" in out, "mobility-pause-fires", out)
+
+
+@case("#61 preflight stays quiet on pause=0 under gaussmarkov")
+def _mobility_pause_quiet():
+    # The knob is stated explicitly, so the coherence rule has nothing to say.
+    # A WARN about non-rwp comparability is expected and correct here; what
+    # must not happen is a FAIL.
+    levels, out = run_preflight(mobility="gaussmarkov", pause=0.0,
+                                pathWindowS=2.0)
+    expect("FAIL" not in levels, "mobility-pause-quiet",
+           f"pause=0 under gaussmarkov should not FAIL\n{out}")
+
+
+@case("#61 preflight FAILs ssrwp at zero speed")
+def _mobility_ssrwp_fires():
+    levels, out = run_preflight(mobility="ssrwp", speed=0.0, pathWindowS=2.0)
+    expect("FAIL" in levels, "mobility-ssrwp-fires",
+           f"ssrwp at speed=0 did not FAIL\n{out}")
+    expect("undefined at zero" in out, "mobility-ssrwp-fires", out)
+
+
+@case("#61 preflight WARNs that a non-rwp model leaves the published corpus")
+def _mobility_corpus_warn():
+    levels, out = run_preflight(mobility="ssrwp", pathWindowS=2.0)
+    expect("WARN" in levels, "mobility-corpus-warn",
+           f"a non-rwp model did not WARN about comparability\n{out}")
+    expect("published corpus" in out, "mobility-corpus-warn", out)
+
+
+@case("#61 preflight says nothing about mobility on the default rwp")
+def _mobility_default_silent():
+    # The must-not-fire half: the model every published number was measured
+    # under must not acquire a new warning, or the gate cries wolf on the
+    # scenario it is most often run against.
+    _, out = run_preflight(pathWindowS=2.0)
+    expect("published corpus" not in out, "mobility-default-silent", out)
+    expect("inert" not in out, "mobility-default-silent", out)
 
 
 # --- #230 preflight ----------------------------------------------------------

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -37,6 +37,9 @@ on:
       propagation:
         description: 'Propagation model: range (disk) | tworay (#24)'
         default: 'range'
+      mobility:
+        description: 'Mobility model (#61): rwp (Random Waypoint — the model every published number was measured under) | ssrwp (steady-state RWP, no speed-decay transient) | gaussmarkov (smooth correlated tracks; pause is inert under it, so pass pause=0)'
+        default: 'rwp'
       range:
         description: 'Transmission range (m) for the disk model (#24 disentangler)'
         default: '300'
@@ -132,7 +135,11 @@ jobs:
             # #24 control: stock ns-3 baselines only, no AntHocNet in the binary.
             cmd="manet-baselines $common --protocols=aodv,olsr,dsdv"
           else
-            cmd="anthocnet-compare $common --diag --protocols=${{ github.event.inputs.protocols }}"
+            # --mobility is deliberately NOT in $common: manet-baselines has no
+            # such option (#61), and ns-3's CommandLine treats an unknown
+            # argument as fatal — it would kill the #24 baselines control arm
+            # instantly, which is the #28 empty-table failure mode.
+            cmd="anthocnet-compare $common --diag --mobility=${{ github.event.inputs.mobility }} --protocols=${{ github.event.inputs.protocols }}"
           fi
           echo "$cmd"
           # #28 hardening: stderr used to be discarded wholesale and the

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -152,6 +152,38 @@ PDR / mean+99th-percentile delay / NRL vs. the swept parameter:
 Unlike the paper (AODV only), every baseline (AODV/OLSR/DSDV) is run on identical
 realisations, so the classification covers all of them.
 
+## Mobility models (`--mobility`, [#61](https://github.com/danieljoppi/AntHocNet/issues/61))
+
+`anthocnet-compare` takes `--mobility=rwp|ssrwp|gaussmarkov`. `paper-benchmark.yml`
+exposes it as a dispatch input.
+
+| value | model | why it exists |
+|---|---|---|
+| **`rwp`** (default) | `RandomWaypointMobilityModel` | The original evaluation's model, and **the model every published number in this repo was measured under.** The default does not change. |
+| `ssrwp` | `SteadyStateRandomWaypointMobilityModel` | Draws initial speed and position from RWP's *stationary* distribution, removing the speed-decay and density transients that make long RWP runs slower than their nominal speed (Yoon et al., INFOCOM 2003). The closest honest comparison to `rwp`. |
+| `gaussmarkov` | `GaussMarkovMobilityModel` (α = 0.85) | Temporally correlated velocity/direction, so tracks are smooth rather than sharp waypoint turns. The qualitatively different model, and the one aerial/FANET claims require. |
+
+Three things worth knowing before dispatching a non-default arm:
+
+- **`--pause` is inert under `gaussmarkov`** — a Gauss-Markov node never stops.
+  `scenario_check.py preflight` **FAILs** the combination rather than letting a
+  pause sweep produce N identical cells and read as "pause has no effect".
+  Pass `--pause=0` to state it explicitly.
+- **A non-`rwp` arm leaves the published corpus.** Preflight WARNs, because the
+  [validation anchors](#validation-anchors-known-expected-results) are
+  RWP-specific (the Broch floor especially) and the results are not comparable
+  to the published cells. New arms need their own anchor entry or a documented
+  reason there isn't one.
+- **The `manet-baselines` control harness has no `--mobility`** and is RWP-only.
+  The flag is passed to `anthocnet-compare` alone; ns-3 treats an unknown
+  command-line argument as fatal, so adding it to the shared argument string
+  would kill the [#24](https://github.com/danieljoppi/AntHocNet/issues/24)
+  baselines arm outright.
+
+`gaussmarkov` is deliberately two-dimensional — the bounding box has zero
+z extent and pitch is fixed at 0 — so nodes stay in the plane the propagation
+models and the field geometry assume.
+
 ## Statistical policy ([#293](https://github.com/danieljoppi/AntHocNet/issues/293))
 
 Every number published in these pages or in the papers repo carries a **95%

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -665,6 +665,10 @@ struct Params {
     // #217: window over which "distinct next hops used for a destination" is
     // counted (s). See the path-diversity block above main().
     double   pathWindowS;
+    // #61: mobility model. "rwp" (Random Waypoint, the default and the model
+    // every published number was measured under) | "ssrwp" (steady-state RWP,
+    // no speed-decay transient) | "gaussmarkov" (smooth correlated tracks).
+    std::string mobility;
 };
 
 struct Result {
@@ -887,10 +891,65 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     std::ostringstream speedStr, pauseStr;
     speedStr << "ns3::UniformRandomVariable[Min=1.0|Max=" << P.speed << "]";
     pauseStr << "ns3::ConstantRandomVariable[Constant=" << P.pause << "]";
-    mobility.SetMobilityModel("ns3::RandomWaypointMobilityModel",
-                              "Speed", StringValue(speedStr.str()),
-                              "Pause", StringValue(pauseStr.str()),
-                              "PositionAllocator", PointerValue(pos));
+    // #61: mobility model selection. `rwp` is the default and is left exactly
+    // as it was — every published number was measured under it, and the
+    // steady-state/Gauss-Markov arms are additions, not replacements.
+    if (P.mobility == "ssrwp") {
+        // Steady-state RWP (Navidi & Camp): initial speed/position are drawn
+        // from RWP's *stationary* distribution, so the run starts where plain
+        // RWP only arrives asymptotically. This removes the speed-decay
+        // transient that makes long RWP runs slower than their nominal speed
+        // (Yoon et al., INFOCOM 2003) and the matching density transient.
+        //
+        // It takes its own field bounds instead of a PositionAllocator: the
+        // stationary position distribution is not uniform, so it must place
+        // nodes itself. MinSpeed must be > 0 — the stationary distribution
+        // divides by speed — which the 1.0 m/s floor above already satisfies.
+        mobility.SetMobilityModel("ns3::SteadyStateRandomWaypointMobilityModel",
+                                  "MinSpeed", DoubleValue(1.0),
+                                  "MaxSpeed", DoubleValue(P.speed),
+                                  "MinPause", DoubleValue(P.pause),
+                                  "MaxPause", DoubleValue(P.pause),
+                                  "MinX", DoubleValue(0.0),
+                                  "MaxX", DoubleValue(P.areaX),
+                                  "MinY", DoubleValue(0.0),
+                                  "MaxY", DoubleValue(P.areaY));
+    } else if (P.mobility == "gaussmarkov") {
+        // Gauss-Markov: velocity and direction are temporally correlated
+        // (alpha = 0.85), so tracks are smooth rather than the sharp
+        // waypoint-to-waypoint turns of RWP. This is the qualitatively
+        // different model #295 asks for, and the one aerial/FANET claims
+        // require.
+        //
+        // Two-dimensional on purpose: the Box's z extent is zero and the pitch
+        // is fixed at 0, so nodes stay in the plane the propagation models and
+        // the 2-D field geometry assume.
+        //
+        // There is no pause concept here -- a Gauss-Markov node never stops.
+        // `--pause` is therefore inert under this model, which is why
+        // scenario_check.py's preflight refuses the combination rather than
+        // letting a sweep believe it varied something.
+        mobility.SetMobilityModel(
+            "ns3::GaussMarkovMobilityModel",
+            "Bounds", BoxValue(Box(0.0, P.areaX, 0.0, P.areaY, 0.0, 0.0)),
+            "TimeStep", TimeValue(Seconds(1.0)),
+            "Alpha", DoubleValue(0.85),
+            "MeanVelocity", StringValue(speedStr.str()),
+            "MeanDirection",
+            StringValue("ns3::UniformRandomVariable[Min=0.0|Max=6.283185307]"),
+            "MeanPitch", StringValue("ns3::ConstantRandomVariable[Constant=0.0]"),
+            "NormalVelocity",
+            StringValue("ns3::NormalRandomVariable[Mean=0.0|Variance=1.0|Bound=1.0]"),
+            "NormalDirection",
+            StringValue("ns3::NormalRandomVariable[Mean=0.0|Variance=0.2|Bound=0.4]"),
+            "NormalPitch",
+            StringValue("ns3::ConstantRandomVariable[Constant=0.0]"));
+    } else {
+        mobility.SetMobilityModel("ns3::RandomWaypointMobilityModel",
+                                  "Speed", StringValue(speedStr.str()),
+                                  "Pause", StringValue(pauseStr.str()),
+                                  "PositionAllocator", PointerValue(pos));
+    }
     // #352: the initial positions are drawn during Install(), so the allocator
     // has to be pinned BEFORE it — MobilityHelper::AssignStreams can only reach
     // the models (and, through RandomWaypoint, the allocator's later waypoint
@@ -1708,7 +1767,14 @@ int main(int argc, char* argv[]) {
     cmd.AddValue("qdiag", "Emit per-run '# qdiag' lines: per-node MAC queue depth "
                           "distribution (meanQ/maxQ/pctNonzero) — does A2 have a "
                           "signal? (#73)", g_qdiag);
+    std::string mobilityModel = "rwp";
     std::string propagation = "range";
+    cmd.AddValue("mobility",
+                 "Mobility model (#61): 'rwp' (Random Waypoint, default — the "
+                 "model every published number was measured under) | 'ssrwp' "
+                 "(steady-state RWP, no speed-decay transient) | 'gaussmarkov' "
+                 "(smooth correlated tracks; --pause is inert under it)",
+                 mobilityModel);
     cmd.AddValue("propagation", "Propagation loss model: 'range' (disk) or 'tworay'", propagation);
     std::string rateManager = "constant2";
     cmd.AddValue("rateManager",
@@ -1794,6 +1860,14 @@ int main(int argc, char* argv[]) {
     P.cbrBps  = cbrBps >= 0 ? cbrBps : (thesis ? 2048.0 : paper ? 512.0 : 8000.0);
     P.startWindow = paper ? 180.0 : 5.0;
     P.propagation = propagation;
+    P.mobility = mobilityModel;
+    NS_ABORT_MSG_UNLESS(mobilityModel == "rwp" || mobilityModel == "ssrwp" ||
+                            mobilityModel == "gaussmarkov",
+                        "unknown --mobility='" << mobilityModel
+                        << "' (expected rwp|ssrwp|gaussmarkov). Refusing rather "
+                           "than silently falling back to rwp: a typo would "
+                           "otherwise produce a plausible run of the wrong "
+                           "model (#61).");
     P.rateManager = rateManager;
     P.sink = sink;
     P.energyJ = energyJ;
@@ -1880,6 +1954,7 @@ int main(int argc, char* argv[]) {
               << " areaX=" << P.areaX << " areaY=" << P.areaY
               << " speed=" << P.speed << " pause=" << P.pause
               << " range=" << P.range << " propagation=" << P.propagation
+              << " mobility=" << P.mobility
               << " flows=" << P.nFlows << " cbrBps=" << P.cbrBps
               << " rateManager=" << P.rateManager
               << " protocols=" << protocols << '\n';


### PR DESCRIPTION
Unblocks half of v1.4.0's headline exit criterion. Refs #61, part of #295.

## Why this was blocking, and it was not cost

v1.4.0 requires a grid under *"≥2 mobility models × ≥2 channel models"*. The channel axis has existed since #24 (`--propagation=range|tworay`). The mobility axis had **no knob at all** — `anthocnet-compare.cc:890` hardcoded `ns3::RandomWaypointMobilityModel`, and `--speed`/`--pause` parameterise RWP rather than selecting a model.

So the criterion was not merely unfunded after #121 closed; it was **undispatchable**. This adds the axis.

## `--mobility=rwp|ssrwp|gaussmarkov`

| value | model | why |
|---|---|---|
| **`rwp`** (default) | `RandomWaypointMobilityModel` | Left **byte-for-byte as it was**, stream assignment included. Every published number was measured under it and must keep reproducing. |
| `ssrwp` | `SteadyStateRandomWaypointMobilityModel` | Initial speed and position drawn from RWP's *stationary* distribution, removing the speed-decay transient that makes long RWP runs slower than their nominal speed (Yoon et al., INFOCOM 2003). Takes field bounds rather than a `PositionAllocator`, because the stationary position distribution is not uniform — it must place nodes itself. `MinSpeed` must exceed zero (the distribution divides by speed); the existing 1.0 m/s floor already satisfies that. |
| `gaussmarkov` | `GaussMarkovMobilityModel`, α = 0.85 | Temporally correlated velocity and direction — smooth tracks rather than sharp waypoint turns. The **qualitatively different** model #295 asks for. Deliberately 2-D: zero-z bounding box and pitch fixed at 0, so nodes stay in the plane the propagation models and field geometry assume. |

An unrecognised value **aborts**. A silent fallback to `rwp` would produce a plausible run of the wrong model — the failure this axis is least able to detect after the fact.

## Preflight learns the knob in the same commit (#230 rule)

| rule | catches |
|---|---|
| `pause > 0` with `gaussmarkov` → **FAIL** | Gauss-Markov nodes never stop, so `pause` is inert. A pause sweep under it would produce N identical cells and read as *"pause has no effect"* rather than as a misconfiguration. |
| `ssrwp` at `speed ≤ 0` → **FAIL** | stationary distribution undefined at zero |
| any non-`rwp` model → **WARN** | it leaves the published corpus: the validation anchors are RWP-specific (the Broch floor especially), so results are not comparable to published cells and need their own anchor entry or a documented reason there is none (#59) |

`test_scenario_check.py` gains **five** cases — every rule with a must-fire *and* a must-not-fire, including one asserting the default `rwp` path acquires **no** new warning, so the gate does not cry wolf on the scenario it is run against most. **52 cases pass.**

## One trap worth calling out

`paper-benchmark.yml` gets a `mobility` dispatch input, but it is passed to `anthocnet-compare` **only** — deliberately *not* through the shared `$common` argument string.

`manet-baselines` has no `--mobility` option, and ns-3's `CommandLine` treats an unknown argument as **fatal**. Putting it in `$common` would kill the #24 baselines control arm outright and produce exactly the #28 empty-results-table failure that hardening exists to catch. I hit this while writing the workflow change and reverted it; the comment in the YAML records why.

The knob also lands in the `##CONFIG##` provenance block (#369), so a mobility arm records which model produced it without depending on the command echo.

## Verification

**No local ns-3 build, so CI's five-version matrix is the first compile of the C++ half** — the attribute names for both new models (`MinSpeed`/`MaxSpeed`/`MinPause`/`MaxPause`/`MinX`…, and `Bounds`/`TimeStep`/`Alpha`/`MeanVelocity`/`NormalDirection`…) are the risk surface.

Python half fully verified locally: **52/52** `test_scenario_check.py`. `check-mermaid.py`, `check-links.py`, `check-headers.py` all clean (70 markdown, 86 source files).

`rwp` is untouched, so **no existing number moves and no A/B is required**; the new arms have no published numbers yet by construction.

## Still open on #61

Taxonomy classification of mobility rows in `run-scenarios.py`, and trace ingestion via `Ns2MobilityHelper` (BonnMotion / SUMO). The v1.4.0 grid dispatches per point through `paper-benchmark.yml` and needs neither, so I have left #61 open rather than closing it on a partial.

Refs #61, #295, #24, #28, #230, #369, #59

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_