### PR TITLE
feat(bench): add a TCP arm — saturating BulkSend, with ##GOODPUT## as its headline

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -229,6 +229,17 @@ def cmd_preflight(a):
                        "hard cutoff), so the node-degree and connectivity "
                        "figures above are a disk-model estimate and do not "
                        "bound this channel's links (#24, #60)")
+    # #63: a saturating TCP arm invalidates the offered-load arithmetic above.
+    # BulkSend sends as fast as the window allows, so `cbrBps`, `pktPerSec` and
+    # the channel-saturation check are all computed from a load the run does
+    # not actually offer.
+    if a.transport == "tcp":
+        report("WARN", "--transport=tcp is a SATURATING arm: BulkSend ignores "
+                       "cbrBps/pktPerSec, so the offered-load and "
+                       "channel-saturation figures above do not describe this "
+                       "run. It is its own regime, not a variant of the base "
+                       "scenario — do not compare its cells to UDP ones, and "
+                       "read ##GOODPUT## rather than pdr/thrput (#63)")
     if a.propagation == "nakagami":
         report("WARN", "nakagami is the harness's first stochastic channel: "
                        "link existence is a random draw, so per-seed "
@@ -929,6 +940,7 @@ def main():
                    default="rwp")
     p.add_argument("--propagation", choices=("range", "tworay", "nakagami"),
                    default="range")
+    p.add_argument("--transport", choices=("udp", "tcp"), default="udp")
     r = sub.add_parser("results")
     r.add_argument("files", nargs="+")
     r.add_argument("--anchor", choices=sorted(ANCHOR_KEY))

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -114,7 +114,8 @@ def run_preflight(**overrides):
     kw = {"nodes": 50, "areaX": 1500.0, "areaY": 300.0, "range": 300.0,
           "time": 300.0, "pause": 30.0, "speed": 20.0, "flows": 20,
           "pktBytes": 64, "pktPerSec": 1.0, "rateMbps": 2.0,
-          "pathWindowS": 10.0, "mobility": "rwp", "propagation": "range"}
+          "pathWindowS": 10.0, "mobility": "rwp", "propagation": "range",
+          "transport": "udp"}
     kw.update(overrides)
     sc.issues = []
     with contextlib.redirect_stdout(io.StringIO()) as out:
@@ -287,6 +288,26 @@ def _absent_columns():
     levels, out = run_results(**blank)
     expect(levels == [], "absent-columns",
            f"a rule fired on a pre-instrumentation row\n{out}")
+
+
+# --- #63 TCP transport preflight ----------------------------------------------
+
+@case("#63 preflight WARNs that a TCP arm is saturating")
+def _transport_tcp_fires():
+    levels, out = run_preflight(transport="tcp", pathWindowS=2.0)
+    expect("WARN" in levels, "transport-tcp-fires",
+           f"a saturating TCP arm did not WARN\n{out}")
+    expect("SATURATING" in out, "transport-tcp-fires", out)
+    expect("##GOODPUT##" in out, "transport-tcp-fires",
+           f"the WARN did not name the metric to read instead\n{out}")
+
+
+@case("#63 preflight says nothing about transport on the udp default")
+def _transport_udp_silent():
+    # Must-not-fire: udp is what every published number used, so it must not
+    # acquire a new warning.
+    _, out = run_preflight(pathWindowS=2.0)
+    expect("SATURATING" not in out, "transport-udp-silent", out)
 
 
 # --- #61/#60 grid regression floors ------------------------------------------

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -40,6 +40,9 @@ on:
       mobility:
         description: 'Mobility model (#61): rwp (Random Waypoint — the model every published number was measured under) | ssrwp (steady-state RWP, no speed-decay transient) | gaussmarkov (smooth correlated tracks; pause is inert under it, so pass pause=0)'
         default: 'rwp'
+      transport:
+        description: 'Transport (#63): udp (CBR OnOff — what every published number was measured under) | tcp (saturating BulkSend). A TCP cell is its own regime, not a variant of the base scenario: pdr/thrput/nrl change meaning and the reorder columns go absent. Read ##GOODPUT##.'
+        default: 'udp'
       range:
         description: 'Transmission range (m) for the disk model (#24 disentangler)'
         default: '300'
@@ -139,7 +142,7 @@ jobs:
             # such option (#61), and ns-3's CommandLine treats an unknown
             # argument as fatal — it would kill the #24 baselines control arm
             # instantly, which is the #28 empty-table failure mode.
-            cmd="anthocnet-compare $common --diag --mobility=${{ github.event.inputs.mobility }} --protocols=${{ github.event.inputs.protocols }}"
+            cmd="anthocnet-compare $common --diag --mobility=${{ github.event.inputs.mobility }} --transport=${{ github.event.inputs.transport }} --protocols=${{ github.event.inputs.protocols }}"
           fi
           echo "$cmd"
           # #28 hardening: stderr used to be discarded wholesale and the
@@ -276,6 +279,13 @@ jobs:
           # were dispatched with are unrecoverable — the command echo lives
           # ~900 lines above the cheap tail and dies with the run.
           grep '^##CONFIG##' "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #63: application-level goodput. Added in the same commit that emits
+          # it, per the rule above. This is the TCP arm's *headline* -- under
+          # TCP the pdr and thrput columns change meaning (retransmissions
+          # inflate both), so a TCP cell whose ##GOODPUT## rows were unreachable
+          # would be a cell with no readable primary metric at all.
+          grep '^##GOODPUT##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
           # the *only* place the #209/#212/#215/#217 metric families appear in a

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -219,6 +219,33 @@ to be discovered:
   `AssignStreams` call, so runs stay reproducible
   ([#352](https://github.com/danieljoppi/AntHocNet/issues/352)).
 
+## Transport (`--transport`, [#63](https://github.com/danieljoppi/AntHocNet/issues/63))
+
+`udp` (default) is the paper's CBR/OnOff traffic and what **every published
+number was measured under**. `tcp` installs a saturating `BulkSendApplication`
+over `TcpSocketFactory`.
+
+**A TCP cell is its own regime, not a variant of the base scenario.** Twenty
+saturating flows congest the pinned 2 Mbit/s channel, so its delay and delivery
+columns are not comparable with a UDP cell's, and `scenario_check.py preflight`
+WARNs to that effect: `BulkSend` ignores `cbrBps`/`pktPerSec`, so the
+offered-load and channel-saturation arithmetic does not describe the run.
+
+Saturating rather than rate-matched is a deliberate choice. At the paper's
+512 bps (1 packet/s) a TCP congestion window never leaves 1–2 segments, so
+reordering — the entire mechanism this arm exists to expose — could not affect
+it. A load-matched TCP arm would be comparable to the UDP cells and would have
+the finding designed out of it.
+
+Read [`##GOODPUT##`](metrics.md#application-goodput-goodput-63), not `pdr`: the
+table there lists the three columns that change meaning under TCP, and why the
+reorder columns are absent rather than zero.
+
+The congestion-control variant is recorded in the run's `##CONFIG##` block
+(`ns3::TcpL4Protocol::SocketType`), because ns-3's default has changed across
+releases and a cell that does not state it is not reproducible against a future
+image.
+
 ## Statistical policy ([#293](https://github.com/danieljoppi/AntHocNet/issues/293))
 
 Every number published in these pages or in the papers repo carries a **95%

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -196,6 +196,37 @@ all-delivered basis. What it cannot say is how the split looks on the packets
 both protocols carried, where the delay ratio is 1.44× rather than 1.68×. That
 is the question `hopsCommon` answers.
 
+### Application goodput (`##GOODPUT##`, #63)
+
+```
+##GOODPUT## <run> <proto> <kbps>
+```
+
+Application bytes delivered per second, summed over the `PacketSink`s —
+**measured at the application, not derived from FlowMonitor.**
+
+Emitted on **every** run, not only TCP ones, and that is deliberate: on the UDP
+arm it should track the `thrput` column closely, and the agreement is a free
+cross-check that the metric is wired correctly. On TCP the two diverge, and the
+gap between them *is* the retransmission overhead.
+
+**On a TCP cell this is the headline, and `pdr` is not.** TCP retransmits until
+it succeeds, so FlowMonitor's `txPackets` inflates while `rxPackets` counts each
+delivery once: the ratio stops being a delivery fraction. Three columns change
+meaning on a TCP cell and must not be compared with a UDP one:
+
+| column | why it breaks under TCP |
+|---|---|
+| `pdr` | retransmissions inflate the denominator; it is no longer "fraction of offered data delivered" |
+| `thrput` | FlowMonitor counts delivered *IP* bytes, so retransmitted segments count as throughput |
+| `nrl` | control packets per *delivered data packet* — retransmissions inflate the denominator, which **flatters** whichever protocol reorders most, inverting the metric exactly where it matters |
+
+The reorder columns are **absent** on a TCP cell rather than zero: `RecordRxSeq`
+reads a `SeqTsSizeHeader` off the sink's `Rx` trace, which carries whole
+datagrams on UDP but byte-stream chunks on TCP, so the hook is not connected at
+all. Worth stating plainly — TCP is the arm where reordering matters most, and
+it is the arm this instrumentation cannot measure.
+
 ### Run provenance (`##CONFIG##`, #369)
 
 ```

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -669,6 +669,10 @@ struct Params {
     // every published number was measured under) | "ssrwp" (steady-state RWP,
     // no speed-decay transient) | "gaussmarkov" (smooth correlated tracks).
     std::string mobility;
+    // #63: transport. "udp" (CBR OnOff, the default and what every published
+    // number was measured under) | "tcp" (saturating BulkSend). Read the
+    // metric-semantics warning above the flow loop before quoting a TCP cell.
+    std::string transport;
 };
 
 struct Result {
@@ -713,6 +717,12 @@ struct Result {
     // -1 = not measured (the PHY State trace is only connected when the energy
     // model is on), which suppresses the ##AIR## row entirely.
     double airTxS = -1.0, airRxS = -1.0, airCcaS = -1.0;
+    // #63: application bytes actually delivered, per second, summed over the
+    // PacketSinks. Distinct from throughputKbps, which is FlowMonitor's
+    // delivered *IP* bytes and therefore counts TCP retransmissions. On UDP the
+    // two agree; on TCP their gap is the retransmission overhead, which is why
+    // this is the TCP arm's headline rather than PDR.
+    double goodputKbps = 0.0;
     double energyJ = 0.0;        // total consumed over all nodes (J)
     double energyPerPktJ = 0.0;  // energyJ / delivered data packets (J/pkt)
     double resMinJ = 0.0;        // residual energy across nodes: min / mean /
@@ -1105,6 +1115,36 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         uint32_t src = i;
         uint32_t dst = converge ? static_cast<uint32_t>(P.sink) : (P.nNodes - 1 - i);
         if (src == dst) continue;  // source coincides with the gateway: skip
+        // #63: the TCP arm. A saturating BulkSend, not a rate-limited OnOff
+        // over TCP: at the paper's 512 bps / 1 packet-per-second the congestion
+        // window never leaves 1-2 segments, so reordering — the entire reason
+        // this arm exists — could not affect it. The trade is that 20
+        // saturating flows congest a pinned 2 Mbit/s channel, so this is its
+        // own regime and NOT a drop-in variant of the UDP base scenario.
+        //
+        // READ THE METRICS DIFFERENTLY HERE. TCP retransmits until it succeeds,
+        // so FlowMonitor's txPackets inflates and `pdr` stops being a delivery
+        // ratio; `thrput` counts retransmitted IP bytes rather than goodput;
+        // and NRL's per-delivered-packet denominator inflates with them, which
+        // *flatters* whichever protocol reorders most — the opposite of what
+        // this arm is measuring. The headline for a TCP cell is ##GOODPUT##
+        // (application bytes delivered), emitted below.
+        if (P.transport == "tcp") {
+            BulkSendHelper bulk("ns3::TcpSocketFactory",
+                                InetSocketAddress(ifs.GetAddress(dst), port));
+            bulk.SetAttribute("MaxBytes", UintegerValue(0));  // unbounded
+            const double startS = startVar->GetValue();
+            bulk.SetAttribute("StartTime", TimeValue(Seconds(startS)));
+            bulk.SetAttribute("StopTime", TimeValue(Seconds(P.simTime - 1.0)));
+            apps.Add(bulk.Install(nodes.Get(src)));
+            if (!converge) {
+                g_flowStart.push_back(startS);
+                PacketSinkHelper sink("ns3::TcpSocketFactory",
+                                      InetSocketAddress(Ipv4Address::GetAny(), port));
+                sinks.Add(sink.Install(nodes.Get(dst)));
+            }
+            continue;
+        }
         OnOffHelper onoff("ns3::UdpSocketFactory",
                           InetSocketAddress(ifs.GetAddress(dst), port));
         onoff.SetAttribute("DataRate", StringValue(rate.str()));
@@ -1135,7 +1175,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         }
     }
     if (converge && P.sink >= 0 && static_cast<uint32_t>(P.sink) < P.nNodes) {
-        PacketSinkHelper sink("ns3::UdpSocketFactory",
+        PacketSinkHelper sink(P.transport == "tcp" ? "ns3::TcpSocketFactory"
+                                                   : "ns3::UdpSocketFactory",
                               InetSocketAddress(Ipv4Address::GetAny(), port));
         sinks.Add(sink.Install(nodes.Get(P.sink)));
     }
@@ -1162,8 +1203,20 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     // sequence number is read here rather than through PacketSink's own
     // EnableSeqTsSizeHeader path (that one runs a TCP-oriented reassembly buffer
     // we have no use for on UDP).
-    for (uint32_t i = 0; i < sinks.GetN(); ++i) {
-        sinks.Get(i)->TraceConnectWithoutContext("Rx", MakeCallback(&RecordRxSeq));
+    // #63: NOT connected under TCP. RecordRxSeq reads a SeqTsSizeHeader off the
+    // sink's "Rx" trace, which hands over whole datagrams on UDP but byte-stream
+    // chunks on TCP — the parse would be garbage rather than absent, i.e. a
+    // wrong number instead of no number. The reorder columns therefore read as
+    // absent on a TCP cell, following the ##HOLD##/##AIR## rule.
+    //
+    // The irony is worth stating: TCP is the arm where reordering matters most
+    // (it is what collapses the congestion window, and the reason #63 exists)
+    // and it is the arm our reordering instrumentation cannot measure. Read the
+    // mechanism from ##GOODPUT## against the UDP arm instead.
+    if (P.transport != "tcp") {
+        for (uint32_t i = 0; i < sinks.GetN(); ++i) {
+            sinks.Get(i)->TraceConnectWithoutContext("Rx", MakeCallback(&RecordRxSeq));
+        }
     }
 
     if (g_diag) {
@@ -1212,6 +1265,21 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     FlushDiversityWindow();
     Result r;
     r.proto = proto;
+    // #63: application-level goodput, summed over the PacketSinks. Measured
+    // rather than derived, and independent of FlowMonitor — so on the UDP arm
+    // it should track throughputKbps closely, and that agreement is a free
+    // cross-check on the new metric. On TCP the two diverge by exactly the
+    // retransmitted bytes.
+    {
+        uint64_t rxBytes = 0;
+        for (uint32_t i = 0; i < sinks.GetN(); ++i) {
+            Ptr<PacketSink> ps = DynamicCast<PacketSink>(sinks.Get(i));
+            if (ps) rxBytes += ps->GetTotalRx();
+        }
+        r.goodputKbps = P.simTime > 0.0
+                            ? 8.0 * static_cast<double>(rxBytes) / P.simTime / 1000.0
+                            : 0.0;
+    }
     double totalDelay = 0.0;
     uint64_t rxForDelay = 0;
     double totalRxBytes = 0.0;
@@ -1803,7 +1871,15 @@ int main(int argc, char* argv[]) {
                           "distribution (meanQ/maxQ/pctNonzero) — does A2 have a "
                           "signal? (#73)", g_qdiag);
     std::string mobilityModel = "rwp";
+    std::string transport = "udp";
     std::string propagation = "range";
+    cmd.AddValue("transport",
+                 "Transport (#63): 'udp' (CBR OnOff, default — what every "
+                 "published number was measured under) | 'tcp' (saturating "
+                 "BulkSend). A TCP cell is its own regime: pdr/thrput/nrl "
+                 "change meaning and the reorder columns go absent; read "
+                 "##GOODPUT##.",
+                 transport);
     cmd.AddValue("mobility",
                  "Mobility model (#61): 'rwp' (Random Waypoint, default — the "
                  "model every published number was measured under) | 'ssrwp' "
@@ -1912,6 +1988,12 @@ int main(int argc, char* argv[]) {
                            "silent fallback would produce a plausible run of "
                            "the wrong channel (#60).");
     P.mobility = mobilityModel;
+    P.transport = transport;
+    NS_ABORT_MSG_UNLESS(transport == "udp" || transport == "tcp",
+                        "unknown --transport='" << transport
+                        << "' (expected udp|tcp). Refusing rather than "
+                           "defaulting to udp: a typo would silently produce a "
+                           "UDP run labelled as a TCP one (#63).");
     NS_ABORT_MSG_UNLESS(mobilityModel == "rwp" || mobilityModel == "ssrwp" ||
                             mobilityModel == "gaussmarkov",
                         "unknown --mobility='" << mobilityModel
@@ -2006,6 +2088,7 @@ int main(int argc, char* argv[]) {
               << " speed=" << P.speed << " pause=" << P.pause
               << " range=" << P.range << " propagation=" << P.propagation
               << " mobility=" << P.mobility
+              << " transport=" << P.transport
               << " flows=" << P.nFlows << " cbrBps=" << P.cbrBps
               << " rateManager=" << P.rateManager
               << " protocols=" << protocols << '\n';
@@ -2030,6 +2113,24 @@ int main(int argc, char* argv[]) {
                 std::cout << "##CONFIG## attr " << info.name << '='
                           << info.initialValue->SerializeToString(info.checker)
                           << '\n';
+            }
+        }
+    }
+    // #63: on a TCP run, the congestion-control variant IS part of the
+    // configuration -- ns-3's default has changed across releases, so a cell
+    // that does not record it is not reproducible against a future image.
+    if (P.transport == "tcp") {
+        TypeId tcpTid;
+        if (TypeId::LookupByNameFailSafe("ns3::TcpL4Protocol", &tcpTid)) {
+            const std::size_t nT = tcpTid.GetAttributeN();
+            for (std::size_t a = 0; a < nT; ++a) {
+                const TypeId::AttributeInformation info = tcpTid.GetAttribute(a);
+                if (info.name != "SocketType") continue;
+                if (!info.initialValue || !info.checker) break;
+                std::cout << "##CONFIG## attr ns3::TcpL4Protocol::SocketType="
+                          << info.initialValue->SerializeToString(info.checker)
+                          << '\n';
+                break;
             }
         }
     }
@@ -2108,6 +2209,14 @@ int main(int argc, char* argv[]) {
                           << (nodeSeconds > 0.0 ? 100.0 * busy / nodeSeconds : 0.0)
                           << "\n";
             }
+            // #63: application bytes delivered per second, from the
+            // PacketSinks. Emitted on every run, not only TCP ones: on UDP it
+            // should track the thrput column, and that agreement is the
+            // cross-check that the metric is wired correctly. On TCP the gap
+            // between the two is the retransmission overhead, and ##GOODPUT##
+            // -- not pdr, not thrput -- is the cell's headline.
+            std::cout << std::fixed << "##GOODPUT## " << s << ' ' << list[i]
+                      << ' ' << std::setprecision(3) << r.goodputKbps << "\n";
             agg[i].pdr += r.pdr;
             agg[i].delay += r.meanDelayMs;
             agg[i].delay99 += r.delay99Ms;


### PR DESCRIPTION
The **last v1.4.0 exit-criterion item**. Closes #63's core ask; refs #295.

`anthocnet-compare` built traffic only with `OnOffHelper` over `UdpSocketFactory`, so the TCP arm was undispatchable in the same way the mobility axis was before #373.

`--transport=udp|tcp`, defaulting to `udp`, which is left **byte-for-byte** as it was.

## Saturating, not rate-matched — and why

#63's acceptance asks for `BulkSend` goodput; the roadmap asks for a ranking-stability arm. [The design note](https://github.com/danieljoppi/AntHocNet/issues/63#issuecomment-5212330646) laid both out rather than picking silently. This implements the **saturating** one:

At the paper's 512 bps (1 packet/s), a TCP congestion window never leaves 1–2 segments — so **reordering, the entire mechanism this arm exists to expose, could not affect it.** A load-matched arm would be comparable to the UDP cells and would have the finding designed out of it.

The cost, stated on the page and in preflight: 20 saturating flows congest the pinned 2 Mbit/s channel, so **a TCP cell is its own regime, not a drop-in variant of the base scenario.**

## The part that needed designing first: four metrics change meaning

Adding the socket factory is ten lines. None of the following would fail a build, a test, or the results gate — each would produce a plausible table meaning something other than it says:

| column | what breaks under TCP |
|---|---|
| `pdr` | retransmissions inflate `txPackets`; it stops being a delivery ratio |
| `thrput` | FlowMonitor counts delivered *IP* bytes — retransmitted segments count as throughput |
| `nrl` | denominator is delivered data packets, which retransmissions inflate → **flatters whichever protocol reorders most**, inverting the metric exactly where this arm points |
| reorder columns | `RecordRxSeq` parses a `SeqTsSizeHeader` off the sink `Rx` trace — datagrams on UDP, **byte-stream chunks** on TCP |

So a new headline metric ships **with** the arm:

```
##GOODPUT## <run> <proto> <kbps>
```

Application bytes delivered per second from the `PacketSink`s — measured at the application, independent of FlowMonitor. Emitted on **every** run, not only TCP ones: on UDP it should track `thrput`, and that agreement is a free cross-check that the metric is wired correctly. On TCP the gap between them *is* the retransmission overhead.

Added to `paper-benchmark.yml`'s compact re-emit **in this commit**, per the `##MATCH##` rule — a TCP cell whose `##GOODPUT##` rows were unreachable would be a cell with **no readable primary metric at all**.

The reorder hook is **not connected** under TCP, so those columns are absent rather than zero (`##HOLD##`/`##AIR##` rule). Worth saying plainly: **TCP is the arm where reordering matters most, and it is the arm our reordering instrumentation cannot measure.** The mechanism has to be read from `##GOODPUT##` against the UDP arm.

## Reproducibility

`##CONFIG##` gains `transport=`, and on a TCP run also `ns3::TcpL4Protocol::SocketType` read back from the TypeId — ns-3's default congestion control has changed across releases, so a cell that doesn't record it isn't reproducible against a future image.

An unrecognised `--transport` **aborts** rather than defaulting to `udp`: a typo would otherwise produce a UDP run labelled as a TCP one, the least detectable failure this arm has.

## Verification

**No local ns-3 build**, so CI's five-version matrix is the first compile. A cheap `runs=2`/`time=300` probe follows before any campaign — that step is what caught the Gauss-Markov SIGABRT (#375) which CI structurally could not.

**61** scenario-check cases pass (two new: the saturating-arm WARN must fire, and must stay silent on the `udp` default). `ruff`, `check-links`, `check-mermaid`, `check-headers` clean. `udp` untouched → no published number moves, no A/B applies.

Refs #63, #295, #212, #56, #55, #369, #229, #230

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_