### PR TITLE
feat(bench): emit the raw drop-identity counters to test #377's mechanism

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -103,6 +103,13 @@ DIAG_LINE = re.compile(r"^\s*#\s+(paths|energy|drops|reorder)\s+([a-z][\w-]*)\s+
 # Only the commit is matched here — it is the field whose absence makes a cell
 # unreproducible, and the rest are context a human reads off the same line.
 PROV_LINE = re.compile(r"^\s*##PROV##\s+commit=([0-9a-fA-F]{7,40})\b")
+# #377: raw drop-identity counters, one row per (seed, protocol).
+#   ##DROPID## <seed> <proto> hopTx=.. ... overlap=.. unackedRx=..
+# Only the two derived fields are matched: `overlap > 0` is the defect
+# condition, and `unackedRx` is what discriminates its cause.
+DROPID_LINE = re.compile(
+    r"^\s*##DROPID##\s+(\d+)\s+([a-z][\w-]*)\s+.*\boverlap=(-?\d+)\b"
+    r".*\bunackedRx=(-?\d+)\b")
 # #308 phase 2: the per-run common-set rows. Unlike the diagnostic lines above
 # there is one per (run, protocol), so they are folded into the protocol's row
 # as an extremum rather than merged field-by-field — the rules below ask "did
@@ -558,11 +565,61 @@ def check_provenance(path):
                    "unknown.")
 
 
+def check_drop_identity(path):
+    """#377: the drop-cause books must not overlap.
+
+    `drop_chan_pct` is a residual — hopLoss minus the counted causes — so it is
+    only non-negative while those causes are a subset of hopLoss. `overlap > 0`
+    on a ##DROPID## row means they are not, and every percentage in the
+    `drop_*` family for that cell is then an attribution of packets to causes
+    that double-count each other.
+
+    The existing rule catches this from the other side (drop_chan_pct outside
+    [0,100]), but only in aggregate and only once the percentages exist. Here
+    it is per seed, in counts, and it also reports `unackedRx` — the
+    delivered-but-ACK-lost count — because that is what says whether the
+    overlap has the hypothesised cause or another one.
+
+    WARN, not FAIL: the headline metrics (pdr/delay/delay99/thrput/nrl) come
+    from FlowMonitor and never touch these counters, so a cell with an overlap
+    is still readable for everything except the drop family. Failing it would
+    block reads that are perfectly sound.
+    """
+    with open(path) as fh:
+        text = fh.read()
+    if "##DROPID##" not in text:
+        return
+    worst = {}
+    for line in text.splitlines():
+        m = DROPID_LINE.match(line)
+        if not m:
+            continue
+        seed, proto, overlap, unacked = m.group(1), m.group(2), int(m.group(3)), int(m.group(4))
+        if overlap <= 0:
+            continue
+        # Report the worst seed per protocol rather than one line per seed: a
+        # 20-seed fading cell would otherwise emit 80 identical warnings and
+        # bury every other finding in the run.
+        if proto not in worst or overlap > worst[proto][1]:
+            worst[proto] = (seed, overlap, unacked)
+    base = os.path.basename(path)
+    for proto, (seed, overlap, unacked) in sorted(worst.items()):
+        report("WARN", f"{base}/{proto}: drop-cause books overlap by {overlap} "
+                       f"packets at seed {seed} (unackedRx={unacked}) — "
+                       "drop_chan_pct is a residual and goes negative here, so "
+                       "the whole drop_* family is unreadable for this cell "
+                       "(#377). pdr/delay/delay99/thrput/nrl are unaffected. "
+                       "unackedRx of the same order supports the "
+                       "delivered-but-ACK-lost mechanism; unackedRx near zero "
+                       "refutes it and the cause is something else.")
+
+
 def cmd_results(a):
     floor = anchor_floor(a.anchor) if a.anchor else None
     n = 0
     for path in a.files:
         check_provenance(path)
+        check_drop_identity(path)
         for r in parse_results(path):
             n += 1
             tag = f"{r['where']}/{r['proto']}"

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -983,6 +983,56 @@ def _prov_csv_exempt():
            f"CSV input warned about a marker it is not supposed to carry\n{out}")
 
 
+# --- #377 drop-identity overlap ----------------------------------------------
+# Numbers taken from the shape of the reported failure: the rwp x nakagami
+# anthocnet cell reads drop_chan_pct -13.77 on ~20 000 offered packets, i.e. an
+# overlap of a couple of thousand packets, against a clean two-ray cell.
+
+DROPID_CLEAN = ("##DROPID## 1 aodv hopTx=52000 hopRx=50000 ackedHops=50000 "
+                "macDrops=1800 reinjected=0 macTerminal=1800 queue=200 "
+                "hopLoss=2000 overlap=0 unackedRx=0\n")
+DROPID_OVERLAP = ("##DROPID## 3 anthocnet hopTx=52000 hopRx=51000 "
+                  "ackedHops=48250 macDrops=3750 reinjected=0 "
+                  "macTerminal=3750 queue=0 hopLoss=1000 overlap=2750 "
+                  "unackedRx=2750\n")
+
+
+@case("#377 a ##DROPID## row with overlap>0 WARNs and names both figures")
+def _dropid_overlap_fires():
+    _levels, out = run_cell(ISL_CELL + DROPID_OVERLAP)
+    expect("drop-cause books overlap by 2750" in out, "dropid-overlap",
+           f"positive overlap not flagged\n{out}")
+    expect("unackedRx=2750" in out, "dropid-unacked",
+           f"the discriminating figure was not reported alongside it\n{out}")
+
+
+@case("#377 a ##DROPID## row with overlap=0 stays quiet")
+def _dropid_clean_quiet():
+    _levels, out = run_cell(ISL_CELL + DROPID_CLEAN)
+    expect("drop-cause books overlap" not in out, "dropid-clean",
+           f"a clean drop identity was flagged\n{out}")
+
+
+@case("#377 one warning per protocol, not per seed")
+def _dropid_worst_per_proto():
+    # Twenty seeds of the same broken cell must not bury every other finding.
+    rows = "".join(DROPID_OVERLAP.replace("##DROPID## 3 ", f"##DROPID## {s} ")
+                   for s in range(1, 21))
+    _levels, out = run_cell(ISL_CELL + rows)
+    expect(out.count("drop-cause books overlap") == 1, "dropid-once",
+           f"expected one warning for the protocol, got "
+           f"{out.count('drop-cause books overlap')}\n{out}")
+
+
+@case("#377 a cell with no ##DROPID## rows is not flagged")
+def _dropid_absent_quiet():
+    # TCP cells and every pre-#377 run carry no such row; absence is not a
+    # failure, it is the marker not existing yet.
+    _levels, out = run_cell(ISL_CELL)
+    expect("drop-cause books overlap" not in out, "dropid-absent",
+           f"absent counters were treated as a defect\n{out}")
+
+
 def main():
     for name, fn in CASES:
         fn()

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -287,6 +287,15 @@ jobs:
           # would be a cell with no readable primary metric at all.
           grep '^##GOODPUT##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #377: the raw counters behind the drop-cause residual, per seed.
+          # Added in the same commit that emits them, per the rule above. This
+          # marker exists to test one hypothesis about why drop_chan_pct goes
+          # negative on every fading cell, and a hypothesis that cannot be
+          # reached from the cheap tail cannot be tested at all — the whole
+          # point is a two-cell probe read from a log tail, not a campaign.
+          # Absent on a TCP cell by design (the counters are UDP-gated).
+          grep '^##DROPID##' "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
           # the *only* place the #209/#212/#215/#217 metric families appear in a
           # single-point run — the fixed-width table cannot carry them (its field

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -266,6 +266,53 @@ Two limits worth stating:
 - **It does not record the commit.** That is `##PROV##` below, and the split is
   not an oversight — see there.
 
+### Drop-identity counters (`##DROPID##`, #377, NS-3 only, UDP only)
+
+```
+##DROPID## <seed> <proto> hopTx=.. hopRx=.. ackedHops=.. macDrops=.. \
+           reinjected=.. macTerminal=.. queue=.. hopLoss=.. overlap=.. unackedRx=..
+```
+
+Not a metric — the **raw counters behind the drop-cause residual**, one row per
+seed per protocol, so the identity in
+[Where the drop-cause identity comes from](#where-the-drop-cause-identity-comes-from)
+can be audited in counts rather than in percentages.
+
+It exists because `drop_chan_pct` is *inferred, not measured*: it is
+`hopLoss − macDrops − queue`, which is only non-negative while the subtracted
+causes are a subset of `hopLoss`. On every Nakagami cell they are not, by up to
+20 pp ([#377](https://github.com/danieljoppi/AntHocNet/issues/377)). Percentages
+cannot say which of the three books is wrong; counts can.
+
+Two of the fields are derived and are the ones to read first:
+
+| field | definition | what a non-zero value means |
+|---|---|---|
+| `overlap` | `macTerminal + queue − hopLoss` | the subtracted causes exceed the pool they are carved from — the books provably overlap. Identically `−drop_chan_pct · tx / 100`. |
+| `unackedRx` | `hopRx − ackedHops` | frames that reached the next hop's IP layer without the sender recording an ACK — under 802.11, the delivered-but-ACK-lost case |
+
+The reason both are printed is that they test a specific hypothesis against each
+other. A delivered-but-ACK-lost frame is counted in `hopRx` (so it is *not* in
+`hopLoss`) and also in `macDrops` (the sender exhausts its retries), so each
+occurrence drives the residual negative by one. If that is the mechanism,
+`overlap` and `unackedRx` track each other on a fading channel and are both ≈ 0
+on two-ray, where reception is a deterministic function of distance and the
+joint event is near unreachable. **If `overlap` is large while `unackedRx` ≈ 0,
+the hypothesis is refuted** and something else double-counts — which is what
+the line is for.
+
+**Absent under TCP, not zero.** Every counter is gated on `IsDataIp`, which
+tests for UDP on the data port, so a TCP cell would print all zeros — reading
+as "no hops, no overlap, identity clean" when nothing was counted at all. Same
+rule as `##HOLD##`/`##AIR##`, and the same mistake #382 fixed for the reorder
+columns. (Note that `drop_mac_pct` and `drop_chan_pct` are structurally zero on
+a TCP cell for this same reason; that is a separate pre-existing gap, tracked
+on #63, not something this marker introduces.)
+
+`scenario_check.py results` WARNs when a cell carries `##DROPID##` rows with
+`overlap > 0`, naming both figures, so the condition is caught by the gate
+rather than by a human noticing a negative percentage.
+
 ### Measuring commit (`##PROV##`, #365)
 
 ```

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -269,6 +269,10 @@ void RecordRxSeq(Ptr<const Packet> p, const Address& from) {
 uint64_t g_dataHopTx = 0;
 uint64_t g_dataHopRx = 0;
 uint64_t g_macDataDrops = 0;  // data frames dropped at the MAC retry limit
+// #377: data frames the sender got an ACK for. Already counted for the #217
+// diversity windows; kept as a scalar too because the drop-cause identity
+// needs it. See the ##DROPID## emission for what it is used to test.
+uint64_t g_ackedDataHops = 0;
 
 // Is this a CBR *data* IP packet (as opposed to routing control)? Same test as
 // CountControlTx, from the other side.
@@ -587,6 +591,7 @@ void CountAckedDataHop(uint32_t node, Ptr<const AHN_WIFI_MPDU> mpdu) {
     if (pkt->PeekHeader(udp) == 0) return;
     // Data only: routing control is exactly what must NOT count as a used path.
     if (udp.GetDestinationPort() != kDataPort) return;
+    ++g_ackedDataHops;  // #377
     const uint64_t window =
         static_cast<uint64_t>(Simulator::Now().GetSeconds() / g_pathWindowS);
     if (window != g_divWindow) {
@@ -785,6 +790,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_rxDelayBySeq.clear();  // #308
     g_rxHopsBySeq.clear();   // #308 phase 2
     g_dataHopTx = g_dataHopRx = g_macDataDrops = 0;  // #215
+    g_ackedDataHops = 0;  // #377
     // #217
     g_hopSum = g_hopCount = 0;
     g_hopMax = 0;
@@ -1612,6 +1618,63 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         const uint64_t other = dropL3Total > dropRoute + dropTtl + dropQueue
             ? dropL3Total - dropRoute - dropTtl - dropQueue : 0;
         r.dropOtherPct = 100.0 * other / tx;
+        // #377: the raw counters behind the residual above, plus the two
+        // derived quantities that test *why* it goes negative under fading.
+        //
+        // dropChanPct is a residual, so it is only non-negative while the
+        // subtracted causes are a subset of hopLoss. On every Nakagami cell
+        // they are not, by up to 20 pp. Percentages cannot say which book is
+        // wrong, so the counters ship raw:
+        //
+        //   overlap    = macTerminal + queue - hopLoss
+        //                the amount by which the subtracted causes exceed the
+        //                pool they are carved from. Positive == the books
+        //                provably overlap; this is exactly -dropChanPct*tx/100.
+        //   unackedRx  = hopRx - ackedHops
+        //                frames that reached the next hop's IP layer without
+        //                the sender ever recording an ACK. Under 802.11 that
+        //                is the delivered-but-ACK-lost case: the receiver has
+        //                the packet (so it is NOT in hopLoss) while the sender
+        //                retries and eventually reports a retry-limit drop (so
+        //                it IS in macTerminal). Counted once each way, it
+        //                drives the residual negative by one per occurrence.
+        //
+        // The hypothesis under test is that these two track each other on a
+        // fading channel and are both ~0 on two-ray, where reception is a
+        // deterministic function of distance and data-received-but-ACK-lost is
+        // near unreachable. If unackedRx is ~0 while overlap is large, the
+        // hypothesis is refuted and something else double-counts — which is
+        // the outcome this line exists to be able to see.
+        // Signed integers, not doubles: every field is a difference of exact
+        // counters, and printing them through the shared std::cout would
+        // otherwise need a precision change that leaks into every line after
+        // it.
+        const int64_t hopLossN = static_cast<int64_t>(g_dataHopTx)
+                               - static_cast<int64_t>(g_dataHopRx);
+        const int64_t overlap = static_cast<int64_t>(macTerminal)
+                              + static_cast<int64_t>(dropQueue) - hopLossN;
+        const int64_t unackedRx = static_cast<int64_t>(g_dataHopRx)
+                                - static_cast<int64_t>(g_ackedDataHops);
+        // Not emitted under TCP. Every counter above is gated on IsDataIp,
+        // which tests for UDP on the data port, so on a TCP cell they are all
+        // structurally zero — and a zero here would read as "hopTx=0, no
+        // overlap, identity clean" when the truth is that nothing was counted.
+        // Same rule as ##HOLD##/##AIR## and the same mistake #382 fixed for the
+        // reorder columns: suppressing the source is only half of encoding
+        // absence, the emission has to go too.
+        if (P.transport != "tcp") {
+            std::cout << "##DROPID## " << seed << ' ' << proto
+                      << " hopTx=" << g_dataHopTx
+                      << " hopRx=" << g_dataHopRx
+                      << " ackedHops=" << g_ackedDataHops
+                      << " macDrops=" << g_macDataDrops
+                      << " reinjected=" << reinjected
+                      << " macTerminal=" << macTerminal
+                      << " queue=" << dropQueue
+                      << " hopLoss=" << hopLossN
+                      << " overlap=" << overlap
+                      << " unackedRx=" << unackedRx << '\n';
+        }
     }
 
     // #217 route quality.


### PR DESCRIPTION
Instrumentation for [#377](https://github.com/danieljoppi/AntHocNet/issues/377) — `drop_chan_pct` goes negative on every Nakagami cell, for every protocol, with ~20 pp unaccounted, while the matched two-ray cells are clean. This ships what is needed to test **why**, before any remedy is chosen. It fixes nothing yet, by design.

The full derivation is on [#377](https://github.com/danieljoppi/AntHocNet/issues/377#issuecomment-5228858841); the short version is below.

## The mechanism this probe exists to check

`drop_chan_pct` is inferred, not measured:

```
hopLoss     = g_dataHopTx - g_dataHopRx
dropChanPct = 100 * (hopLoss - g_macDataDrops - dropQueue) / tx
```

Non-negative only while the subtracted causes are a **subset** of `hopLoss`. 802.11 unicast is data → ACK — two transmissions, two independent chances to fail — and one joint outcome breaks that:

| event | `hopTx` | `hopRx` | `macDrops` |
|---|---|---|---|
| data arrives, surfaces at the peer's IP layer | +1 | +1 | — |
| ACK lost; sender retries; peer discards the duplicate | — | — | — |
| retries exhausted, sender gives up | — | — | **+1** |

Contribution to `hopLoss`: **0**. Contribution to `macDrops`: **+1**. Subtracting one from the other drives the residual negative by one packet — and the packet was *delivered*, so it is not a drop at all.

This predicts every feature of the report:

- **Fading-only.** Under range/two-ray, reception is a deterministic function of distance, so data-received-but-ACK-lost is near unreachable. The residual has always been non-negative there *by luck of the channel model, not by construction*. Under Nakagami each frame's fade is independent, data and ACK success decorrelate, and the joint event becomes common.
- **Every protocol.** The arithmetic is in shared harness code above the routing layer, which is why AODV (−5.0…−5.6) and OLSR (−7.4…−7.6) go negative alongside AntHocNet (−13.8).
- **Magnitude.** A few percent of unicast frames at tens of thousands of hops is tens of pp.

## What ships

```
##DROPID## <seed> <proto> hopTx=.. hopRx=.. ackedHops=.. macDrops=.. \
           reinjected=.. macTerminal=.. queue=.. hopLoss=.. overlap=.. unackedRx=..
```

Per seed, per protocol, **in counts** — percentages cannot say which of the three books is wrong. Two derived fields carry the test:

| field | definition | reads as |
|---|---|---|
| `overlap` | `macTerminal + queue − hopLoss` | the books provably overlap. Identically `−drop_chan_pct·tx/100`. |
| `unackedRx` | `hopRx − ackedHops` | delivered-but-ACK-lost |

`ackedHops` costs nothing new: the `AckedMpdu` trace was already connected for the #217 diversity windows and already filters to data packets. Only a scalar tally is added beside the existing per-window bookkeeping.

## Refutation conditions, stated before the probe runs

1. `overlap > 0` on Nakagami but `unackedRx ≈ 0` → **hypothesis dead**, regardless of how well it fits; something else double-counts.
2. `overlap ≈ 0` while `drop_chan_pct` is still negative → my reading of which terms cancel is wrong; re-derive before proposing anything.
3. `overlap > 0` on the **two-ray control** → not channel-dependent at all, and the published two-ray drop columns become suspect. That is a materially worse finding than the one on the table.

## Absent under TCP, not zero

Every counter is gated on `IsDataIp`, which tests for UDP on the data port, so a TCP cell would print all zeros — reading as *"no hops, no overlap, identity clean"* when nothing was counted. Same rule as `##HOLD##`/`##AIR##`, and the same defect #382 fixed for the reorder columns: **suppressing the source is only half of encoding absence, the emission has to go too.** So the emission is guarded, not just the counters.

**Noted, not fixed here:** `drop_mac_pct` and `drop_chan_pct` are structurally zero on a TCP cell for this same `IsDataIp` reason, and unlike the reorder columns they are *still emitted*. That is a pre-existing gap in the TCP arm rather than something this marker introduces — it belongs to #63 and is reported there rather than repaired inside a probe commit. It matters right now because a TCP campaign is in flight.

## A gate that can fire

Per the #229/#230 rule, `scenario_check.py results` WARNs when any `##DROPID##` row has `overlap > 0`, naming both the overlap and `unackedRx` so the discriminator is in the warning rather than in a follow-up read.

- **WARN, not FAIL.** `pdr`/`delay`/`delay99`/`thrput`/`nrl` come from FlowMonitor and never touch these counters, so such a cell stays readable for everything except the drop family. Failing would block sound reads.
- **One warning per protocol, not per seed.** A 20-seed fading cell would otherwise emit 80 identical lines and bury every other finding.

Four cases in `test_scenario_check.py` (65 → 69): fires on overlap and names both figures; stays quiet at `overlap=0`; collapses 20 seeds to one warning; treats an absent marker as absence, not a defect.

Per the standing rule, `##DROPID##` is added to `paper-benchmark.yml`'s compact re-emit grep **in this same commit** — the probe is meant to be read from a cheap log tail, and a marker that cannot be reached from one cannot be tested.

## Verification

| gate | result |
|---|---|
| `ruff check ns3/tools docs/tools .claude/skills/benchmark-results/` | All checks passed |
| `test_scenario_check.py` | 69 cases passed |
| `test_stats.py` | 25 cases passed |
| `check-links.py .` | 71 files, 0 problems |
| `check-headers.py .` | 86 files, 0 problems |

**Not verifiable here:** no local ns-3 build, so CI's five-version matrix (3.36/3.41/3.42/3.47/3.48) is the first compile. The emission is on the UDP path only and purely additive — it cannot change any measured value.

## Next

Once merged: a two-cell probe at `runs=2`, `time=300`, `-opt` — `rwp × nakagami` and `rwp × tworay` — read against the refutation conditions above and reported on #377 either way. Two cells, because a Nakagami number with no matched control proves nothing here.

Refs #377, #215, #229, #230, #217, #382, #63, #60

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_