### PR TITLE
fix(bench): the drop-identity overlap must use macDrops, not macTerminal

### DIFF
--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -1024,6 +1024,21 @@ def _dropid_worst_per_proto():
            f"{out.count('drop-cause books overlap')}\n{out}")
 
 
+@case("#377 an AntHocNet row is judged on macDrops, not macTerminal")
+def _dropid_reinject_arm():
+    # Verbatim from probe run 31286508174 (rwp x nakagami), except hopLoss is
+    # lowered by 10 so the true residual goes negative. The re-injection gap is
+    # what matters: macDrops=475 against macTerminal=9. Reading macTerminal
+    # would report overlap -459 and stay silent on the very arm #377 reports
+    # the worst drop_chan_pct for; reading macDrops reports +7 and fires.
+    row = ("##DROPID## 1 anthocnet hopTx=4584 hopRx=4106 ackedHops=3789 "
+           "macDrops=475 reinjected=466 macTerminal=9 queue=0 hopLoss=468 "
+           "overlap=7 unackedRx=317\n")
+    _levels, out = run_cell(ISL_CELL + row)
+    expect("drop-cause books overlap by 7" in out, "dropid-reinject",
+           f"the re-injecting arm was not judged on the raw MAC-drop count\n{out}")
+
+
 @case("#377 a cell with no ##DROPID## rows is not flagged")
 def _dropid_absent_quiet():
     # TCP cells and every pre-#377 run carry no such row; absence is not a

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -288,8 +288,21 @@ Two of the fields are derived and are the ones to read first:
 
 | field | definition | what a non-zero value means |
 |---|---|---|
-| `overlap` | `macTerminal + queue − hopLoss` | the subtracted causes exceed the pool they are carved from — the books provably overlap. Identically `−drop_chan_pct · tx / 100`. |
+| `overlap` | `macDrops + queue − hopLoss` | the subtracted causes exceed the pool they are carved from — the books provably overlap. Identically `−drop_chan_pct · tx / 100`. |
 | `unackedRx` | `hopRx − ackedHops` | frames that reached the next hop's IP layer without the sender recording an ACK — under 802.11, the delivered-but-ACK-lost case |
+
+**`macDrops`, not `macTerminal`, in `overlap`** — and the distinction is not
+pedantic. They are equal for the stock baselines, which never re-inject, and
+differ by two orders of magnitude for AntHocNet, whose
+[#46](https://github.com/danieljoppi/AntHocNet/issues/46) detector re-injects
+most MAC failures: probe run
+[31286508174](https://github.com/danieljoppi/AntHocNet/actions/runs/31286508174)
+reads `macDrops=475 reinjected=466 macTerminal=9`. `drop_chan_pct` subtracts the
+*raw* count — a re-injected packet is not a terminal drop, but its hop
+transmission did fail, so it belongs in the hop accounting — so `overlap` must
+mirror that or it is not the residual it claims to be. The first cut of this
+marker used `macTerminal` and reported `-469` for a cell whose true figure is
+`-3`, which left the gate blind to the AntHocNet arm.
 
 The reason both are printed is that they test a specific hypothesis against each
 other. A delivered-but-ACK-lost frame is counted in `hopRx` (so it is *not* in

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -1626,10 +1626,22 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         // they are not, by up to 20 pp. Percentages cannot say which book is
         // wrong, so the counters ship raw:
         //
-        //   overlap    = macTerminal + queue - hopLoss
+        //   overlap    = macDrops + queue - hopLoss
         //                the amount by which the subtracted causes exceed the
         //                pool they are carved from. Positive == the books
         //                provably overlap; this is exactly -dropChanPct*tx/100.
+        //
+        // `macDrops`, NOT `macTerminal`. The two are the same for the stock
+        // baselines and differ by two orders of magnitude for AntHocNet, whose
+        // #46 detector re-injects most MAC failures (probe run 31286508174:
+        // macDrops=475, reinjected=466, macTerminal=9). dropChanPct subtracts
+        // the *raw* g_macDataDrops -- a re-injected packet is not a terminal
+        // drop, but its hop transmission did fail, so it belongs in the hop
+        // accounting -- and this line has to mirror that or it is not the
+        // residual it claims to be. The first cut used macTerminal and read
+        // -469 where the true figure is -3, which would have left the gate
+        // below blind to the AntHocNet arm: the very arm with the worst
+        // reported drop_chan_pct (-13.77) on #377.
         //   unackedRx  = hopRx - ackedHops
         //                frames that reached the next hop's IP layer without
         //                the sender ever recording an ACK. Under 802.11 that
@@ -1651,7 +1663,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         // it.
         const int64_t hopLossN = static_cast<int64_t>(g_dataHopTx)
                                - static_cast<int64_t>(g_dataHopRx);
-        const int64_t overlap = static_cast<int64_t>(macTerminal)
+        const int64_t overlap = static_cast<int64_t>(g_macDataDrops)
                               + static_cast<int64_t>(dropQueue) - hopLossN;
         const int64_t unackedRx = static_cast<int64_t>(g_dataHopRx)
                                 - static_cast<int64_t>(g_ackedDataHops);


### PR DESCRIPTION
The first #377 probe came back with numbers that **do not agree with themselves**, and the disagreement is in the marker I shipped one PR ago ([#384](https://github.com/danieljoppi/AntHocNet/pull/384)) rather than in the harness it was built to audit.

## The bug

`##DROPID##` printed

```
overlap = macTerminal + queue - hopLoss
```

documented as *"exactly `−dropChanPct·tx/100`"*. It is not, because `dropChanPct` subtracts the **raw** `g_macDataDrops`:

```cpp
r.dropChanPct = 100.0 * (hopLoss - static_cast<double>(g_macDataDrops)
                                 - static_cast<double>(dropQueue)) / tx;
```

and `macTerminal` is `g_macDataDrops` minus the packets AntHocNet's #46 detector re-injected. For the stock baselines the two coincide (`reinjected = 0`). For AntHocNet they do not, by two orders of magnitude — probe seed 1 reads `macDrops=475 reinjected=466 macTerminal=9`.

## How the probe caught it

Recovering the implied offered-packet count from each protocol's reported `chan%` against each candidate residual, on the `rwp × nakagami` cell (run [31286508174](https://github.com/danieljoppi/AntHocNet/actions/runs/31286508174)):

| cell/proto | residual (macDrops) | −overlap (macTerminal) | `chan%` | implied `tx` |
|---|---:|---:|---:|---:|
| nakagami/anthocnet | **25.5** | 602.5 | 1.18 | **2161** |
| nakagami/aodv | 271.5 | 271.5 | 12.55 | 2163 |
| nakagami/olsr | 101.5 | 101.5 | 4.83 | 2101 |
| nakagami/dsdv | 332.5 | 332.5 | 15.38 | 2162 |

Only the `macDrops`-based residual puts AntHocNet's implied `tx` (2161) alongside the other three protocols measured in the same cell. The `macTerminal` figure is off by **24×**.

So the shipped `overlap` was wrong on exactly one arm — **AntHocNet**, the arm #377 reports the worst `drop_chan_pct` for (−13.77). The gate rule keyed on `overlap > 0` would have stayed silent on precisely the arm it exists to watch.

This is the marker's own control catching it: three protocols agreeing on an implied `tx` and one disagreeing by 24× is a self-inconsistency that no amount of reading the code was going to surface. It cost one 8-minute probe.

## The fix

One term. `macTerminal` stays in the emitted line — it is what `drop_mac_pct` reports and is worth seeing — but it is not the term the residual subtracts.

A test pins it, taken verbatim from the probe row with `hopLoss` lowered by 10 so the true residual goes negative:

| read | overlap | gate |
|---|---:|---|
| `macTerminal` (old) | −459 | silent |
| `macDrops` (fixed) | **+7** | fires |

69 → 70 cases. `docs/benchmarks/metrics.md` carried the same wrong identity and is corrected, with the concrete numbers so the next reader does not have to re-derive why the distinction matters.

## Nothing measured changes

`overlap` is a derived diagnostic printed alongside the raw counters. **Every raw counter in the line was and remains correct** — a reader holding the old log lines can recompute the right figure as `macDrops + queue − hopLoss` from fields already printed. No protocol behaviour, no CSV column, no published number is touched.

## Verification

| gate | result |
|---|---|
| `test_scenario_check.py` | 70 cases passed |
| `ruff check ns3/tools docs/tools .claude/skills/benchmark-results/` | All checks passed |
| `check-links.py .` | 71 files, 0 problems |
| implied-`tx` cross-check | recomputed from the probe log; only `macDrops` is consistent across the four protocols |

**Not verifiable here:** no local ns-3 build; CI's five-version matrix is the first compile.

The #377 verdict itself — what the probe says about the ACK-decorrelation hypothesis, and what it does *not* say — is posted on the issue rather than here.

Refs #377, #384, #46, #215

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_