### PR TITLE
fix(bench): reorder columns must be absent under TCP, not zero

### DIFF
--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -2693,13 +2693,24 @@ int main(int argc, char* argv[]) {
     // five columns by name. Expect ~0 for AODV/OLSR/DSDV and for AntHocNet with
     // EnableMultipath=false; a non-zero AntHocNet figure is the stochastic
     // multipath working as designed, not a fault (docs/benchmarks/metrics.md).
-    for (std::size_t i = 0; i < list.size(); ++i) {
-        std::cout << std::fixed << "# reorder " << list[i]
-                  << " ratio=" << std::setprecision(4) << agg[i].reordRatio
-                  << " ratioWorstFlow=" << std::setprecision(4) << agg[i].reordRatioMax
-                  << " extentMean=" << std::setprecision(2) << agg[i].reordExtMean
-                  << " extentMax=" << std::setprecision(2) << agg[i].reordExtMax
-                  << " bufMax=" << std::setprecision(2) << agg[i].reordBufMax << "\n";
+    //
+    // #63: NOT emitted at all under TCP. RecordRxSeq is deliberately not
+    // connected there (a SeqTsSizeHeader cannot be parsed off a byte stream),
+    // so these accumulators never receive a sample and the line would print
+    // all-zeros — asserting "no reordering occurred" when the truth is "nobody
+    // measured". That is precisely the claim ##HOLD## and ##AIR## refuse to
+    // make, and a probe caught this printing 0.0000 on a TCP cell after the
+    // hook was already correctly skipped: disconnecting the source is only
+    // half of encoding absence, the emission has to go too.
+    if (P.transport != "tcp") {
+        for (std::size_t i = 0; i < list.size(); ++i) {
+            std::cout << std::fixed << "# reorder " << list[i]
+                      << " ratio=" << std::setprecision(4) << agg[i].reordRatio
+                      << " ratioWorstFlow=" << std::setprecision(4) << agg[i].reordRatioMax
+                      << " extentMean=" << std::setprecision(2) << agg[i].reordExtMean
+                      << " extentMax=" << std::setprecision(2) << agg[i].reordExtMax
+                      << " bufMax=" << std::setprecision(2) << agg[i].reordBufMax << "\n";
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Corrects a false claim I shipped in #381.

## What was wrong

#381 disconnected `RecordRxSeq` under TCP — correctly, since a `SeqTsSizeHeader` cannot be parsed off a byte stream — and both its commit message and `docs/benchmarks/metrics.md` stated the reorder columns therefore *"read as **absent** rather than zero"*.

**That was false as merged.** The `# reorder` line is emitted by an *unconditional* loop at the end of `main()`, independent of whether anything fed the accumulators. With the hook disconnected they stay at their initial values, so the probe printed:

```
# reorder anthocnet ratio=0.0000 ratioWorstFlow=0.0000 extentMean=0.00 extentMax=0.00 bufMax=0.00
# reorder aodv      ratio=0.0000 ratioWorstFlow=0.0000 extentMean=0.00 extentMax=0.00 bufMax=0.00
```

A zero there asserts **"no reordering occurred."** The truth is **"nobody measured."** And on the TCP arm specifically — where reordering is the mechanism under study and is *expected* to be non-zero — a confident `0.0000` is the most misleading output the harness could produce. It is exactly the claim `##HOLD##` and `##AIR##` exist to refuse.

## The fix

Skip the emission under TCP, so absence is the encoding and the code matches what the docs already say.

The general lesson, recorded in the comment: **disconnecting the source is only half of encoding absence — the emission has to go too.**

## How it was caught

The `runs=2`/`time=300` probe ([run 31270360458](https://github.com/danieljoppi/AntHocNet/actions/runs/31270360458)), pre-registered on #63 with *"reorder columns present on the TCP cell → treat as a defect, not data"*.

**CI could not have caught this.** It compiled the arm on five ns-3 versions and every check passed — the defect is in what a *successful* run prints. This is the third time the cheap-probe step has paid for itself (after the Gauss-Markov `SIGABRT` in #375 and the fading drop-attribution break in #377).

## The probe's other gates passed

- **`##GOODPUT##` 1004.99–1275.90 kbps** against the UDP arm's ~6.4 kbps `thrput` — `BulkSend` is genuinely saturating, so the arm is not silently reproducing the load-matched design I rejected.
- **`##CONFIG##`** carries `transport=tcp` and the congestion-control variant.

That variant read **`ns3::TcpCubic`**, not the NewReno my #63 design note assumed. Nothing depended on the assumption, but it is a concrete case of the marker earning its place: an unrecorded default would have made the arm irreproducible against a future image with nobody noticing.

Also visible in the probe, and consistent with the predicted metric shifts: `thrput` 1330.06 vs goodput ~1204.7 (the gap is retransmitted bytes), and `nrl` collapsing to 1.21/1.65 from the UDP arm's ~35/64 as the delivered-packet denominator inflates. Both are why `##GOODPUT##` is the TCP headline. **Nothing from a 2-run probe is quotable.**

## Verification

61 scenario-check cases pass, `ruff` and doc gates clean. CI's matrix is the first compile, as always. UDP output is unchanged.

Refs #63, #381, #212, #230, #375, #377

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_