### PR TITLE
docs(bench): state the provenance of every results page — and the two answers differ

### DIFF
--- a/docs/benchmarks/scenarios/dense-small.md
+++ b/docs/benchmarks/scenarios/dense-small.md
@@ -4,6 +4,20 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — regenerated on every merge.** Unlike the
+> [sweep pages](../sweeps/area.md), this table is **not** pinned to a release:
+> `benchmarks.yml` re-runs the discrete taxonomy on every merge to the default
+> branch and rewrites the generated block below, so these numbers track the
+> **current tip of `main`** and already include the pheromone-weighting change
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327)) and the
+> per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)). They are a
+> per-merge regression signal at the 10-run publication floor
+> ([#318](https://github.com/danieljoppi/AntHocNet/issues/318)); the
+> release-pinned, 20-seed numbers live on the sweep and headline pages. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it stresses
 
 The fast CI regime; AntHocNet's hard case. A small, dense, barely-mobile field

--- a/docs/benchmarks/scenarios/heavy-load.md
+++ b/docs/benchmarks/scenarios/heavy-load.md
@@ -4,6 +4,20 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — regenerated on every merge.** Unlike the
+> [sweep pages](../sweeps/area.md), this table is **not** pinned to a release:
+> `benchmarks.yml` re-runs the discrete taxonomy on every merge to the default
+> branch and rewrites the generated block below, so these numbers track the
+> **current tip of `main`** and already include the pheromone-weighting change
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327)) and the
+> per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)). They are a
+> per-merge regression signal at the 10-run publication floor
+> ([#318](https://github.com/danieljoppi/AntHocNet/issues/318)); the
+> release-pinned, 20-seed numbers live on the sweep and headline pages. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it stresses
 
 Many flows / higher CBR. Same field as the paper base scenario, but twice the

--- a/docs/benchmarks/scenarios/high-mobility.md
+++ b/docs/benchmarks/scenarios/high-mobility.md
@@ -4,6 +4,20 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — regenerated on every merge.** Unlike the
+> [sweep pages](../sweeps/area.md), this table is **not** pinned to a release:
+> `benchmarks.yml` re-runs the discrete taxonomy on every merge to the default
+> branch and rewrites the generated block below, so these numbers track the
+> **current tip of `main`** and already include the pheromone-weighting change
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327)) and the
+> per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)). They are a
+> per-merge regression signal at the 10-run publication floor
+> ([#318](https://github.com/danieljoppi/AntHocNet/issues/318)); the
+> release-pinned, 20-seed numbers live on the sweep and headline pages. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it stresses
 
 Constant motion (pause=0). The paper base field with nodes never resting, so

--- a/docs/benchmarks/scenarios/large-scale.md
+++ b/docs/benchmarks/scenarios/large-scale.md
@@ -4,6 +4,20 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — regenerated on every merge.** Unlike the
+> [sweep pages](../sweeps/area.md), this table is **not** pinned to a release:
+> `benchmarks.yml` re-runs the discrete taxonomy on every merge to the default
+> branch and rewrites the generated block below, so these numbers track the
+> **current tip of `main`** and already include the pheromone-weighting change
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327)) and the
+> per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)). They are a
+> per-merge regression signal at the 10-run publication floor
+> ([#318](https://github.com/danieljoppi/AntHocNet/issues/318)); the
+> release-pinned, 20-seed numbers live on the sweep and headline pages. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it stresses
 
 100 nodes. The paper base scenario grown in both node count and terrain, so

--- a/docs/benchmarks/scenarios/paper-base.md
+++ b/docs/benchmarks/scenarios/paper-base.md
@@ -4,6 +4,20 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — regenerated on every merge.** Unlike the
+> [sweep pages](../sweeps/area.md), this table is **not** pinned to a release:
+> `benchmarks.yml` re-runs the discrete taxonomy on every merge to the default
+> branch and rewrites the generated block below, so these numbers track the
+> **current tip of `main`** and already include the pheromone-weighting change
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327)) and the
+> per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)). They are a
+> per-merge regression signal at the 10-run publication floor
+> ([#318](https://github.com/danieljoppi/AntHocNet/issues/318)); the
+> release-pinned, 20-seed numbers live on the sweep and headline pages. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it stresses
 
 The paper's base scenario (AntHocNet's design regime). It is also the

--- a/docs/benchmarks/scenarios/sparse-static.md
+++ b/docs/benchmarks/scenarios/sparse-static.md
@@ -4,6 +4,20 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — regenerated on every merge.** Unlike the
+> [sweep pages](../sweeps/area.md), this table is **not** pinned to a release:
+> `benchmarks.yml` re-runs the discrete taxonomy on every merge to the default
+> branch and rewrites the generated block below, so these numbers track the
+> **current tip of `main`** and already include the pheromone-weighting change
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327)) and the
+> per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)). They are a
+> per-merge regression signal at the 10-run publication floor
+> ([#318](https://github.com/danieljoppi/AntHocNet/issues/318)); the
+> release-pinned, 20-seed numbers live on the sweep and headline pages. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it stresses
 
 Connectivity-limited but stable (pause=900). The paper base field with mobility

--- a/docs/benchmarks/sweeps/area.md
+++ b/docs/benchmarks/sweeps/area.md
@@ -4,6 +4,19 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — measured at `v1.3.0`.** Every number on this page was
+> produced by the campaign runs named below, all of which predate the
+> [`v1.3.0`](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.3.0) tag
+> (`19009be`). No commit between `v1.2.0` and that tag changes routing
+> behaviour, so **checking out `v1.3.0` reproduces these cells.** The default
+> branch will not: it has since changed the pheromone weighting
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327), `betaAnts`/
+> `betaData` 2.0 → 20) and the per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)), either of
+> which moves measured values. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it varies
 
 Reproduces **Fig. 1** of the AntHocNet paper (Di Caro/Ducatelle/Gambardella,

--- a/docs/benchmarks/sweeps/pause.md
+++ b/docs/benchmarks/sweeps/pause.md
@@ -4,6 +4,19 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — measured at `v1.3.0`.** Every number on this page was
+> produced by the campaign runs named below, all of which predate the
+> [`v1.3.0`](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.3.0) tag
+> (`19009be`). No commit between `v1.2.0` and that tag changes routing
+> behaviour, so **checking out `v1.3.0` reproduces these cells.** The default
+> branch will not: it has since changed the pheromone weighting
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327), `betaAnts`/
+> `betaData` 2.0 → 20) and the per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)), either of
+> which moves measured values. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it varies
 
 Reproduces **Fig. 2** of the AntHocNet paper (Di Caro/Ducatelle/Gambardella,

--- a/docs/benchmarks/sweeps/scale.md
+++ b/docs/benchmarks/sweeps/scale.md
@@ -4,6 +4,19 @@
 
 [← Benchmark index](../../benchmarks.md) · [Metrics](../metrics.md) · [Methodology](../methodology.md)
 
+> **Provenance — measured at `v1.3.0`.** Every number on this page was
+> produced by the campaign runs named below, all of which predate the
+> [`v1.3.0`](https://github.com/danieljoppi/AntHocNet/releases/tag/v1.3.0) tag
+> (`19009be`). No commit between `v1.2.0` and that tag changes routing
+> behaviour, so **checking out `v1.3.0` reproduces these cells.** The default
+> branch will not: it has since changed the pheromone weighting
+> ([#327](https://github.com/danieljoppi/AntHocNet/issues/327), `betaAnts`/
+> `betaData` 2.0 → 20) and the per-seed RNG stream assignment
+> ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)), either of
+> which moves measured values. See
+> [Provenance](../methodology.md#provenance-which-version-a-number-was-measured-at)
+> and [#365](https://github.com/danieljoppi/AntHocNet/issues/365).
+
 ## What it varies
 
 Reproduces **Fig. 3** of the AntHocNet paper (Di Caro/Ducatelle/Gambardella,


### PR DESCRIPTION
Discharges #365's first acceptance criterion for the nine MANET results pages: *"No published results page states a number without stating the commit it was measured at."* None of them did.

The useful finding is that **the sweep pages and the scenario pages need opposite statements** — a single blanket banner, which is what #365's text implies, would have been actively wrong for one family.

## Sweep pages (area, pause, scale) — pinned to `v1.3.0`

Their numbers come from campaign dispatches whose run IDs the pages already record, and **every one of those runs predates the `v1.3.0` tag** (`19009be`). Since no commit between `v1.2.0` and that tag changes routing behaviour, **checking out `v1.3.0` reproduces these cells exactly.** The default branch does not — `#327` (β 2.0 → 20) and `#352` (per-seed RNG streams) both landed after the tag.

The banner points at the reader's actual next action: check out the tag.

## Scenario pages (the six discrete taxonomy pages) — deliberately *not* pinned

`benchmarks.yml` re-runs the discrete taxonomy on **every merge** and rewrites the generated block, so these numbers track the current tip of `main` and **already include #327 and #352**. They are the one family that is current rather than release-pinned.

Telling a reader to check out `v1.3.0` to reproduce them would be **actively wrong** — precisely the error a uniform banner would have introduced. Their banner says what they actually are: a per-merge regression signal at the 10-run floor (#318), with the release-pinned 20-seed numbers living on the sweep and headline pages.

## Both banners survive regeneration

They sit **outside** the `<!-- BENCHMARK-TABLE-START/END -->` markers. `update-benchmarks.py` replaces only content between the markers — its module docstring states this explicitly (*"hand-written prose above and below a block survives regeneration"*) — so neither banner is at risk from the next merge.

## The satellite page is deliberately untouched

`docs/benchmarks/satellite/isl-grid.md` already carries #318's wording pass marking its low-run cells as *"diagnostic identities, not estimates"* with the runs-floor exception explained. #365's *"explicitly marked"* branch is satisfied there; a second banner would be redundant.

## Still #365's, and not guessed at here

**The generated blocks do not carry the commit they were produced from.** For the scenario pages that is mechanical — `update-benchmarks.py` runs in the same job as the measurement, so it could stamp `GITHUB_SHA`. For the sweep pages it is **not**: the campaign runs at one commit and the CSV is imported at another, and the CSV schema has no column for the measuring commit. Closing that properly means adding one, which deserves its own change rather than a plausible-looking guess in this PR.

## Verification

`check-links.py` and `check-mermaid.py` clean (70 tracked markdown files, 0 problems), covering the new cross-document anchors into `methodology.md#provenance-…`. Documentation only — no number changes, no code, so no A/B applies.

Refs #365, #327, #352, #318, #368, #110

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_