### PR TITLE
fix(bench): carve genuine losses out of the drop residual, not raw MAC drops

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -574,6 +574,13 @@ def check_drop_identity(path):
     `drop_*` family for that cell is then an attribution of packets to causes
     that double-count each other.
 
+    Since the residual carves out `macLost` (retry-limit drops minus the
+    delivered-but-ACK-lost ones) rather than the raw MAC-drop count, `overlap`
+    can no longer go positive for the reason #377 reported — `macLost` is a
+    subset of hopLoss by construction. The rule is kept anyway, and that is
+    deliberate: a positive value now means the books have overlapped for some
+    *other* reason, which is exactly the case nobody is watching for.
+
     The existing rule catches this from the other side (drop_chan_pct outside
     [0,100]), but only in aggregate and only once the percentages exist. Here
     it is per seed, in counts, and it also reports `unackedRx` — the

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -1024,19 +1024,41 @@ def _dropid_worst_per_proto():
            f"{out.count('drop-cause books overlap')}\n{out}")
 
 
-@case("#377 an AntHocNet row is judged on macDrops, not macTerminal")
+@case("#377 an AntHocNet row is judged on the same term the residual uses")
 def _dropid_reinject_arm():
-    # Verbatim from probe run 31286508174 (rwp x nakagami), except hopLoss is
-    # lowered by 10 so the true residual goes negative. The re-injection gap is
-    # what matters: macDrops=475 against macTerminal=9. Reading macTerminal
-    # would report overlap -459 and stay silent on the very arm #377 reports
-    # the worst drop_chan_pct for; reading macDrops reports +7 and fires.
+    # Shaped from probe run 31286508174 (rwp x nakagami) with hopLoss lowered
+    # so the residual goes negative. The re-injection gap is what matters:
+    # macDrops=475 against macTerminal=9. A rule keyed on macTerminal would
+    # report a large negative overlap and stay silent on the very arm #377
+    # reports the worst drop_chan_pct for.
     row = ("##DROPID## 1 anthocnet hopTx=4584 hopRx=4106 ackedHops=3789 "
-           "macDrops=475 reinjected=466 macTerminal=9 queue=0 hopLoss=468 "
-           "overlap=7 unackedRx=317\n")
+           "macDrops=475 reinjected=466 macTerminal=9 macLost=158 queue=0 "
+           "hopLoss=151 overlap=7 unackedRx=317\n")
     _levels, out = run_cell(ISL_CELL + row)
     expect("drop-cause books overlap by 7" in out, "dropid-reinject",
-           f"the re-injecting arm was not judged on the raw MAC-drop count\n{out}")
+           f"the re-injecting arm was not flagged\n{out}")
+
+
+@case("#377 the real 900 s Nakagami rows read clean once macLost is subtracted")
+def _dropid_corrected_residual_quiet():
+    # Verbatim counters from run 31288485211 seeds 1-2, the cell that reported
+    # drop_chan_pct -13.10 before the correction. overlap is recomputed as
+    # macLost + queue - hopLoss, which is <= 0 by construction because macLost
+    # is a subset of hopLoss. If a future change reverts the residual to the
+    # raw MAC-drop count these rows go positive again and this case fails.
+    rows = (
+        "##DROPID## 1 anthocnet hopTx=20571 hopRx=18761 ackedHops=17194 "
+        "macDrops=2738 reinjected=2698 macTerminal=40 macLost=1171 queue=0 "
+        "hopLoss=1810 overlap=-639 unackedRx=1567\n"
+        "##DROPID## 1 aodv hopTx=12721 hopRx=11387 ackedHops=10433 "
+        "macDrops=1899 reinjected=0 macTerminal=1899 macLost=945 queue=0 "
+        "hopLoss=1334 overlap=-389 unackedRx=954\n"
+        "##DROPID## 1 olsr hopTx=11762 hopRx=10862 ackedHops=9738 "
+        "macDrops=1554 reinjected=0 macTerminal=1554 macLost=430 queue=0 "
+        "hopLoss=900 overlap=-470 unackedRx=1124\n")
+    _levels, out = run_cell(ISL_CELL + rows)
+    expect("drop-cause books overlap" not in out, "dropid-corrected",
+           f"the corrected residual was still flagged as overlapping\n{out}")
 
 
 @case("#377 a cell with no ##DROPID## rows is not flagged")

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -270,7 +270,8 @@ Two limits worth stating:
 
 ```
 ##DROPID## <seed> <proto> hopTx=.. hopRx=.. ackedHops=.. macDrops=.. \
-           reinjected=.. macTerminal=.. queue=.. hopLoss=.. overlap=.. unackedRx=..
+           reinjected=.. macTerminal=.. macLost=.. queue=.. hopLoss=.. \
+           overlap=.. unackedRx=..
 ```
 
 Not a metric — the **raw counters behind the drop-cause residual**, one row per
@@ -278,41 +279,69 @@ seed per protocol, so the identity in
 [Where the drop-cause identity comes from](#where-the-drop-cause-identity-comes-from)
 can be audited in counts rather than in percentages.
 
-It exists because `drop_chan_pct` is *inferred, not measured*: it is
-`hopLoss − macDrops − queue`, which is only non-negative while the subtracted
-causes are a subset of `hopLoss`. On every Nakagami cell they are not, by up to
-20 pp ([#377](https://github.com/danieljoppi/AntHocNet/issues/377)). Percentages
-cannot say which of the three books is wrong; counts can.
+`drop_chan_pct` is *inferred, not measured* — it is what is left of `hopLoss`
+after the counted causes are removed — so it is only non-negative while those
+causes are genuinely a subset of `hopLoss`. They were not, and the failure was
+large: on every Nakagami cell the residual ran negative, to −13.10 % with 19.85
+pp unaccounted ([#377](https://github.com/danieljoppi/AntHocNet/issues/377)).
 
-Two of the fields are derived and are the ones to read first:
+### Why a retry-limit drop is not a lost packet
 
-| field | definition | what a non-zero value means |
+802.11 unicast is data → ACK: two transmissions, two independent chances to
+fail. The joint outcome that breaks the subset property is **data delivered,
+ACK lost**:
+
+| event | `hopTx` | `hopRx` | `macDrops` |
+|---|---|---|---|
+| data arrives, surfaces at the peer's IP layer | +1 | +1 | — |
+| ACK lost; sender retries; peer discards the duplicate | — | — | — |
+| retries exhausted, sender gives up | — | — | **+1** |
+
+Contribution to `hopLoss`: **zero**. Contribution to `macDrops`: **one**. Each
+occurrence drives the residual negative by one packet — and the packet was
+*delivered*, so it is not a drop at all.
+
+That is why the fields below exist, and why `macLost` rather than `macDrops` is
+what the residual subtracts:
+
+| field | definition | reads as |
 |---|---|---|
-| `overlap` | `macDrops + queue − hopLoss` | the subtracted causes exceed the pool they are carved from — the books provably overlap. Identically `−drop_chan_pct · tx / 100`. |
-| `unackedRx` | `hopRx − ackedHops` | frames that reached the next hop's IP layer without the sender recording an ACK — under 802.11, the delivered-but-ACK-lost case |
+| `unackedRx` | `hopRx − ackedHops` | frames that reached the next hop's IP layer with no ACK recorded at the sender — the delivered-but-ACK-lost count |
+| `macLost` | `macDrops − unackedRx` | retry-limit drops where the frame genuinely did **not** arrive. A subset of `hopLoss` **by construction**, so the residual cannot go negative for this reason |
+| `overlap` | `macLost + queue − hopLoss` | Identically `−drop_chan_pct · tx / 100`. Now ≤ 0 by construction; a positive value means the books overlap for some *other* reason, which is why the gate on it is kept |
 
-**`macDrops`, not `macTerminal`, in `overlap`** — and the distinction is not
-pedantic. They are equal for the stock baselines, which never re-inject, and
-differ by two orders of magnitude for AntHocNet, whose
-[#46](https://github.com/danieljoppi/AntHocNet/issues/46) detector re-injects
-most MAC failures: probe run
-[31286508174](https://github.com/danieljoppi/AntHocNet/actions/runs/31286508174)
-reads `macDrops=475 reinjected=466 macTerminal=9`. `drop_chan_pct` subtracts the
-*raw* count — a re-injected packet is not a terminal drop, but its hop
-transmission did fail, so it belongs in the hop accounting — so `overlap` must
-mirror that or it is not the residual it claims to be. The first cut of this
-marker used `macTerminal` and reported `-469` for a cell whose true figure is
-`-3`, which left the gate blind to the AntHocNet arm.
+**Which columns the correction touches.** `drop_chan_pct` always subtracts
+`macLost`. `drop_mac_pct` subtracts it **only where that column is
+`macDrops`-based** — i.e. where nothing was re-injected. AntHocNet's
+`drop_mac_pct` already reports `macTerminal`, with
+[#46](https://github.com/danieljoppi/AntHocNet/issues/46) re-injection removed,
+and correcting it a second time would double-count.
 
-The reason both are printed is that they test a specific hypothesis against each
-other. A delivered-but-ACK-lost frame is counted in `hopRx` (so it is *not* in
-`hopLoss`) and also in `macDrops` (the sender exhausts its retries), so each
-occurrence drives the residual negative by one. If that is the mechanism,
-`overlap` and `unackedRx` track each other on a fading channel and are both ≈ 0
-on two-ray, where reception is a deterministic function of distance and the
-joint event is near unreachable. **If `overlap` is large while `unackedRx` ≈ 0,
-the hypothesis is refuted** and something else double-counts — which is what
-the line is for.
+Measured at 900 s, 5 seeds, runs
+[31288485211](https://github.com/danieljoppi/AntHocNet/actions/runs/31288485211)
+(Nakagami) and
+[31288489422](https://github.com/danieljoppi/AntHocNet/actions/runs/31288489422)
+(two-ray):
+
+| cell | `unackedRx` per run | `drop_chan_pct` before → after | identity `sum` after |
+|---|---|---|---|
+| nakagami / aodv | 1028 | −6.04 → **+6.72** | 99.87 |
+| nakagami / olsr | 1155 | −7.95 → **+6.69** | 100.00 |
+| nakagami / dsdv | 1112 | +3.62 → +17.50 | 100.22 |
+| two-ray (all) | 0.2 – 8.8 | unchanged to ~0.1 pp | 99.91 – 100.02 |
+
+The three orders of magnitude between the channels is the point: `unackedRx` is
+a property of independent per-frame fading, so on two-ray — where reception is
+a deterministic function of distance — the correction is a no-op, exactly as it
+should be.
+
+**Not closed for AntHocNet.** Its arm lands at `sum` **101.41**, over by 1.41
+pp. `hopLoss` is a per-hop tally while the identity is end-to-end, and a packet
+whose hop failed, was re-injected by #46 and then arrived by another route
+contributes to the first but is not an end-to-end loss. Tracked on
+[#386](https://github.com/danieljoppi/AntHocNet/issues/386), which also reads
+`unackedRx` against `reinjected` to bound how many re-injections are of packets
+that had already arrived (≥ 58.8 % per run under fading).
 
 **Absent under TCP, not zero.** Every counter is gated on `IsDataIp`, which
 tests for UDP on the data port, so a TCP cell would print all zeros — reading

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -1606,11 +1606,38 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             g_macDataDrops > reinjected ? g_macDataDrops - reinjected : 0;
         const double hopLoss = static_cast<double>(g_dataHopTx)
                              - static_cast<double>(g_dataHopRx);
+        // #377: a retry-limit drop is not necessarily a lost packet. 802.11
+        // unicast is data then ACK, two independent chances to fail, and under
+        // fading the data frame can arrive while its ACK does not: the peer
+        // has the packet (so it is NOT in hopLoss) while the sender exhausts
+        // its retries (so it IS in g_macDataDrops). Subtracting the raw count
+        // from hopLoss therefore removes packets that were never in it, and
+        // the residual runs negative — measured at -13.10 % on a Nakagami cell
+        // (run 31288485211) against +1.88 % on the matched two-ray control.
+        //
+        // macLost is the genuinely-lost subset. It is a subset of hopLoss by
+        // construction — a frame that hit the retry limit and did not arrive
+        // is, definitionally, a hop that was sent and not received — so the
+        // residual below cannot go negative for the reason #377 reports.
+        // Verified against both probe cells: the identity closes to 99.87 /
+        // 100.00 / 100.22 for the three baselines and is a near no-op on
+        // two-ray, where unackedRx is 0-13 packets per run.
+        const uint64_t unackedRx = g_dataHopRx > g_ackedDataHops
+            ? g_dataHopRx - g_ackedDataHops : 0;
+        const uint64_t macLost =
+            g_macDataDrops > unackedRx ? g_macDataDrops - unackedRx : 0;
         r.dropRoutePct = 100.0 * dropRoute / tx;
         r.dropTtlPct   = 100.0 * dropTtl / tx;
         r.dropQueuePct = 100.0 * dropQueue / tx;
-        r.dropMacPct   = 100.0 * macTerminal / tx;
-        r.dropChanPct  = 100.0 * (hopLoss - static_cast<double>(g_macDataDrops)
+        // The correction applies to dropMacPct only where that column is
+        // macDrops-based, i.e. where nothing was re-injected. AntHocNet's is
+        // already macTerminal — #46 has removed the re-injected packets from
+        // it — and subtracting unackedRx again would correct it twice. Its
+        // arm keeps the hop-vs-terminal residue tracked on #386; the three
+        // baselines never re-inject, so macTerminal == g_macDataDrops there
+        // and macLost is the right replacement.
+        r.dropMacPct   = 100.0 * (reinjected ? macTerminal : macLost) / tx;
+        r.dropChanPct  = 100.0 * (hopLoss - static_cast<double>(macLost)
                                           - static_cast<double>(dropQueue)) / tx;
         // L3 drops in none of the buckets above (bad checksum, interface down,
         // fragment timeout — all structurally zero in this harness). Diagnostic
@@ -1618,55 +1645,47 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         const uint64_t other = dropL3Total > dropRoute + dropTtl + dropQueue
             ? dropL3Total - dropRoute - dropTtl - dropQueue : 0;
         r.dropOtherPct = 100.0 * other / tx;
-        // #377: the raw counters behind the residual above, plus the two
-        // derived quantities that test *why* it goes negative under fading.
+        // #377: the raw counters behind the residual above, so the attribution
+        // can be audited in counts rather than in percentages.
         //
-        // dropChanPct is a residual, so it is only non-negative while the
-        // subtracted causes are a subset of hopLoss. On every Nakagami cell
-        // they are not, by up to 20 pp. Percentages cannot say which book is
-        // wrong, so the counters ship raw:
-        //
-        //   overlap    = macDrops + queue - hopLoss
+        //   overlap    = macLost + queue - hopLoss
         //                the amount by which the subtracted causes exceed the
-        //                pool they are carved from. Positive == the books
-        //                provably overlap; this is exactly -dropChanPct*tx/100.
+        //                pool they are carved from. Exactly -dropChanPct*tx/100,
+        //                so it MUST track whatever that residual subtracts --
+        //                it has been wrong twice for failing to. It read
+        //                macTerminal first (24x off on the AntHocNet arm, whose
+        //                #46 detector re-injects nearly every MAC failure), then
+        //                the raw macDrops; both are superseded now that the
+        //                residual carves out only the genuinely-lost subset.
         //
-        // `macDrops`, NOT `macTerminal`. The two are the same for the stock
-        // baselines and differ by two orders of magnitude for AntHocNet, whose
-        // #46 detector re-injects most MAC failures (probe run 31286508174:
-        // macDrops=475, reinjected=466, macTerminal=9). dropChanPct subtracts
-        // the *raw* g_macDataDrops -- a re-injected packet is not a terminal
-        // drop, but its hop transmission did fail, so it belongs in the hop
-        // accounting -- and this line has to mirror that or it is not the
-        // residual it claims to be. The first cut used macTerminal and read
-        // -469 where the true figure is -3, which would have left the gate
-        // below blind to the AntHocNet arm: the very arm with the worst
-        // reported drop_chan_pct (-13.77) on #377.
+        //                With macLost a subset of hopLoss by construction, this
+        //                can no longer go positive for the #377 reason. The gate
+        //                on it is kept precisely so that if it ever does, the
+        //                books have overlapped for some *other* reason and that
+        //                is worth hearing about.
+        //
         //   unackedRx  = hopRx - ackedHops
-        //                frames that reached the next hop's IP layer without
-        //                the sender ever recording an ACK. Under 802.11 that
-        //                is the delivered-but-ACK-lost case: the receiver has
-        //                the packet (so it is NOT in hopLoss) while the sender
-        //                retries and eventually reports a retry-limit drop (so
-        //                it IS in macTerminal). Counted once each way, it
-        //                drives the residual negative by one per occurrence.
+        //                frames that reached the next hop's IP layer without the
+        //                sender ever recording an ACK -- the delivered-but-ACK-
+        //                lost case the correction above removes. Kept in the
+        //                line because it is the quantity that explains the
+        //                correction's size, and because #386 reads it against
+        //                `reinjected` to bound how many re-injections are of
+        //                packets that had already arrived (>=58.8% per run on
+        //                a Nakagami cell).
         //
-        // The hypothesis under test is that these two track each other on a
-        // fading channel and are both ~0 on two-ray, where reception is a
-        // deterministic function of distance and data-received-but-ACK-lost is
-        // near unreachable. If unackedRx is ~0 while overlap is large, the
-        // hypothesis is refuted and something else double-counts — which is
-        // the outcome this line exists to be able to see.
+        // Measured, both probe cells at 900 s: unackedRx is 1028-1719 per run
+        // under Nakagami and 0.2-8.8 under two-ray, three orders of magnitude
+        // apart on cells differing only in the fading model.
+        //
         // Signed integers, not doubles: every field is a difference of exact
         // counters, and printing them through the shared std::cout would
         // otherwise need a precision change that leaks into every line after
         // it.
         const int64_t hopLossN = static_cast<int64_t>(g_dataHopTx)
                                - static_cast<int64_t>(g_dataHopRx);
-        const int64_t overlap = static_cast<int64_t>(g_macDataDrops)
+        const int64_t overlap = static_cast<int64_t>(macLost)
                               + static_cast<int64_t>(dropQueue) - hopLossN;
-        const int64_t unackedRx = static_cast<int64_t>(g_dataHopRx)
-                                - static_cast<int64_t>(g_ackedDataHops);
         // Not emitted under TCP. Every counter above is gated on IsDataIp,
         // which tests for UDP on the data port, so on a TCP cell they are all
         // structurally zero — and a zero here would read as "hopTx=0, no
@@ -1682,6 +1701,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                       << " macDrops=" << g_macDataDrops
                       << " reinjected=" << reinjected
                       << " macTerminal=" << macTerminal
+                      << " macLost=" << macLost
                       << " queue=" << dropQueue
                       << " hopLoss=" << hopLossN
                       << " overlap=" << overlap


### PR DESCRIPTION
Implements the remedy that [#377's probe pair](https://github.com/danieljoppi/AntHocNet/issues/377#issuecomment-5229480475) established. The identity fails on every fading cell — `drop_chan_pct` reads **−13.10 %** with 19.85 pp unaccounted (run [31288485211](https://github.com/danieljoppi/AntHocNet/actions/runs/31288485211), 900 s, 5 seeds) against **+1.88 %** on the matched two-ray control.

## The cause

802.11 unicast is data → ACK: two transmissions, two independent chances to fail. One joint outcome breaks the accounting.

| event | `hopTx` | `hopRx` | `macDrops` |
|---|---|---|---|
| data arrives, surfaces at the peer's IP layer | +1 | +1 | — |
| ACK lost; sender retries; peer discards the duplicate | — | — | — |
| retries exhausted, sender gives up | — | — | **+1** |

Contribution to `hopLoss`: **zero**. To `macDrops`: **one**. Subtracting the raw count therefore removes packets that were never in `hopLoss` — and the packet was *delivered*, so it is not a drop at all.

Verified on all 35 probe rows with zero residual:

```
overlap = macDrops + queue − hopLoss = unackedRx − otherLoss
```

so the residual goes negative **exactly when** delivered-but-ACK-lost frames outnumber true channel losses. **DSDV under Nakagami is the confirming case**: its `unackedRx` is large (1112/run) yet its `chan` stays positive, because its `otherLoss` (1402) is larger still. A protocol escaping the defect in the same cell, same seeds, for the reason the identity predicts, is what makes this a mechanism rather than a fitted story.

## The fix

```
macLost = g_macDataDrops − unackedRx        // retry-limit drops that really did lose the frame
```

A frame that hit the retry limit and was not received is, definitionally, a hop that was sent and not received — so **`macLost` is a subset of `hopLoss` by construction** and the residual cannot go negative for this reason again. That is the improvement over the old arrangement, which was non-negative on the disk and two-ray channels *by luck of the channel model*, not by construction.

`drop_chan_pct` always subtracts `macLost`. `drop_mac_pct` subtracts it **only where that column is `macDrops`-based** (`reinjected == 0`). AntHocNet's already reports `macTerminal` with #46 re-injection removed; correcting it twice would move mass rather than fix it.

## Verification

Re-implementing the edited expressions against the recorded per-seed counters from both probe cells:

| cell / proto | `mac%` | `chan%` | `sum%` | `chan ≥ 0` |
|---|---:|---:|---:|:--:|
| nakagami / aodv | 13.23 | 6.72 | **99.87** | yes |
| nakagami / olsr | 5.23 | 6.69 | **100.00** | yes |
| nakagami / dsdv | 11.11 | 17.50 | **100.22** | yes |
| two-ray / aodv | 9.05 | 2.31 | 99.91 | yes |
| two-ray / olsr | 7.86 | 1.67 | 100.02 | yes |
| two-ray / dsdv | 12.66 | 2.66 | 100.02 | yes |

The two-ray rows are the control. `unackedRx` is 0.2–8.8 packets per run there, so the correction is a **no-op to ~0.1 pp** — which is what a correct fix looks like on a channel that cannot exercise the failure.

| gate | result |
|---|---|
| `test_scenario_check.py` | 71 cases passed |
| `test_stats.py` | 25 cases passed |
| `ruff check` | All checks passed |
| `check-links.py .` | 71 files, 0 problems |
| `check-headers.py .` | 86 files, 0 problems |
| `check-default-parity.py` | OK |

## Not closed for AntHocNet — stated, not papered over

Its arm lands at `sum` **101.41**, over by **1.41 pp**. `hopLoss` is a per-hop tally while the identity is end-to-end, and a packet whose hop failed, was re-injected by #46, then arrived by another route contributes to the first without being an end-to-end loss.

Tracked on [#386](https://github.com/danieljoppi/AntHocNet/issues/386), which bounds the scale of the interaction: **at least 58.8 % of re-injections per run are of packets that had already arrived.** The gate keeps flagging that arm until it is resolved. This PR does not claim to fix it.

## `##DROPID##` changes with the residual

The line gains `macLost`, and `overlap` is redefined to `macLost + queue − hopLoss` so it stays identically `−drop_chan_pct · tx / 100`.

That field has now been wrong **twice** for failing to track what the residual subtracts — `macTerminal` in #384, raw `macDrops` in #385. The comment says so explicitly, because the next person to change the residual has to change this too.

## Why the gate rule stays

`overlap` can no longer go positive for the #377 reason, so the rule could arguably be deleted. It is kept deliberately: a positive value now means the books overlap for some *other* reason — precisely the case nobody is watching for.

Two cases added (70 → 71): the re-injecting arm still fires, and the real 900 s Nakagami rows read clean under the corrected residual, so **a revert to the raw MAC-drop count fails the suite**.

**Not verifiable here:** no local ns-3, so CI's five-version matrix is the first compile. The arithmetic above was verified by re-implementing the edited expressions against recorded counters, not by running the simulator — the first real confirmation is a re-run of the two probe cells after merge.

Refs #377, #386, #385, #384, #215, #229, #46, #60

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_