### PR TITLE
feat(bench): regression floors for the grid arms — and why they are not anchors

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -40,7 +40,12 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 ANCHORS_YML = os.path.normpath(
     os.path.join(HERE, "..", "..", "..", "ns3", "tools", "anchors.yml"))
 ANCHOR_KEY = {"single-hop": "single_hop_pdr_min",
-              "broch-low-mobility": "broch_low_mobility_aodv_pdr_min"}
+              "broch-low-mobility": "broch_low_mobility_aodv_pdr_min",
+              # #61/#60 grid arms. Regression floors from our own 20-seed
+              # measurement, not literature values — see anchors.yml for why
+              # there is nothing external to anchor these against.
+              "grid-tworay": "grid_tworay_aodv_pdr_min",
+              "grid-nakagami": "grid_nakagami_aodv_pdr_min"}
 
 # #217: core Config::maxPathLength — the cap on the visited path an ant carries
 # and therefore on any path the protocol can lay. A delivered data packet
@@ -233,9 +238,12 @@ def cmd_preflight(a):
                        "before quoting a tail metric (#60)")
     if a.mobility != "rwp":
         report("WARN", f"--mobility={a.mobility} is not the model the "
-                       "published corpus was measured under (rwp); its "
-                       "anchor floors do not apply and results are not "
-                       "comparable to the published cells (#59, #61)")
+                       "published corpus was measured under (rwp), so its "
+                       "results are not comparable to the published cells. "
+                       "The Broch floor is RWP-specific and does not apply; "
+                       "validate with --anchor grid-tworay / grid-nakagami "
+                       "instead, which are regression floors from the v1.4.0 "
+                       "grid rather than literature values (#59, #61, #60)")
     # #230: the diversity window must be short relative to how fast the
     # topology changes, or a route being *replaced* inside one window reads as
     # two concurrent paths and path_div_used stops meaning multipath. Two nodes

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -289,6 +289,79 @@ def _absent_columns():
            f"a rule fired on a pre-instrumentation row\n{out}")
 
 
+# --- #61/#60 grid regression floors ------------------------------------------
+#
+# These floors are derived from our own measurement, not from literature, so
+# the must-not-fire half matters more than usual: if they fire on the very
+# numbers they were calibrated from, they are wrong by construction.
+
+def run_results_anchor(anchor, **overrides):
+    """Check one row against an --anchor floor; return (levels, stdout)."""
+    row = dict(CLEAN, **overrides)
+    text = ",".join(row) + "\n" + ",".join(str(v) for v in row.values()) + "\n"
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        sc.issues = []
+        args = argparse.Namespace(files=[path], anchor=anchor)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            try:
+                sc.cmd_results(args)
+            except SystemExit:
+                pass
+        return list(sc.issues), out.getvalue()
+    finally:
+        os.unlink(path)
+
+
+@case("#60 grid-tworay floor stays quiet at the measured AODV PDR")
+def _grid_tworay_quiet():
+    # 83.90 is the worst measured two-ray cell (gaussmarkov, run 31239973590).
+    # Assert on the anchor's own verdict, not on the global level list: the
+    # shared CLEAN fixture trips unrelated rules once pdr_pct is overridden,
+    # and a test that keys on "any FAIL" would be testing those instead.
+    _, out = run_results_anchor("grid-tworay", protocol="aodv",
+                                pdr_pct="83.90")
+    expect("floor 75.0 met" in out, "grid-tworay-quiet",
+           f"the floor fired on the number it was calibrated from\n{out}")
+    expect("'grid-tworay' floor 75.0 violated" not in out,
+           "grid-tworay-quiet", out)
+
+
+@case("#60 grid-tworay floor fires on a #51-class collapse")
+def _grid_tworay_fires():
+    _, out = run_results_anchor("grid-tworay", protocol="aodv",
+                                pdr_pct="50.0")
+    expect("'grid-tworay' floor 75.0 violated" in out, "grid-tworay-fires",
+           f"a ~50% rate-manager regression did not fire\n{out}")
+
+
+@case("#60 grid-nakagami floor stays quiet at the measured AODV PDR")
+def _grid_nakagami_quiet():
+    # 67.23 is the worst measured fading cell (gaussmarkov, run 31239979624)
+    # and sits well below the two-ray floor — which is exactly why the fading
+    # arm needs its own threshold rather than reusing grid-tworay.
+    _, out = run_results_anchor("grid-nakagami", protocol="aodv",
+                                pdr_pct="67.23")
+    expect("floor 55.0 met" in out, "grid-nakagami-quiet",
+           f"the floor fired on the number it was calibrated from\n{out}")
+    expect("'grid-nakagami' floor 55.0 violated" not in out,
+           "grid-nakagami-quiet", out)
+
+
+@case("#60 grid-tworay floor would reject a healthy fading cell")
+def _grid_wrong_anchor_fires():
+    # The reason there are two floors: a legitimate Nakagami reading checked
+    # against the two-ray floor must FAIL, so picking the wrong --anchor is a
+    # loud error rather than a silently-passing one.
+    _, out = run_results_anchor("grid-tworay", protocol="aodv",
+                                pdr_pct="67.23")
+    expect("'grid-tworay' floor 75.0 violated" in out,
+           "grid-wrong-anchor-fires",
+           f"a fading cell passed the two-ray floor\n{out}")
+
+
 # --- #61 mobility-model preflight --------------------------------------------
 
 @case("#61 preflight FAILs pause>0 under gaussmarkov (inert knob)")

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -680,6 +680,46 @@ enforced locally by
 [`.claude/skills/benchmark-results/scenario_check.py`](../../.claude/skills/benchmark-results/scenario_check.py)
 (#134), which reads `anchors.yml` rather than duplicating it.
 
+### Grid-arm regression floors — a third kind, and not an anchor
+([#61](https://github.com/danieljoppi/AntHocNet/issues/61) / [#60](https://github.com/danieljoppi/AntHocNet/issues/60))
+
+`anchors.yml` also carries `grid_tworay_aodv_pdr_min` and
+`grid_nakagami_aodv_pdr_min`, reachable as `--anchor grid-tworay` /
+`--anchor grid-nakagami`. **They are not validation anchors, and the difference
+is worth keeping straight.**
+
+The wifi anchors above are *literature-derived* (Broch et al.); the satellite
+ones are *analytic identities* on a lossless p2p link. Both are external: they
+can tell you the number is **wrong**. For AODV under steady-state RWP,
+Gauss-Markov or Nakagami fading at the paper base scenario there is **no
+published reference value and no analytic identity** — so there is nothing
+external to check against, and inventing a figure would be exactly the kind of
+unsourced constant [#88](https://github.com/danieljoppi/AntHocNet/issues/88) and
+[#173](https://github.com/danieljoppi/AntHocNet/issues/173) turned out to be.
+
+What these two floors do instead is catch a
+[#51](https://github.com/danieljoppi/AntHocNet/issues/51)-class harness or
+channel regression on arms **CI never runs** — a 4-hour campaign cell is not a
+per-merge gate, so without them a broken substrate would be discovered only by
+reading the results. They are derived from our own 20-seed measurement
+([grid](grid.md)), so they validate that the substrate still works, **not** that
+the number is right. Recalibrate them against a re-measurement, never against a
+literature claim.
+
+Two consequences of that provenance:
+
+- **They are keyed by channel, not by cell.** AODV moves only 2.7 pp across the
+  three mobility models on two-ray and 6.3 pp on Nakagami, so one floor per
+  channel covers the worst mobility case without six near-duplicate thresholds.
+- **The margins are deliberately generous** (~11 % below the worst measured
+  two-ray cell, ~18 % below the worst fading one — wider there because link
+  existence includes a random draw). A floor that false-fires gets ignored, and
+  then it is not a gate ([#229](https://github.com/danieljoppi/AntHocNet/issues/229)).
+
+Picking the wrong one is a loud error rather than a quiet pass: a healthy
+Nakagami reading checked against `grid-tworay` FAILs, and there is a test case
+pinning that.
+
 ### Satellite validation anchors ([#237](https://github.com/danieljoppi/AntHocNet/issues/237))
 
 The anchors above are **literature-derived and approximate** ("AODV ≈ 90–100%")

--- a/ns3/tools/anchors.yml
+++ b/ns3/tools/anchors.yml
@@ -32,3 +32,35 @@ sat_hop_delay_slack_ms: 1.5
 # (time=300, runs=3). 85.0 leaves margin for the gate's 2-run average and
 # random node placement — tighten once more gate runs accumulate.
 broch_low_mobility_aodv_pdr_min: 85.0
+
+# --- v1.4.0 grid arms (#61/#60) — regression floors, NOT validation anchors --
+# These differ in kind from everything above, and the distinction matters.
+# The wifi anchors are literature-derived (Broch et al.) and the satellite ones
+# are analytic identities on a lossless p2p link. For AODV under steady-state
+# RWP, Gauss-Markov or Nakagami fading at the paper base scenario there is
+# **no published reference value and no analytic identity** — so there is
+# nothing external to anchor against, and inventing one would be the kind of
+# unsourced constant #88 and #173 turned out to be.
+#
+# What these are instead: floors derived from our own 20-seed measurement, to
+# catch a #51-class harness/channel regression on an arm that CI never runs.
+# They validate that the substrate still works, not that the number is right.
+# Recalibrate them against a re-measurement, never against a literature claim.
+#
+# Keyed by channel rather than per cell: across the three mobility models AODV
+# moves only 2.7 pp on two-ray and 6.3 pp on Nakagami, so one floor per channel
+# covers the worst mobility case without six near-duplicate thresholds.
+# A floor that false-fires gets ignored (#229), so the margins are generous.
+
+# Measured AODV PDR on two-ray, v1.4.0 grid (runs 31239953345 / 31239962932 /
+# 31239973590): 85.92 / 86.56 / 83.90 %. Worst case 83.90 (Gauss-Markov).
+# 75.0 is ~11 % below it — wide enough for placement variation, tight enough
+# that a rate-manager or propagation regression (which reads ~50 %) still fires.
+grid_tworay_aodv_pdr_min: 75.0
+
+# Measured AODV PDR on Nakagami, v1.4.0 grid (runs 31239958344 / 31239968258 /
+# 31239979624): 73.49 / 73.02 / 67.23 %. Worst case 67.23 (Gauss-Markov).
+# 55.0 is ~18 % below it: a wider margin than the two-ray floor on purpose,
+# because link existence here includes a random draw and per-seed dispersion is
+# correspondingly higher (#60).
+grid_nakagami_aodv_pdr_min: 55.0


### PR DESCRIPTION
Closes #295's second acceptance criterion: *"every new arm has preflight + results checks and an anchors entry **or** a documented reason there isn't one."*

`ssrwp`, `gaussmarkov` and `nakagami` had **neither**. `anchors.yml` carried only `single_hop`, the two satellite values and `broch_low_mobility` — and the Broch floor is RWP-specific. The preflight WARN added in #373 said anchor floors *"do not apply"*, which is a warning, not an entry and not a reason.

## The answer is both halves of that "or"

The two existing anchor families **cannot** be extended to these arms:

| family | basis | can say the number is… |
|---|---|---|
| wifi (`broch_low_mobility`) | literature-derived (Broch et al.) | **wrong** |
| satellite (`sat_*`) | analytic identity on a lossless p2p link | **wrong** |

For AODV under steady-state RWP, Gauss-Markov or Nakagami fading at the paper base scenario there is **no published reference value and no analytic identity**. Inventing one would be precisely the unsourced constant #88 and #173 turned out to be. `anchors.yml` now says that explicitly instead of leaving the gap implicit — that is the "documented reason" half.

## What is added: a third, clearly-labelled kind

Regression floors derived from our own 20-seed grid measurement (#379):

```yaml
grid_tworay_aodv_pdr_min:   75.0   # worst measured cell 83.90, ~11% margin
grid_nakagami_aodv_pdr_min: 55.0   # worst measured cell 67.23, ~18% margin
```

They catch a **#51-class harness or channel regression on arms CI never runs** — a 4-hour campaign cell is not a per-merge gate, so without them a broken substrate is found only by reading the results. They validate that the *substrate still works*, **not** that the number is right; the comment says to recalibrate against a re-measurement and never against a literature claim.

Two consequences of that provenance, both documented:

- **Keyed by channel, not per cell.** AODV moves only 2.7 pp across the three mobility models on two-ray and 6.3 pp on Nakagami, so one floor per channel covers the worst mobility case without six near-duplicate thresholds.
- **Margins are generous on purpose** — wider on Nakagami, where link existence includes a random draw. A floor that false-fires gets ignored, and then it is not a gate (#229).

Reachable as `--anchor grid-tworay` / `--anchor grid-nakagami`; the #373 preflight WARN now points at them rather than only saying the Broch floor does not apply.

## Tests — the must-not-fire half carries the weight here

Because these floors are calibrated from our own numbers, **if they fire on the readings they were derived from they are wrong by construction.** Both quiet cases therefore assert against the exact measured worst-case value (83.90 / 67.23), not a comfortable round number.

A fourth case pins that picking the wrong floor is **loud**: a healthy Nakagami reading checked against `grid-tworay` FAILs rather than passing silently.

One thing worth flagging about the assertions: they key on the anchor's own verdict string, not on *"any FAIL in the levels list"*. Overriding `pdr_pct` on the shared `CLEAN` fixture trips unrelated drop-identity and #230 rules, so a level-based assertion tests those instead of the floor. **My first cut did exactly that and passed for the wrong reason** — caught because the quiet case failed against a fixture whose other rules had fired.

## Verification

**59** `test_scenario_check.py` cases pass, `ruff` clean, `check-links.py` / `check-mermaid.py` / `check-headers.py` clean. No protocol behaviour changes and no published number moves.

Refs #295, #61, #60, #59, #51, #229, #379

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_