### PR TITLE
feat(bench): add a Nakagami fading channel — the other half of the v1.4.0 grid

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -212,6 +212,25 @@ def cmd_preflight(a):
         report("FAIL", "--mobility=ssrwp needs a positive speed: the "
                        "steady-state distribution divides by speed and is "
                        "undefined at zero (#61)")
+    # #60 channel-model coherence. The degree/connectivity arithmetic above is
+    # a *disk-model* calculation: it treats `range` as a hard link cutoff. Under
+    # tworay and nakagami there is no cutoff — links are governed by tx power
+    # vs receiver sensitivity, and under nakagami by a random draw on top of
+    # that — so `range` bounds nothing and the estimate is indicative only.
+    # Pre-existing for tworay; stated now rather than left for the fading arm
+    # to discover.
+    if a.propagation != "range":
+        report("WARN", f"--propagation={a.propagation}: --range is inert (no "
+                       "hard cutoff), so the node-degree and connectivity "
+                       "figures above are a disk-model estimate and do not "
+                       "bound this channel's links (#24, #60)")
+    if a.propagation == "nakagami":
+        report("WARN", "nakagami is the harness's first stochastic channel: "
+                       "link existence is a random draw, so per-seed "
+                       "dispersion is higher than on the deterministic "
+                       "channels and the #293 runs floor should be treated as "
+                       "a minimum, not a target — check the interval widths "
+                       "before quoting a tail metric (#60)")
     if a.mobility != "rwp":
         report("WARN", f"--mobility={a.mobility} is not the model the "
                        "published corpus was measured under (rwp); its "
@@ -900,6 +919,8 @@ def main():
     p.add_argument("--pathWindowS", type=float, default=10)
     p.add_argument("--mobility", choices=("rwp", "ssrwp", "gaussmarkov"),
                    default="rwp")
+    p.add_argument("--propagation", choices=("range", "tworay", "nakagami"),
+                   default="range")
     r = sub.add_parser("results")
     r.add_argument("files", nargs="+")
     r.add_argument("--anchor", choices=sorted(ANCHOR_KEY))

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -114,7 +114,7 @@ def run_preflight(**overrides):
     kw = {"nodes": 50, "areaX": 1500.0, "areaY": 300.0, "range": 300.0,
           "time": 300.0, "pause": 30.0, "speed": 20.0, "flows": 20,
           "pktBytes": 64, "pktPerSec": 1.0, "rateMbps": 2.0,
-          "pathWindowS": 10.0, "mobility": "rwp"}
+          "pathWindowS": 10.0, "mobility": "rwp", "propagation": "range"}
     kw.update(overrides)
     sc.issues = []
     with contextlib.redirect_stdout(io.StringIO()) as out:
@@ -334,6 +334,33 @@ def _mobility_default_silent():
     _, out = run_preflight(pathWindowS=2.0)
     expect("published corpus" not in out, "mobility-default-silent", out)
     expect("inert" not in out, "mobility-default-silent", out)
+
+
+# --- #60 channel-model preflight ---------------------------------------------
+
+@case("#60 preflight WARNs that --range is inert off the disk model")
+def _channel_range_inert_fires():
+    levels, out = run_preflight(propagation="tworay", pathWindowS=2.0)
+    expect("WARN" in levels, "channel-range-inert-fires",
+           f"tworay did not WARN that range is inert\n{out}")
+    expect("inert" in out, "channel-range-inert-fires", out)
+
+
+@case("#60 preflight WARNs that nakagami is stochastic")
+def _channel_nakagami_fires():
+    levels, out = run_preflight(propagation="nakagami", pathWindowS=2.0)
+    expect("WARN" in levels, "channel-nakagami-fires",
+           f"nakagami did not WARN about dispersion\n{out}")
+    expect("stochastic channel" in out, "channel-nakagami-fires", out)
+
+
+@case("#60 preflight says nothing about the channel on the disk default")
+def _channel_default_silent():
+    # Must-not-fire half: the disk model is what the published corpus used and
+    # what most dispatches pass, so it must not acquire a new warning.
+    _, out = run_preflight(pathWindowS=2.0)
+    expect("inert" not in out, "channel-default-silent", out)
+    expect("stochastic channel" not in out, "channel-default-silent", out)
 
 
 # --- #230 preflight ----------------------------------------------------------

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -35,7 +35,7 @@ on:
         description: 'Comma-separated protocol list'
         default: 'anthocnet,aodv,olsr,dsdv'
       propagation:
-        description: 'Propagation model: range (disk) | tworay (#24)'
+        description: 'Propagation model: range (disk) | tworay (#24) | nakagami (#60 — the same two-ray path loss plus Nakagami-m fading, so tworay-vs-nakagami isolates fading alone). range is inert under the latter two.'
         default: 'range'
       mobility:
         description: 'Mobility model (#61): rwp (Random Waypoint — the model every published number was measured under) | ssrwp (steady-state RWP, no speed-decay transient) | gaussmarkov (smooth correlated tracks; pause is inert under it, so pass pause=0)'

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -184,6 +184,41 @@ Three things worth knowing before dispatching a non-default arm:
 z extent and pitch is fixed at 0 — so nodes stay in the plane the propagation
 models and the field geometry assume.
 
+## Channel models (`--propagation`, [#24](https://github.com/danieljoppi/AntHocNet/issues/24) / [#60](https://github.com/danieljoppi/AntHocNet/issues/60))
+
+| value | model | why |
+|---|---|---|
+| **`range`** (default) | `RangePropagationLossModel` | A hard disk cutoff at `--range`. Reproducible connectivity independent of tx-power/sensitivity defaults — the #24 calibration disentangler. **The model the published corpus was measured under.** |
+| `tworay` | `TwoRayGroundPropagationLossModel` | The original evaluation's model: Friis below the crossover distance, 1/d⁴ beyond, so capture and edge losses vary with distance. |
+| `nakagami` | two-ray **+** `NakagamiPropagationLossModel` | The fading arm. Nakagami models only the fading envelope, so it is stacked on a distance-dependent model. |
+
+**`nakagami` deliberately reuses `tworay`'s exact path loss** (same `Frequency`,
+same `HeightAboveZ`), so the pair `{tworay, nakagami}` is a **controlled
+contrast isolating fading alone** rather than two unrelated channels. A
+channel-sensitivity axis built from two models that differ in several ways at
+once cannot attribute what it finds.
+
+The Nakagami *m*-profile is left at ns-3's defaults (`Distance1` 80 m,
+`Distance2` 200 m, `m0` 1.5, `m1` 0.75, `m2` 0.75) — near-Rician close in,
+Rayleigh-like further out. Not tuned: an unsourced *m*-profile would be exactly
+the kind of invented constant [#88](https://github.com/danieljoppi/AntHocNet/issues/88)
+and [#173](https://github.com/danieljoppi/AntHocNet/issues/173) were.
+
+Two consequences the preflight now states at dispatch time rather than leaving
+to be discovered:
+
+- **`--range` is inert under `tworay` and `nakagami`.** There is no hard
+  cutoff; link existence is governed by tx power against receiver sensitivity.
+  The preflight's node-degree and connectivity arithmetic is a *disk-model*
+  calculation and is indicative only on these channels.
+- **`nakagami` is the harness's first stochastic channel.** Link existence
+  includes a random draw, so per-seed dispersion is higher than on the
+  deterministic channels and the [runs floor](#runs-floor) should be treated as
+  a minimum rather than a target — check interval widths before quoting a tail
+  metric. Its RNG draws are pinned per seed by the existing channel
+  `AssignStreams` call, so runs stay reproducible
+  ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)).
+
 ## Statistical policy ([#293](https://github.com/danieljoppi/AntHocNet/issues/293))
 
 Every number published in these pages or in the papers repo carries a **95%

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -821,6 +821,33 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         channel.AddPropagationLoss("ns3::TwoRayGroundPropagationLossModel",
                                    "Frequency", DoubleValue(2.4e9),
                                    "HeightAboveZ", DoubleValue(1.5));
+    } else if (P.propagation == "nakagami") {
+        // #60: the fading arm. Two-ray path loss with Nakagami-m fast fading
+        // stacked on top -- YansWifiChannelHelper chains loss models, and
+        // Nakagami models *only* the fading envelope, so it needs a
+        // distance-dependent model underneath it or there is no path loss at
+        // all.
+        //
+        // Deliberately the same two-ray path loss as the `tworay` arm, with
+        // identical Frequency/HeightAboveZ. That makes {tworay, nakagami} a
+        // controlled contrast isolating fading alone, rather than two
+        // unrelated channels -- which is what a channel-sensitivity axis
+        // actually needs to say anything.
+        //
+        // ns-3's defaults (Distance1 80 m, Distance2 200 m, m0 1.5, m1 0.75,
+        // m2 0.75) are the ns-2 model's: near-Rician close in, Rayleigh-ish
+        // (m < 1) further out. Left at the defaults on purpose -- an
+        // unsourced m-profile is exactly the kind of invented constant #88 and
+        // #173 were.
+        //
+        // This is the first *stochastic* channel in the harness. Its RNG draws
+        // are pinned by the existing channel.AssignStreams call below, which
+        // was written for precisely this case.
+        channel.SetPropagationDelay("ns3::ConstantSpeedPropagationDelayModel");
+        channel.AddPropagationLoss("ns3::TwoRayGroundPropagationLossModel",
+                                   "Frequency", DoubleValue(2.4e9),
+                                   "HeightAboveZ", DoubleValue(1.5));
+        channel.AddPropagationLoss("ns3::NakagamiPropagationLossModel");
     } else if (P.range > 0.0) {
         // A clean disk model at the paper's transmission range (reproducible
         // connectivity, independent of tx-power/sensitivity defaults).
@@ -1775,7 +1802,12 @@ int main(int argc, char* argv[]) {
                  "(steady-state RWP, no speed-decay transient) | 'gaussmarkov' "
                  "(smooth correlated tracks; --pause is inert under it)",
                  mobilityModel);
-    cmd.AddValue("propagation", "Propagation loss model: 'range' (disk) or 'tworay'", propagation);
+    cmd.AddValue("propagation",
+                 "Propagation loss model: 'range' (disk) | 'tworay' (#24) | "
+                 "'nakagami' (#60: the same two-ray path loss plus Nakagami-m "
+                 "fading, so tworay-vs-nakagami isolates fading alone). "
+                 "--range is inert under tworay and nakagami.",
+                 propagation);
     std::string rateManager = "constant2";
     cmd.AddValue("rateManager",
                  "Rate control: constant1|constant2|constant5|constant11 (fixed "
@@ -1859,7 +1891,18 @@ int main(int argc, char* argv[]) {
     P.nFlows  = nFlows > 0 ? static_cast<uint32_t>(nFlows) : (paper ? 20 : 5);
     P.cbrBps  = cbrBps >= 0 ? cbrBps : (thesis ? 2048.0 : paper ? 512.0 : 8000.0);
     P.startWindow = paper ? 180.0 : 5.0;
+    // An explicitly empty --propagation= has always meant "the default", and
+    // scenario-matrix.yml documents its blank input that way; normalise it
+    // rather than letting the guard below reject a working dispatch.
+    if (propagation.empty()) propagation = "range";
     P.propagation = propagation;
+    NS_ABORT_MSG_UNLESS(propagation == "range" || propagation == "tworay" ||
+                            propagation == "nakagami",
+                        "unknown --propagation='" << propagation
+                        << "' (expected range|tworay|nakagami). Refusing rather "
+                           "than falling through to a default channel: the "
+                           "silent fallback would produce a plausible run of "
+                           "the wrong channel (#60).");
     P.mobility = mobilityModel;
     NS_ABORT_MSG_UNLESS(mobilityModel == "rwp" || mobilityModel == "ssrwp" ||
                             mobilityModel == "gaussmarkov",


### PR DESCRIPTION
Closes the channel half of v1.4.0's grid criterion. Refs #60, part of #295.

#373 gave the grid its mobility axis. This gives it a channel axis that means something.

## Why `{range, tworay}` was not really two channel models

v1.4.0 asks for *"≥2 channel models"*, and literally that was already satisfiable. But `range` is a **hard disk cutoff** — a propagation abstraction with no fading, no shadowing, no distance-dependent loss curve. Counting it as one of the two satisfies the criterion's letter while leaving #295's stated motivation untouched: *"log-distance/disk-only channels draw the same critique"* that RWP-only mobility does. I argued this [on #295](https://github.com/danieljoppi/AntHocNet/issues/295#issuecomment-5210651391) and this PR is the consequence.

## `--propagation=nakagami`

`NakagamiPropagationLossModel` stacked on the two-ray path loss. Nakagami models **only the fading envelope**, so it needs a distance-dependent model underneath it or there is no path loss at all; `YansWifiChannelHelper` chains loss models, which is what makes the composition work.

**The choice of what to stack it on is the point.** It reuses `tworay`'s *exact* path loss — same `Frequency`, same `HeightAboveZ` — so `{tworay, nakagami}` is a **controlled contrast isolating fading alone**, not two unrelated channels. A sensitivity axis whose two arms differ in several ways at once cannot attribute what it finds.

The *m*-profile stays at ns-3's defaults (`Distance1` 80 m, `Distance2` 200 m, `m0` 1.5, `m1` 0.75, `m2` 0.75) — near-Rician close in, Rayleigh-like further out. Deliberately **not** tuned: an unsourced *m*-profile is exactly the class of invented constant #88 and #173 turned out to be.

## It needed no new RNG plumbing, and that is not luck

This is the harness's first **stochastic** channel. The existing `channel.AssignStreams` call already covers it — and was written for this case, saying so in its comment:

> *"the propagation models configured above are all deterministic, so the channel normally reports 0 streams — pinned anyway so swapping in a fading model (Nakagami, …) cannot reintroduce the position dependence."*

So runs stay reproducible per seed under #352 without touching the stream budget.

## Two guard details

- An unrecognised `--propagation` now **aborts** rather than falling through to the disk branch — same reasoning as `--mobility` in #373: a silent fallback produces a plausible run of the wrong channel.
- An explicitly **empty** `--propagation=` is normalised to `range` *before* that guard, because `scenario-matrix.yml` documents its blank input as meaning the default and that dispatch must keep working. Without the normalisation this PR would have broken every blank-propagation matrix run.

## Preflight learns the axis

| rule | why |
|---|---|
| any non-`range` model → **WARN** that `--range` is inert | there is no hard cutoff, so the node-degree and connectivity arithmetic above it is a *disk-model* estimate that does not bound this channel's links. Pre-existing for `tworay`; stated now rather than left for the fading arm to discover. |
| `nakagami` → **WARN** that it is stochastic | link existence includes a random draw, so per-seed dispersion is higher than on the deterministic channels and the #293 runs floor is a **minimum, not a target** — check interval widths before quoting a tail metric |

Three test cases including the must-not-fire half asserting the disk default acquires no new warning. **55 pass**, ruff clean.

## Verification

**No local ns-3 build, so CI's five-version matrix is the first compile.** `range` and `tworay` are untouched, so no existing number moves and no A/B is required; the fading arm has no published numbers yet by construction.

`check-mermaid.py`, `check-links.py`, `check-headers.py` clean; `ruff` clean (run from the repo root, per the lesson on #373).

## What this unlocks

With #373, the grid is now dispatchable as `{rwp, ssrwp, gaussmarkov} × {tworay, nakagami}` at 20 seeds — six cells, each fitting the 6 h ceiling, all parallel, zero dollars. The remaining v1.4.0 gap is the TCP arm (#63), for which I posted a [design note](https://github.com/danieljoppi/AntHocNet/issues/63#issuecomment-5212330646) rather than an implementation, because it changes what four published metrics mean and cannot be validated without a run.

Refs #60, #295, #24, #352, #293, #88, #173, #373

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_