### PR TITLE
fix(bench): gauss-markov aborted on NormalPitch — a constant where ns-3 demands a normal

### DIFF
--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -969,8 +969,16 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             StringValue("ns3::NormalRandomVariable[Mean=0.0|Variance=1.0|Bound=1.0]"),
             "NormalDirection",
             StringValue("ns3::NormalRandomVariable[Mean=0.0|Variance=0.2|Bound=0.4]"),
+            // Zero-variance *Normal*, not a ConstantRandomVariable: ns-3 types
+            // the three Normal* attributes with
+            // MakePointerChecker<NormalRandomVariable>, so a constant is
+            // rejected outright ("Invalid value for attribute set
+            // (NormalPitch)", SIGABRT). MeanPitch above takes the plain
+            // RandomVariableStream checker and does accept a constant, which
+            // is why only this one tripped. Variance 0 keeps the pitch pinned
+            // at 0 and the model two-dimensional.
             "NormalPitch",
-            StringValue("ns3::ConstantRandomVariable[Constant=0.0]"));
+            StringValue("ns3::NormalRandomVariable[Mean=0.0|Variance=0.0|Bound=0.0]"));
     } else {
         mobility.SetMobilityModel("ns3::RandomWaypointMobilityModel",
                                   "Speed", StringValue(speedStr.str()),


### PR DESCRIPTION
Found by the first-ever execution of `--mobility=gaussmarkov` — a `runs=2`/`time=300` probe ([run 31238324844](https://github.com/danieljoppi/AntHocNet/actions/runs/31238324844)), dispatched before the v1.4.0 grid precisely to check the new arms run at all.

## The failure

```
msg="Invalid value for attribute set (NormalPitch) on ns3::GaussMarkovMobilityModel",
   file=/opt/ns-3/src/core/model/object-factory.cc, line=79
NS_FATAL, terminating
... died with <Signals.SIGABRT: 6>
```

ns-3 types `GaussMarkovMobilityModel`'s three `Normal*` attributes with `MakePointerChecker<NormalRandomVariable>` — they reject anything that is not a `NormalRandomVariable`. #373 set `NormalPitch` to a `ConstantRandomVariable` to pin pitch at zero and keep the model two-dimensional; the checker refuses it.

`MeanPitch` takes the plain `RandomVariableStream` checker and *does* accept a constant. **That asymmetry is why the mistake looked symmetric and correct in review** — the two pitch attributes sit on adjacent lines, and only one of them is fussy.

## The fix

A zero-variance normal — same intent, in the type the attribute demands:

```
NormalPitch = ns3::NormalRandomVariable[Mean=0.0|Variance=0.0|Bound=0.0]
```

## Why CI could not have caught it

The five-version matrix **compiles** `anthocnet-compare` but never **runs** it with `--mobility=gaussmarkov`, and this is a runtime attribute-type check, not a compile error. With no local ns-3 build in this environment, nothing had executed the code path before this probe.

That is the entire argument for the cheap-probe step the benchmark-results procedure mandates — *preflight → one cheap point → campaign*. **This defect cost a 2-run/300 s probe to find.** Dispatched straight into the v1.4.0 grid it would have cost a 20-seed cell, and it would have been the arm that silently produced nothing while the other five looked fine.

## The other two probes passed

Unaffected by this fix, and both met their [pre-registered plausibility gates](https://github.com/danieljoppi/AntHocNet/issues/295#issuecomment-5224391068):

| probe | anthocnet | aodv |
|---|---|---|
| `ssrwp` × `tworay` | 95.4 | 87.1 |
| `rwp` × `nakagami` | 81.3 | 63.4 |

The nakagami row is the one that mattered: it is **clearly below** the two-ray probe, which is the pre-registered evidence that the fading term actually bites rather than the second `AddPropagationLoss` being silently dropped from the chain. Had it come back near-identical to `tworay`, the composition — not the protocol — would have been the thing to doubt.

(2-run probes; nothing here is quotable and no number from them will be published.)

## Verification

`ruff` clean, **55** `test_scenario_check.py` cases pass. No published number moves — `rwp` and the deterministic channels are untouched, and `gaussmarkov` has never produced a number. A re-probe of the arm follows once this merges.

Refs #61, #373, #295, #60

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_