### PR TITLE
feat(bench): widen the data-packet predicate to accept tcp on the data port

### DIFF
--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -52,6 +52,7 @@
 #include "ns3/flow-monitor-module.h"
 #include "ns3/ipv4-flow-classifier.h"
 #include "ns3/ipv4-l3-protocol.h"
+#include "ns3/tcp-header.h"
 #include "ns3/udp-header.h"
 // #212: the application-level sequence number the reordering metrics key on.
 // Part of the applications module (already included above) since ns-3.31, so it
@@ -280,6 +281,14 @@ bool IsDataIp(Ptr<const Packet> p) {
     Ptr<Packet> c = p->Copy();
     Ipv4Header ip;
     if (c->RemoveHeader(ip) == 0) return false;
+    if (ip.GetProtocol() == 6) {  // TCP (#389)
+        // Pure TCP ACKs are excluded naturally: on the reverse path the
+        // destination port is the sender's ephemeral port, so only forward
+        // data segments count — matching what the UDP arm counts.
+        TcpHeader tcp;
+        if (c->PeekHeader(tcp) == 0) return false;
+        return tcp.GetDestinationPort() == kDataPort;
+    }
     if (ip.GetProtocol() != 17) return false;  // not UDP
     UdpHeader udp;
     if (c->PeekHeader(udp) == 0) return false;
@@ -586,11 +595,20 @@ void CountAckedDataHop(uint32_t node, Ptr<const AHN_WIFI_MPDU> mpdu) {
     if (llc.GetType() != 0x0800) return;  // not IPv4
     Ipv4Header ip;
     if (pkt->RemoveHeader(ip) == 0) return;
-    if (ip.GetProtocol() != 17) return;  // not UDP; routing control here is UDP
-    UdpHeader udp;
-    if (pkt->PeekHeader(udp) == 0) return;
     // Data only: routing control is exactly what must NOT count as a used path.
-    if (udp.GetDestinationPort() != kDataPort) return;
+    // Routing control here is UDP, so a data-port TCP segment is by
+    // construction never control (#389).
+    if (ip.GetProtocol() == 6) {  // TCP
+        TcpHeader tcp;
+        if (pkt->PeekHeader(tcp) == 0) return;
+        if (tcp.GetDestinationPort() != kDataPort) return;
+    } else if (ip.GetProtocol() == 17) {  // UDP
+        UdpHeader udp;
+        if (pkt->PeekHeader(udp) == 0) return;
+        if (udp.GetDestinationPort() != kDataPort) return;
+    } else {
+        return;  // neither UDP nor TCP
+    }
     ++g_ackedDataHops;  // #377
     const uint64_t window =
         static_cast<uint64_t>(Simulator::Now().GetSeconds() / g_pathWindowS);
@@ -609,16 +627,29 @@ void CountAckedDataHop(uint32_t node, Ptr<const AHN_WIFI_MPDU> mpdu) {
 // transport, i.e. exactly the delivered packets PDR counts. The header arrives
 // with the TTL the packet carried on the wire.
 void CountDeliveredHops(const Ipv4Header& ip, Ptr<const Packet> p, uint32_t) {
-    if (ip.GetProtocol() != 17) return;
+    const bool isTcp = ip.GetProtocol() == 6;  // #389: TCP data counts here too
     UdpHeader udp;
-    if (p->PeekHeader(udp) == 0) return;
-    if (udp.GetDestinationPort() != kDataPort) return;
+    if (isTcp) {
+        TcpHeader tcp;
+        if (p->PeekHeader(tcp) == 0) return;
+        if (tcp.GetDestinationPort() != kDataPort) return;
+    } else {
+        if (ip.GetProtocol() != 17) return;
+        if (p->PeekHeader(udp) == 0) return;
+        if (udp.GetDestinationPort() != kDataPort) return;
+    }
     const uint8_t ttl = ip.GetTtl();
     const uint32_t hops =
         ttl < kIpDefaultTtl ? static_cast<uint32_t>(kIpDefaultTtl - ttl) + 1u : 1u;
     g_hopSum += hops;
     ++g_hopCount;
     if (hops > g_hopMax) g_hopMax = hops;
+
+    // #389: stop here under TCP. SeqTsSizeHeader only exists in UDP datagrams;
+    // under TCP the common-set key cannot be parsed off a byte stream (and the
+    // flow key below needs udp.GetSourcePort()), so g_rxHopsBySeq stays empty
+    // by design — absence is the encoding, same principle as #382.
+    if (isTcp) return;
 
     // #308 phase 2: also record this packet's hop count under the same
     // (flow, seq) key the delays use, so the common set can be measured in hops
@@ -1686,13 +1717,13 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                                - static_cast<int64_t>(g_dataHopRx);
         const int64_t overlap = static_cast<int64_t>(macLost)
                               + static_cast<int64_t>(dropQueue) - hopLossN;
-        // Not emitted under TCP. Every counter above is gated on IsDataIp,
-        // which tests for UDP on the data port, so on a TCP cell they are all
-        // structurally zero — and a zero here would read as "hopTx=0, no
-        // overlap, identity clean" when the truth is that nothing was counted.
-        // Same rule as ##HOLD##/##AIR## and the same mistake #382 fixed for the
-        // reorder columns: suppressing the source is only half of encoding
-        // absence, the emission has to go too.
+        // Not emitted under TCP. Since #389 the counters above DO count TCP
+        // data segments, but the drop-cause identity itself is unvalidated
+        // under TCP — it was closed on per-packet UDP books, and TCP counts
+        // segments and retransmits them, so the arithmetic has not been shown
+        // to close there. The emission stays suppressed until it is (#389
+        // follow-up); same rule as ##HOLD##/##AIR## and #382 — an unvalidated
+        // line would read as clean books, so absence is the encoding.
         if (P.transport != "tcp") {
             std::cout << "##DROPID## " << seed << ' ' << proto
                       << " hopTx=" << g_dataHopTx


### PR DESCRIPTION
Closes #389.

## What

Three metric families in `anthocnet-compare.cc` read **structurally zero** on any TCP cell because their transport test accepts only UDP (protocol 17) on `kDataPort`. The TCP campaign measured the cost: 16/16 protocol-cells printed `mac=0.00 chan=0.00`, with **3.05–6.16 pp of offered traffic attributed to nothing**, reproducing across four disjoint seed groups ([evidence](https://github.com/danieljoppi/AntHocNet/issues/63#issuecomment-5229356849)). This PR widens the test at all three sites to also accept protocol 6 with `TcpHeader` destination port == `kDataPort`:

| site | counters | note |
|---|---|---|
| `IsDataIp` | `g_dataHopTx`/`g_dataHopRx`/`g_macDataDrops` (#215 `drop_mac`/`drop_chan`) | TCP branch inserted **before** the UDP path; UDP lines byte-for-byte untouched |
| `CountAckedDataHop` (inline test) | `g_ackedDataHops`, path-diversity family (#217) | routing control is UDP, so a data-port TCP segment is by construction never control; diversity keying unchanged |
| `CountDeliveredHops` (inline test) | TTL hop stats (`g_hopSum`/`g_hopCount`/`g_hopMax`) | the #308 phase-2 `SeqTsSizeHeader` → `g_rxHopsBySeq` block stays **UDP-only** and TCP returns before it — the common-set key cannot be parsed off a TCP byte stream, and a blind `PeekHeader` would deserialize payload bytes into fake sequence keys. Absence is the encoding (#382 principle) |

Pure TCP ACKs are excluded naturally: the reverse path's destination port is the sender's ephemeral port, so only forward data segments count — matching what the UDP arm counts.

**Deliberately untouched:** the reorder path (`RecordRxSeq` — absence under TCP is correct, #382) and the `##DROPID##` TCP suppression — the counters behind it now count under TCP, but the drop-cause identity was closed on per-packet UDP books, and TCP counts segments and retransmits them; the emission stays suppressed until the identity is validated there (comment updated to say exactly that).

## Merge gate — pre-registered A/B probe

The reading was [pre-registered on #389 before the diff existed](https://github.com/danieljoppi/AntHocNet/issues/389#issuecomment-5232280465): four `paper-benchmark` dispatches, {`main`, this branch} × {`udp`, `tcp`}, paper base at `runs=2, time=300`, identical seeds. **Do not merge until it passes**:

- UDP treatment vs control **byte-identical** on every printed digit (the predicate is a passive observer; any drift means it isn't).
- TCP FlowMonitor metrics byte-identical between arms; only counter-derived columns may change.
- TCP treatment: `mac`/`chan` and `# paths` go non-zero where control prints structural zeros; `sum` moves toward 100.
- Any of the four pre-registered refutation conditions blocks the merge.

Exact identity closure under TCP is explicitly **not** claimed — segments-vs-packets and retransmissions may leave an honest residual, which gets filed, not hidden.

## Verification here

No local ns-3 build exists in this environment — CI's five-version matrix (3.36/3.41/3.42/3.47/3.48) is the first compile of this change. `protocol-review` invariant checks pass (example-only change; no core/wire-format surface). The A/B probe above is the behavioural verification, run pre-merge.

Refs #63, #215, #217, #230, #377, #382, #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_