### PR TITLE
feat(bench): measure re-injection identity and fate directly — the #386 counter

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -118,14 +118,19 @@ DROPID_REINJ_FIELDS = re.compile(
     r"^\s*##DROPID##\s+(\d+)\s+([a-z][\w-]*)\s+.*\bmacDrops=(\d+)\b"
     r".*\breinjected=(\d+)\b.*\bunackedRx=(-?\d+)\b")
 # #386: re-injection identity/fate, one row per (seed, anthocnet) on UDP cells.
-#   ##REINJ## <seed> <proto> events=.. parsed=.. ofDelivered=.. pkts=..
-#     pktsDelivBefore=.. pktsDelivAfterOnly=.. pktsNever=.. pktsDupDeliv=..
-#     dupRx=.. postTx=.. postRx=.. l3DropRoute=.. l3DropTtl=.. l3DropOther=..
+#   ##REINJ## <seed> <proto> events=.. parsed=.. unparsedIcmp=..
+#     unparsedOther=.. ofDelivered=.. pkts=.. pktsDelivBefore=..
+#     pktsDelivAfterOnly=.. pktsNever=.. pktsDupDeliv=.. dupRx=.. postTx=..
+#     postRx=.. l3DropRoute=.. l3DropTtl=.. l3DropOther=..
 # Absent for the baselines and on TCP cells (absence encoding, #382); a
-# detector-off anthocnet arm emits it with all fields zero. Only the fields the
-# rules read are matched; the l3Drop* tail is the cuttable stage and is not.
+# detector-off anthocnet arm emits it with all fields zero. The unparsed*
+# fields classify re-injections the (flow, seq) identity could not name — the
+# invariance probe's non-data (ICMP) finding, #386 comment 5233656930. Only
+# the fields the rules read are matched; the l3Drop* tail is the cuttable
+# stage and is not.
 REINJ_LINE = re.compile(
     r"^\s*##REINJ##\s+(\d+)\s+([a-z][\w-]*)\s+events=(\d+)\s+parsed=(\d+)"
+    r"\s+unparsedIcmp=(\d+)\s+unparsedOther=(\d+)"
     r"\s+ofDelivered=(\d+)\s+pkts=(\d+)\s+pktsDelivBefore=(\d+)"
     r"\s+pktsDelivAfterOnly=(\d+)\s+pktsNever=(\d+)\b")
 # #386: the knob the coherence rule reads. Preflight cannot see extraArgs (it
@@ -652,9 +657,12 @@ def check_reinj(path):
     (>=59% of re-injections are of already-delivered packets). Its trace fires
     at the SAME adapter site that increments MacReinjectedPackets(), so
     `events` and ##DROPID##'s `reinjected` are two readings of one increment —
-    a mismatch is an instrumentation bug, never a protocol behaviour. The same
-    holds for `parsed`: on a UDP cell every non-ant data packet is a SeqTs CBR
-    datagram, so the (flow, seq) parse must be total.
+    a mismatch is an instrumentation bug, never a protocol behaviour. The
+    parse books must close the same way: parsed + unparsedIcmp + unparsedOther
+    == events. A non-zero unparsed count itself is a FINDING, not an error —
+    the invariance probe measured 2 events at seed 2 the SeqTs identity could
+    not name (#386 comment 5233656930): the detector re-injects any non-ant IP
+    payload, ICMP included — so it WARNs with the counts rather than FAILing.
 
     Controls (the #229/#230 rule, a-priori values):
       - baselines emit NO row at all (absence encoding, #382) — a row with a
@@ -689,10 +697,11 @@ def check_reinj(path):
         if not m:
             continue
         seed, proto = m.group(1), m.group(2)
-        events, parsed, of_deliv, pkts = (int(m.group(3)), int(m.group(4)),
-                                          int(m.group(5)), int(m.group(6)))
-        before, after_only, never = (int(m.group(7)), int(m.group(8)),
-                                     int(m.group(9)))
+        events, parsed = int(m.group(3)), int(m.group(4))
+        unp_icmp, unp_other = int(m.group(5)), int(m.group(6))
+        of_deliv, pkts = int(m.group(7)), int(m.group(8))
+        before, after_only, never = (int(m.group(9)), int(m.group(10)),
+                                     int(m.group(11)))
         tag = f"{base}/{proto}"
         if proto != "anthocnet":
             report("FAIL", f"{tag}: ##REINJ## row for a protocol with no "
@@ -705,12 +714,23 @@ def check_reinj(path):
                            f"{dropid[seed][1]} at seed {seed} — one increment "
                            "site, two readings; the ##REINJ## trace or the "
                            "adapter counter is broken (#386)")
-        if parsed != events:
-            report("FAIL", f"{tag}: parsed={parsed} != events={events} at "
-                           f"seed {seed} — the (flow, seq) parse must be total "
-                           "on a UDP cell; a re-injected data packet the "
-                           "identity cannot name means the books are partial "
+        if parsed + unp_icmp + unp_other != events:
+            report("FAIL", f"{tag}: parsed={parsed} + unparsedIcmp={unp_icmp} "
+                           f"+ unparsedOther={unp_other} != events={events} at "
+                           f"seed {seed} — every re-injection is either named "
+                           "by the (flow, seq) identity or classified "
+                           "unparsed; a gap means the books are partial "
                            "(#386)")
+        elif unp_icmp + unp_other > 0:
+            report("WARN", f"{tag}: {unp_icmp + unp_other} non-data "
+                           f"re-injection(s) at seed {seed} "
+                           f"(unparsedIcmp={unp_icmp}, "
+                           f"unparsedOther={unp_other}) — the detector's "
+                           "books include re-injected traffic the SeqTs "
+                           "identity cannot name (ICMP etc., #386 comment "
+                           "5233656930). A finding about what NotifyTxError "
+                           "re-injects, not an error; the fate buckets cover "
+                           "only the parsed events")
         if of_deliv > events or before + after_only + never != pkts:
             report("FAIL", f"{tag}: fate buckets incoherent at seed {seed} "
                            f"(ofDelivered={of_deliv}/events={events}, "

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -110,6 +110,30 @@ PROV_LINE = re.compile(r"^\s*##PROV##\s+commit=([0-9a-fA-F]{7,40})\b")
 DROPID_LINE = re.compile(
     r"^\s*##DROPID##\s+(\d+)\s+([a-z][\w-]*)\s+.*\boverlap=(-?\d+)\b"
     r".*\bunackedRx=(-?\d+)\b")
+# #386: the same ##DROPID## row read for the re-injection cross-checks — the
+# fields check_reinj needs (macDrops/reinjected for the events identity and the
+# inclusion-exclusion floor). Separate from DROPID_LINE so the #377 rule's
+# match groups stay untouched.
+DROPID_REINJ_FIELDS = re.compile(
+    r"^\s*##DROPID##\s+(\d+)\s+([a-z][\w-]*)\s+.*\bmacDrops=(\d+)\b"
+    r".*\breinjected=(\d+)\b.*\bunackedRx=(-?\d+)\b")
+# #386: re-injection identity/fate, one row per (seed, anthocnet) on UDP cells.
+#   ##REINJ## <seed> <proto> events=.. parsed=.. ofDelivered=.. pkts=..
+#     pktsDelivBefore=.. pktsDelivAfterOnly=.. pktsNever=.. pktsDupDeliv=..
+#     dupRx=.. postTx=.. postRx=.. l3DropRoute=.. l3DropTtl=.. l3DropOther=..
+# Absent for the baselines and on TCP cells (absence encoding, #382); a
+# detector-off anthocnet arm emits it with all fields zero. Only the fields the
+# rules read are matched; the l3Drop* tail is the cuttable stage and is not.
+REINJ_LINE = re.compile(
+    r"^\s*##REINJ##\s+(\d+)\s+([a-z][\w-]*)\s+events=(\d+)\s+parsed=(\d+)"
+    r"\s+ofDelivered=(\d+)\s+pkts=(\d+)\s+pktsDelivBefore=(\d+)"
+    r"\s+pktsDelivAfterOnly=(\d+)\s+pktsNever=(\d+)\b")
+# #386: the knob the coherence rule reads. Preflight cannot see extraArgs (it
+# takes numeric scenario args only), so detector-off coherence is enforced
+# results-side from the ##CONFIG## attr dump of effective attribute values.
+CONFIG_MACDET_OFF = re.compile(
+    r"^\s*##CONFIG##\s+attr\s+EnableMacFailureDetector=(?:false|0)\s*$",
+    re.MULTILINE)
 # #308 phase 2: the per-run common-set rows. Unlike the diagnostic lines above
 # there is one per (run, protocol), so they are folded into the protocol's row
 # as an extremum rather than merged field-by-field — the rules below ask "did
@@ -621,12 +645,103 @@ def check_drop_identity(path):
                        "refutes it and the cause is something else.")
 
 
+def check_reinj(path):
+    """#386: the re-injection identity/fate books must be internally coherent.
+
+    ##REINJ## is the direct counter behind the #386 inclusion-exclusion floor
+    (>=59% of re-injections are of already-delivered packets). Its trace fires
+    at the SAME adapter site that increments MacReinjectedPackets(), so
+    `events` and ##DROPID##'s `reinjected` are two readings of one increment —
+    a mismatch is an instrumentation bug, never a protocol behaviour. The same
+    holds for `parsed`: on a UDP cell every non-ant data packet is a SeqTs CBR
+    datagram, so the (flow, seq) parse must be total.
+
+    Controls (the #229/#230 rule, a-priori values):
+      - baselines emit NO row at all (absence encoding, #382) — a row with a
+        non-anthocnet protocol is a harness regression, FAIL;
+      - an EnableMacFailureDetector=false arm emits the row with events=0 (a
+        measured zero; the ##CONFIG## attr dump carries the effective knob
+        value, so the coherence is checkable results-side — preflight cannot
+        see extraArgs), FAIL otherwise.
+
+    The floor comparison is WARN, not FAIL: ofDelivered counts sink deliveries
+    strictly before re-injection time, while the ##DROPID## floor is built from
+    next-hop arrivals (unackedRx), so the two sit on slightly different events
+    and a small shortfall can be timing, not books. A large one means the
+    direct counter and the bound disagree and #386's premise needs re-checking.
+    """
+    with open(path) as fh:
+        text = fh.read()
+    if "##REINJ##" not in text:
+        return
+    base = os.path.basename(path)
+    detector_off = bool(CONFIG_MACDET_OFF.search(text))
+    # seed -> (macDrops, reinjected, unackedRx) from the anthocnet ##DROPID##
+    # rows, for the cross-book identity and the floor.
+    dropid = {}
+    for line in text.splitlines():
+        dm = DROPID_REINJ_FIELDS.match(line)
+        if dm and dm.group(2) == "anthocnet":
+            dropid[dm.group(1)] = (int(dm.group(3)), int(dm.group(4)),
+                                   int(dm.group(5)))
+    for line in text.splitlines():
+        m = REINJ_LINE.match(line)
+        if not m:
+            continue
+        seed, proto = m.group(1), m.group(2)
+        events, parsed, of_deliv, pkts = (int(m.group(3)), int(m.group(4)),
+                                          int(m.group(5)), int(m.group(6)))
+        before, after_only, never = (int(m.group(7)), int(m.group(8)),
+                                     int(m.group(9)))
+        tag = f"{base}/{proto}"
+        if proto != "anthocnet":
+            report("FAIL", f"{tag}: ##REINJ## row for a protocol with no "
+                           f"detector at seed {seed} — the baselines must stay "
+                           "absent, not zero (#386 control); the harness "
+                           "emission gate has regressed")
+            continue
+        if seed in dropid and events != dropid[seed][1]:
+            report("FAIL", f"{tag}: events={events} != reinjected="
+                           f"{dropid[seed][1]} at seed {seed} — one increment "
+                           "site, two readings; the ##REINJ## trace or the "
+                           "adapter counter is broken (#386)")
+        if parsed != events:
+            report("FAIL", f"{tag}: parsed={parsed} != events={events} at "
+                           f"seed {seed} — the (flow, seq) parse must be total "
+                           "on a UDP cell; a re-injected data packet the "
+                           "identity cannot name means the books are partial "
+                           "(#386)")
+        if of_deliv > events or before + after_only + never != pkts:
+            report("FAIL", f"{tag}: fate buckets incoherent at seed {seed} "
+                           f"(ofDelivered={of_deliv}/events={events}, "
+                           f"{before}+{after_only}+{never} != pkts={pkts}) — "
+                           "the partition must be exact (#386)")
+        if detector_off and events > 0:
+            report("FAIL", f"{tag}: events={events} at seed {seed} with "
+                           "EnableMacFailureDetector=false in ##CONFIG## — "
+                           "the detector-off control must read 0; either the "
+                           "gate or the config dump is wrong (#386)")
+        if seed in dropid:
+            mac_drops, reinjected, unacked = dropid[seed]
+            floor = reinjected + unacked - mac_drops
+            if floor > 0 and of_deliv < floor:
+                report("WARN", f"{tag}: ofDelivered={of_deliv} below the "
+                               f"inclusion-exclusion floor {floor} "
+                               f"(reinjected={reinjected}+unackedRx={unacked}"
+                               f"-macDrops={mac_drops}) at seed {seed} — the "
+                               "direct counter sits under the bound it was "
+                               "built to confirm. A small shortfall can be "
+                               "sink-vs-next-hop timing; a large one says the "
+                               "#386 books disagree (#386)")
+
+
 def cmd_results(a):
     floor = anchor_floor(a.anchor) if a.anchor else None
     n = 0
     for path in a.files:
         check_provenance(path)
         check_drop_identity(path)
+        check_reinj(path)
         for r in parse_results(path):
             n += 1
             tag = f"{r['where']}/{r['proto']}"

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -1070,6 +1070,59 @@ def _dropid_absent_quiet():
            f"absent counters were treated as a defect\n{out}")
 
 
+# --- #386 re-injection identity ------------------------------------------------
+# The clean fixture is shaped from the real 900 s gaussmarkov x nakagami cell
+# (run 31288485211 seed 1): reinjected=2698, unackedRx=1567, macDrops=2738, so
+# the inclusion-exclusion floor is 2698+1567-2738 = 1527 and the direct counter
+# must read at least that. The ##DROPID## row is the same one the #377
+# corrected-residual case uses, so it is known quiet under check_drop_identity.
+
+DROPID_REINJ_ARM = (
+    "##DROPID## 1 anthocnet hopTx=20571 hopRx=18761 ackedHops=17194 "
+    "macDrops=2738 reinjected=2698 macTerminal=40 macLost=1171 queue=0 "
+    "hopLoss=1810 overlap=-639 unackedRx=1567\n")
+REINJ_CLEAN = (
+    "##REINJ## 1 anthocnet events=2698 parsed=2698 ofDelivered=1608 pkts=2100 "
+    "pktsDelivBefore=1300 pktsDelivAfterOnly=520 pktsNever=280 "
+    "pktsDupDeliv=900 dupRx=940 postTx=5200 postRx=4600 "
+    "l3DropRoute=120 l3DropTtl=3 l3DropOther=0\n")
+
+
+@case("#386 a coherent ##REINJ## row against its ##DROPID## row stays quiet")
+def _reinj_clean_quiet():
+    # events == reinjected, parsed == events, buckets partition pkts, and
+    # ofDelivered=1608 sits above the 1527 floor: every #386 rule must hold its
+    # fire, or correct books become unreadable noise.
+    _levels, out = run_cell(ISL_CELL + DROPID_REINJ_ARM + REINJ_CLEAN)
+    expect("#386" not in out, "reinj-clean",
+           f"a coherent re-injection book was flagged\n{out}")
+
+
+@case("#386 events != reinjected FAILs, and a baseline ##REINJ## row FAILs")
+def _reinj_incoherent_fires():
+    # The one-increment-site identity: the ##REINJ## trace fires exactly where
+    # the adapter counter increments, so 460 vs 466 can only be a broken hook.
+    # The aodv row violates the absence control — baselines have no detector
+    # and must emit nothing, not zeros. ofDelivered=310 keeps the (separate)
+    # floor WARN out of this case: 466+317-475 = 308.
+    row = ("##DROPID## 1 anthocnet hopTx=4584 hopRx=4106 ackedHops=3789 "
+           "macDrops=475 reinjected=466 macTerminal=9 macLost=158 queue=0 "
+           "hopLoss=151 overlap=7 unackedRx=317\n"
+           "##REINJ## 1 anthocnet events=460 parsed=460 ofDelivered=310 "
+           "pkts=400 pktsDelivBefore=250 pktsDelivAfterOnly=90 pktsNever=60 "
+           "pktsDupDeliv=40 dupRx=41 postTx=800 postRx=700 "
+           "l3DropRoute=20 l3DropTtl=1 l3DropOther=0\n"
+           "##REINJ## 1 aodv events=0 parsed=0 ofDelivered=0 pkts=0 "
+           "pktsDelivBefore=0 pktsDelivAfterOnly=0 pktsNever=0 "
+           "pktsDupDeliv=0 dupRx=0 postTx=0 postRx=0 "
+           "l3DropRoute=0 l3DropTtl=0 l3DropOther=0\n")
+    _levels, out = run_cell(ISL_CELL + row)
+    expect("events=460 != reinjected=466" in out, "reinj-mismatch",
+           f"the events/reinjected identity break was not flagged\n{out}")
+    expect("protocol with no detector" in out, "reinj-baseline-row",
+           f"a baseline ##REINJ## row was accepted\n{out}")
+
+
 def main():
     for name, fn in CASES:
         fn()

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -1082,7 +1082,8 @@ DROPID_REINJ_ARM = (
     "macDrops=2738 reinjected=2698 macTerminal=40 macLost=1171 queue=0 "
     "hopLoss=1810 overlap=-639 unackedRx=1567\n")
 REINJ_CLEAN = (
-    "##REINJ## 1 anthocnet events=2698 parsed=2698 ofDelivered=1608 pkts=2100 "
+    "##REINJ## 1 anthocnet events=2698 parsed=2698 unparsedIcmp=0 "
+    "unparsedOther=0 ofDelivered=1608 pkts=2100 "
     "pktsDelivBefore=1300 pktsDelivAfterOnly=520 pktsNever=280 "
     "pktsDupDeliv=900 dupRx=940 postTx=5200 postRx=4600 "
     "l3DropRoute=120 l3DropTtl=3 l3DropOther=0\n")
@@ -1098,29 +1099,53 @@ def _reinj_clean_quiet():
            f"a coherent re-injection book was flagged\n{out}")
 
 
-@case("#386 events != reinjected FAILs, and a baseline ##REINJ## row FAILs")
+@case("#386 events != reinjected FAILs, non-closing parse books FAIL, "
+      "and a baseline ##REINJ## row FAILs")
 def _reinj_incoherent_fires():
     # The one-increment-site identity: the ##REINJ## trace fires exactly where
     # the adapter counter increments, so 460 vs 466 can only be a broken hook.
-    # The aodv row violates the absence control — baselines have no detector
-    # and must emit nothing, not zeros. ofDelivered=310 keeps the (separate)
-    # floor WARN out of this case: 466+317-475 = 308.
+    # parsed=456 + unparsedIcmp=2 + unparsedOther=0 = 458 != events=460: two
+    # re-injections neither named nor classified — partial books, FAIL (the
+    # shape of the invariance probe's seed-2 reading, 617 vs 619, before the
+    # unparsed counters existed). The aodv row violates the absence control —
+    # baselines have no detector and must emit nothing, not zeros.
+    # ofDelivered=310 keeps the (separate) floor WARN out of this case:
+    # 466+317-475 = 308.
     row = ("##DROPID## 1 anthocnet hopTx=4584 hopRx=4106 ackedHops=3789 "
            "macDrops=475 reinjected=466 macTerminal=9 macLost=158 queue=0 "
            "hopLoss=151 overlap=7 unackedRx=317\n"
-           "##REINJ## 1 anthocnet events=460 parsed=460 ofDelivered=310 "
+           "##REINJ## 1 anthocnet events=460 parsed=456 unparsedIcmp=2 "
+           "unparsedOther=0 ofDelivered=310 "
            "pkts=400 pktsDelivBefore=250 pktsDelivAfterOnly=90 pktsNever=60 "
            "pktsDupDeliv=40 dupRx=41 postTx=800 postRx=700 "
            "l3DropRoute=20 l3DropTtl=1 l3DropOther=0\n"
-           "##REINJ## 1 aodv events=0 parsed=0 ofDelivered=0 pkts=0 "
+           "##REINJ## 1 aodv events=0 parsed=0 unparsedIcmp=0 "
+           "unparsedOther=0 ofDelivered=0 pkts=0 "
            "pktsDelivBefore=0 pktsDelivAfterOnly=0 pktsNever=0 "
            "pktsDupDeliv=0 dupRx=0 postTx=0 postRx=0 "
            "l3DropRoute=0 l3DropTtl=0 l3DropOther=0\n")
     _levels, out = run_cell(ISL_CELL + row)
     expect("events=460 != reinjected=466" in out, "reinj-mismatch",
            f"the events/reinjected identity break was not flagged\n{out}")
+    expect("unparsedOther=0 != events=460" in out, "reinj-books-open",
+           f"non-closing parse books were not flagged\n{out}")
     expect("protocol with no detector" in out, "reinj-baseline-row",
            f"a baseline ##REINJ## row was accepted\n{out}")
+
+
+@case("#386 non-data re-injections with closing books WARN, never FAIL")
+def _reinj_unparsed_warns():
+    # The invariance probe's actual finding (comment 5233656930): 2 events the
+    # SeqTs identity could not name, books otherwise perfect. That is a fact
+    # about what NotifyTxError re-injects (any non-ant IP payload, ICMP
+    # included) — the gate must surface it without blocking the cell.
+    row = REINJ_CLEAN.replace("parsed=2698 unparsedIcmp=0",
+                              "parsed=2696 unparsedIcmp=2")
+    _levels, out = run_cell(ISL_CELL + DROPID_REINJ_ARM + row)
+    expect("non-data re-injection(s)" in out, "reinj-unparsed-warn",
+           f"the non-data finding was not surfaced\n{out}")
+    expect("FAIL" not in out, "reinj-unparsed-no-fail",
+           f"a coherent book with a non-data finding was FAILed\n{out}")
 
 
 def main():

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -329,6 +329,14 @@ jobs:
           # Absent on a TCP cell by design (the counters are UDP-gated).
           grep '^##DROPID##' "$GITHUB_WORKSPACE/paper-results.txt" \
             >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
+          # #386: re-injection identity/fate rows — the direct counter behind
+          # the ##DROPID## unackedRx-vs-reinjected floor. Added in the same
+          # commit that emits them, per the ##MATCH## rule above. Present for
+          # the anthocnet arm on UDP cells only (a detector-off arm emits it
+          # with all-zero fields); absent for the baselines and on TCP cells
+          # by design.
+          grep '^##REINJ##' "$GITHUB_WORKSPACE/paper-results.txt" \
+            >> "$GITHUB_WORKSPACE/bench-rows.txt" || true
           # #230: the '# paths/energy/drops/stddev/reorder' diagnostic lines are
           # the *only* place the #209/#212/#215/#217 metric families appear in a
           # single-point run — the fixed-width table cannot carry them (its field

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -358,7 +358,8 @@ rather than by a human noticing a negative percentage.
 ### Re-injection identity & fate (`##REINJ##`, #386, NS-3 only, AntHocNet + UDP only)
 
 ```
-##REINJ## <seed> anthocnet events=.. parsed=.. ofDelivered=.. pkts=.. \
+##REINJ## <seed> anthocnet events=.. parsed=.. unparsedIcmp=.. \
+          unparsedOther=.. ofDelivered=.. pkts=.. \
           pktsDelivBefore=.. pktsDelivAfterOnly=.. pktsNever=.. \
           pktsDupDeliv=.. dupRx=.. postTx=.. postRx=.. \
           l3DropRoute=.. l3DropTtl=.. l3DropOther=..
@@ -384,7 +385,8 @@ packet (UDP header + SeqTs, the queued form) and off each IP hop transmission.
 | field | definition | reads as |
 |---|---|---|
 | `events` | `MacReinject` trace fires | must equal `##DROPID##` `reinjected` — a mismatch is an instrumentation bug (FAIL) |
-| `parsed` | fires where the `(flow, seq)` parse succeeded | must equal `events` on a UDP cell — every non-ant data packet is a SeqTs CBR datagram (FAIL) |
+| `parsed` | fires where the `(flow, seq)` parse succeeded | `parsed + unparsedIcmp + unparsedOther` must equal `events` — every re-injection is either named or classified (FAIL when the books do not close) |
+| `unparsedIcmp` / `unparsedOther` | parse failures, split by IP protocol 1 vs anything else | **a finding, not an error** (WARN when non-zero): `NotifyTxError` re-injects *any* non-ant IP payload, so ICMP (e.g. TTL-exceeded) rides the detector too. Measured on the invariance probe: 2 events at one seed the SeqTs identity could not name ([#386](https://github.com/danieljoppi/AntHocNet/issues/386) comment 5233656930). The fate buckets below cover only the parsed events |
 | `ofDelivered` | fires where the key was already in the sink's delivered set **at trace-fire time** | re-injections of already-delivered packets. No timestamps needed: traces fire in simulation-event order, so presence in the delivered map means "delivered strictly earlier" |
 
 `ofDelivered` is deliberately **"already delivered AT RE-INJECTION TIME"**, not

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -355,6 +355,87 @@ on #63, not something this marker introduces.)
 `overlap > 0`, naming both figures, so the condition is caught by the gate
 rather than by a human noticing a negative percentage.
 
+### Re-injection identity & fate (`##REINJ##`, #386, NS-3 only, AntHocNet + UDP only)
+
+```
+##REINJ## <seed> anthocnet events=.. parsed=.. ofDelivered=.. pkts=.. \
+          pktsDelivBefore=.. pktsDelivAfterOnly=.. pktsNever=.. \
+          pktsDupDeliv=.. dupRx=.. postTx=.. postRx=.. \
+          l3DropRoute=.. l3DropTtl=.. l3DropOther=..
+```
+
+The **direct counter** behind the `##DROPID##` inclusion–exclusion floor: under
+fading, ≥ 58.8 % of the [#46](https://github.com/danieljoppi/AntHocNet/issues/46)
+detector-D re-injections are of packets that had *already arrived* at the
+destination (`unackedRx` vs `reinjected`, a lower bound). This row measures
+that overlap per packet instead of bounding it, and follows what re-injected
+packets then do. One row per seed, AntHocNet arm only.
+
+Packet identity is the `(flow, seq)` key the sink-side maps already use:
+`flow = (source IP, source UDP port)` — byte-identical to the PacketSink `Rx`
+trace's sender address — and `seq` from the `SeqTsSizeHeader`. The adapter's
+`MacReinject` trace source fires **at the same statement that increments
+`MacReinjectedPackets()`**, so `events` and `##DROPID##`'s `reinjected` are two
+readings of one increment; the harness parses the key off the re-injected
+packet (UDP header + SeqTs, the queued form) and off each IP hop transmission.
+
+**Event view** (one count per re-injection):
+
+| field | definition | reads as |
+|---|---|---|
+| `events` | `MacReinject` trace fires | must equal `##DROPID##` `reinjected` — a mismatch is an instrumentation bug (FAIL) |
+| `parsed` | fires where the `(flow, seq)` parse succeeded | must equal `events` on a UDP cell — every non-ant data packet is a SeqTs CBR datagram (FAIL) |
+| `ofDelivered` | fires where the key was already in the sink's delivered set **at trace-fire time** | re-injections of already-delivered packets. No timestamps needed: traces fire in simulation-event order, so presence in the delivered map means "delivered strictly earlier" |
+
+`ofDelivered` is deliberately **"already delivered AT RE-INJECTION TIME"**, not
+"eventually delivered anyway" — a copy that passed the failing hop but had not
+yet reached the sink counts as not-yet-delivered here, so it is conservative
+against the floor. The eventual-fate buckets below carry the other quantity.
+
+**Packet view** (distinct re-injected `(flow, seq)` keys, classified at end of
+run):
+
+| field | definition |
+|---|---|
+| `pkts` | distinct keys ever re-injected |
+| `pktsDelivBefore` | delivered before their **first** re-injection (the waste-certain class) |
+| `pktsDelivAfterOnly` | never delivered before first re-injection, delivered by end of run (delivered late — the re-injection plausibly saved them) |
+| `pktsNever` | never delivered at all (dropped) |
+| `pktsDupDeliv` / `dupRx` | keys the sink delivered ≥ 2 times / total surplus deliveries (how much duplicate delivery inflates FlowMonitor's rx) |
+| `postTx` / `postRx` | IP-layer hop transmissions / arrivals of re-injected keys **after** their first re-injection — the hops re-injected packets go on to consume (the wasted-work number); `postTx − postRx` is their post-re-injection in-medium loss |
+
+`pktsDelivBefore + pktsDelivAfterOnly + pktsNever = pkts` exactly;
+`scenario_check.py results` FAILs a row where the partition does not sum, and
+WARNs when `ofDelivered` falls below the same-seed inclusion–exclusion floor
+`reinjected + unackedRx − macDrops` (WARN, not FAIL: the floor is built from
+*next-hop arrivals* while `ofDelivered` counts *sink deliveries*, so a small
+shortfall can be timing rather than broken books).
+
+The trailing `l3DropRoute`/`l3DropTtl`/`l3DropOther` fields attribute the
+L3-visible drops of re-injected keys (the pending-queue ageout's error callback
+lands in `DROP_ROUTE_ERROR`; TTL exhaustion in `DROP_TTL_EXPIRED`). A key that
+ends in `pktsNever` with no L3 drop died in the medium/MAC — the residue the
+#377/[#388](https://github.com/danieljoppi/AntHocNet/issues/388) drop identity
+is sensitive to. This stage is deliberately isolated (own callback, own trace
+connect, fields grouped last) so it can be cut cleanly if an ns-3 version in
+the CI matrix rejects the `Ipv4L3Protocol` `Drop` trace signature.
+
+**Absence encoding** (the #382 rule, with the #229/#230 controls stated as
+numbers):
+
+- **Baselines (AODV/OLSR/DSDV): no row at all.** They have no failure detector
+  and no re-injection; a `0` would read as "measured, nothing happened".
+  `scenario_check.py results` FAILs any `##REINJ##` row naming a non-AntHocNet
+  protocol.
+- **TCP cells: no row.** The SeqTs identity does not exist on a byte stream
+  (same reason the reorder columns are absent there).
+- **`EnableMacFailureDetector=false`: row present, every field `= 0`.** The
+  hooks stay connected and the trace simply never fires, so the zeros are
+  *measured*. The knob's effective value is in the `##CONFIG## attr` dump, and
+  `scenario_check.py results` FAILs `events > 0` alongside
+  `EnableMacFailureDetector=false` — preflight cannot enforce this (it never
+  sees `extraArgs`), so the coherence check is results-side by design.
+
 ### Measuring commit (`##PROV##`, #365)
 
 ```

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -238,6 +238,11 @@ std::map<Address, std::map<uint32_t, double>> g_rxDelayBySeq;
 // comes from the IP TTL and the sink's Rx trace has no IP header left to read.
 std::map<Address, std::map<uint32_t, uint32_t>> g_rxHopsBySeq;
 
+// #386: (flow, seq) -> number of sink deliveries seen so far. Same key as the
+// two maps above; filled by RecordRxSeq, read by the re-injection identity
+// block further down (see "re-injection identity & fate").
+std::map<Address, std::map<uint32_t, uint32_t>> g_rxCount;
+
 void RecordRxSeq(Ptr<const Packet> p, const Address& from) {
     SeqTsSizeHeader h;
     p->PeekHeader(h);
@@ -245,6 +250,12 @@ void RecordRxSeq(Ptr<const Packet> p, const Address& from) {
     const double now = Simulator::Now().GetSeconds();
     g_rxArrival[from].push_back(now);
     g_rxDelayBySeq[from][h.GetSeq()] = now - h.GetTs().GetSeconds();
+    // #386: per-key delivery count, so the re-injection instrumentation can ask
+    // "was this packet already delivered?" at trace-fire time and count
+    // duplicate deliveries at end of run. Kept for ALL protocols (this callback
+    // has no protocol knowledge): one uint32 per delivered (flow, seq), the
+    // same growth order as g_rxDelayBySeq's double above — accepted.
+    g_rxCount[from][h.GetSeq()] += 1;
 }
 
 // --- drop-cause breakdown (#215) --------------------------------------------
@@ -295,11 +306,150 @@ bool IsDataIp(Ptr<const Packet> p) {
     return udp.GetDestinationPort() == kDataPort;
 }
 
+// --- re-injection identity & fate (#386) -------------------------------------
+// The #46 detector-D re-injection path puts a MAC retry-limit-dropped data
+// packet back into the pending queue. The #377/#386 inclusion-exclusion bound
+// says >=59% of those re-injections are of packets that had ALREADY arrived at
+// the destination (unackedRx vs reinjected, a floor); this block measures it
+// directly, per packet, and follows what re-injected packets then DO.
+//
+// Identity is the (flow, seq) key the sink-side maps already use: flow =
+// InetSocketAddress(source IP, source UDP port) — byte-identical to the
+// PacketSink "Rx" trace's `from` (see CountDeliveredHops's key construction) —
+// and seq = the SeqTsSizeHeader sequence number. ns-3 Packet::GetUid() would
+// also survive the re-inject Copy() (uid lives in the copied metadata), but
+// (flow, seq) is what the delivered set is already keyed by, is readable in
+// logs, and survives any future packet re-creation.
+//
+// "Already delivered AT RE-INJECTION TIME" needs no timestamps: traces fire in
+// simulation-event order, so if the key is in g_rxCount when the MacReinject
+// trace fires, the delivery happened strictly earlier. A copy that has passed
+// the failing hop but not yet reached the sink counts as not-yet-delivered
+// here, so ofDelivered is a conservative direct count and the end-of-run fate
+// buckets bound the same quantity from the other side.
+
+// Per re-injected (flow, seq) key. `rxAtFirstReinj` snapshots the delivered
+// count when the key was FIRST re-injected (>=1 = the "already delivered"
+// class); postTx/postRx count this key's IP-layer hop transmissions/arrivals
+// AFTER that moment (membership in g_reinj starts at first re-injection, so
+// pre-re-injection hops are excluded by construction). The l3Drop* fields are
+// the isolated, cuttable drop-cause stage (see CountReinjL3Drop).
+struct ReinjInfo {
+    uint32_t events = 0;          // re-injection events for this key
+    uint32_t rxAtFirstReinj = 0;  // sink deliveries seen at first re-injection
+    uint64_t postTx = 0;          // hop transmissions after first re-injection
+    uint64_t postRx = 0;          // hop arrivals after first re-injection
+    uint32_t l3DropRoute = 0;     // L3 drops: route error / no route
+    uint32_t l3DropTtl = 0;       // L3 drops: TTL expired
+    uint32_t l3DropOther = 0;     // L3 drops: any other reason
+};
+std::map<std::pair<Address, uint32_t>, ReinjInfo> g_reinj;
+uint64_t g_reinjEvents = 0;       // MacReinject trace fires (== reinjected)
+uint64_t g_reinjParsed = 0;       // fires where the (flow, seq) parse succeeded
+uint64_t g_reinjOfDelivered = 0;  // fires with the key already delivered
+
+// (flow, seq) off a packet whose front is the UDP header (the form the
+// MacReinject trace and the Ipv4L3Protocol traces hand over — IP header
+// separate). False on anything that is not a SeqTs CBR datagram; on the UDP
+// arm every non-ant data packet is one, so parsed != events is an
+// instrumentation bug and scenario_check FAILs it.
+bool ReinjKeyFromUdp(const Ipv4Header& ip, Ptr<const Packet> p,
+                     Address& flow, uint32_t& seq) {
+    if (ip.GetProtocol() != 17) return false;
+    Ptr<Packet> c = p->Copy();
+    UdpHeader udp;
+    if (c->RemoveHeader(udp) == 0) return false;
+    if (udp.GetDestinationPort() != kDataPort) return false;
+    SeqTsSizeHeader h;
+    if (c->PeekHeader(h) == 0) return false;
+    flow = InetSocketAddress(ip.GetSource(), udp.GetSourcePort());
+    seq = h.GetSeq();
+    return true;
+}
+
+// Same key off a full IP packet (the Ipv4L3Protocol "Tx"/"Rx" trace form).
+bool ReinjKeyFromIp(Ptr<const Packet> p, Address& flow, uint32_t& seq) {
+    Ptr<Packet> c = p->Copy();
+    Ipv4Header ip;
+    if (c->RemoveHeader(ip) == 0) return false;
+    return ReinjKeyFromUdp(ip, c, flow, seq);
+}
+
+// Connected to the adapter's "MacReinject" trace (anthocnet + UDP arm only).
+// Read-only: the packet is peeked via a Copy, never mutated — the pre-merge
+// A/B relies on this whole block being behaviour-invariant.
+void CountMacReinject(const Ipv4Header& ip, Ptr<const Packet> p) {
+    ++g_reinjEvents;
+    Address flow;
+    uint32_t seq = 0;
+    if (!ReinjKeyFromUdp(ip, p, flow, seq)) return;
+    ++g_reinjParsed;
+    uint32_t rxNow = 0;
+    const auto f = g_rxCount.find(flow);
+    if (f != g_rxCount.end()) {
+        const auto s = f->second.find(seq);
+        if (s != f->second.end()) rxNow = s->second;
+    }
+    if (rxNow > 0) ++g_reinjOfDelivered;
+    auto ins = g_reinj.emplace(std::make_pair(flow, seq), ReinjInfo{});
+    if (ins.second) ins.first->second.rxAtFirstReinj = rxNow;
+    ++ins.first->second.events;
+}
+
+// #386 l3Drop stage — deliberately isolated (own callback, own connect line,
+// fields grouped at the END of the ##REINJ## line) so that if any CI ns-3
+// version rejects the "Drop" trace signature the whole stage is cut from the
+// change rather than version-gated. Attributes the L3-visible drops of
+// re-injected keys: the pending-queue ageout's error callback lands in
+// DROP_ROUTE_ERROR, TTL exhaustion in DROP_TTL_EXPIRED. A re-injected key that
+// ends undelivered with NO L3 drop died in the medium/MAC — the residue the
+// #377/#388 drop identity is sensitive to.
+void CountReinjL3Drop(const Ipv4Header& ip, Ptr<const Packet> p,
+                      Ipv4L3Protocol::DropReason reason, Ptr<Ipv4>, uint32_t) {
+    if (g_reinj.empty()) return;
+    Address flow;
+    uint32_t seq = 0;
+    if (!ReinjKeyFromUdp(ip, p, flow, seq)) return;
+    const auto it = g_reinj.find(std::make_pair(flow, seq));
+    if (it == g_reinj.end()) return;
+    if (reason == Ipv4L3Protocol::DROP_ROUTE_ERROR ||
+        reason == Ipv4L3Protocol::DROP_NO_ROUTE) {
+        ++it->second.l3DropRoute;
+    } else if (reason == Ipv4L3Protocol::DROP_TTL_EXPIRED) {
+        ++it->second.l3DropTtl;
+    } else {
+        ++it->second.l3DropOther;
+    }
+}
+
 void CountDataHopTx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t iface) {
-    if (iface != 0 && IsDataIp(p)) ++g_dataHopTx;
+    if (iface != 0 && IsDataIp(p)) {
+        ++g_dataHopTx;
+        // #386: subsequent hops of re-injected packets. g_reinj only fills on
+        // the anthocnet arm (the trace is connected nowhere else), so the
+        // emptiness gate keeps the extra parse off every other arm.
+        if (!g_reinj.empty()) {
+            Address flow;
+            uint32_t seq = 0;
+            if (ReinjKeyFromIp(p, flow, seq)) {
+                const auto it = g_reinj.find(std::make_pair(flow, seq));
+                if (it != g_reinj.end()) ++it->second.postTx;
+            }
+        }
+    }
 }
 void CountDataHopRx(Ptr<const Packet> p, Ptr<Ipv4>, uint32_t iface) {
-    if (iface != 0 && IsDataIp(p)) ++g_dataHopRx;
+    if (iface != 0 && IsDataIp(p)) {
+        ++g_dataHopRx;
+        if (!g_reinj.empty()) {  // #386: see CountDataHopTx
+            Address flow;
+            uint32_t seq = 0;
+            if (ReinjKeyFromIp(p, flow, seq)) {
+                const auto it = g_reinj.find(std::make_pair(flow, seq));
+                if (it != g_reinj.end()) ++it->second.postRx;
+            }
+        }
+    }
 }
 
 // WifiMac "DroppedMpdu": a retry-limit drop is the MAC giving up on a unicast,
@@ -820,6 +970,9 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_rxArrival.clear();  // #89
     g_rxDelayBySeq.clear();  // #308
     g_rxHopsBySeq.clear();   // #308 phase 2
+    g_rxCount.clear();       // #386
+    g_reinj.clear();         // #386
+    g_reinjEvents = g_reinjParsed = g_reinjOfDelivered = 0;  // #386
     g_dataHopTx = g_dataHopRx = g_macDataDrops = 0;  // #215
     g_ackedDataHops = 0;  // #377
     // #217
@@ -1103,6 +1256,29 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             // #217 path length: TTL of every locally delivered data packet.
             l3->TraceConnectWithoutContext("LocalDeliver",
                                            MakeCallback(&CountDeliveredHops));
+        }
+    }
+    // #386: re-injection identity & fate. anthocnet + UDP only: the baselines
+    // have no detector (their arms emit NO ##REINJ## line — absence, not zero,
+    // per the #382 rule), and under TCP the SeqTs identity does not exist. The
+    // EnableMacFailureDetector=false arm keeps the hooks: its trace never
+    // fires, so every field reads a *measured* zero, which is what lets
+    // scenario_check assert the detector-off control as a number.
+    if (proto == "anthocnet" && P.transport != "tcp") {
+        for (uint32_t i = 0; i < nodes.GetN(); ++i) {
+            Ptr<Ipv4> ip = nodes.Get(i)->GetObject<Ipv4>();
+            Ptr<Ipv4RoutingProtocol> rp = ip ? ip->GetRoutingProtocol() : nullptr;
+            if (rp) {
+                rp->TraceConnectWithoutContext("MacReinject",
+                                               MakeCallback(&CountMacReinject));
+            }
+            // l3Drop stage — isolated connect, cuttable with CountReinjL3Drop
+            // if a CI ns-3 version rejects the "Drop" signature (#386).
+            Ptr<Ipv4L3Protocol> l3 = nodes.Get(i)->GetObject<Ipv4L3Protocol>();
+            if (l3) {
+                l3->TraceConnectWithoutContext("Drop",
+                                               MakeCallback(&CountReinjL3Drop));
+            }
         }
     }
     for (uint32_t i = 0; i < devices.GetN(); ++i) {
@@ -1737,6 +1913,66 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
                       << " hopLoss=" << hopLossN
                       << " overlap=" << overlap
                       << " unackedRx=" << unackedRx << '\n';
+        }
+
+        // #386: the direct re-injection counter behind the >=59% inclusion-
+        // exclusion floor above (unackedRx vs reinjected), plus what re-injected
+        // packets then DO. Event view: `events` MUST equal `reinjected` (the
+        // trace fires at the same site that increments the adapter counter —
+        // scenario_check FAILs a mismatch), `parsed` must equal `events` on the
+        // UDP arm, `ofDelivered` counts re-injections of packets already at the
+        // destination AT RE-INJECTION TIME (the floor's direct counterpart).
+        // Packet view (distinct keys): pktsDelivBefore (delivered before first
+        // re-injection) / pktsDelivAfterOnly (delivered late, only after) /
+        // pktsNever (dropped) partition `pkts`; pktsDupDeliv/dupRx count sink
+        // duplicates; postTx/postRx are the hops re-injected packets traversed
+        // afterwards (attempts / arrivals — the wasted-work number). The
+        // l3Drop* tail is the isolated cuttable drop-cause stage.
+        //
+        // Emitted for anthocnet+UDP only — baselines and TCP stay ABSENT (no
+        // detector / no SeqTs identity; #382 absence rule). A detector-off
+        // anthocnet arm still emits, all fields measured zeros, so the
+        // EnableMacFailureDetector=false control is a number, not an absence.
+        if (proto == "anthocnet" && P.transport != "tcp") {
+            uint64_t pkts = 0, delivBefore = 0, delivAfterOnly = 0, never = 0;
+            uint64_t dupDeliv = 0, dupRx = 0, postTx = 0, postRx = 0;
+            uint64_t l3Route = 0, l3Ttl = 0, l3Other = 0;
+            for (const auto& kv : g_reinj) {
+                ++pkts;
+                uint32_t endCount = 0;
+                const auto f = g_rxCount.find(kv.first.first);
+                if (f != g_rxCount.end()) {
+                    const auto s = f->second.find(kv.first.second);
+                    if (s != f->second.end()) endCount = s->second;
+                }
+                if (kv.second.rxAtFirstReinj >= 1) ++delivBefore;
+                else if (endCount >= 1) ++delivAfterOnly;
+                else ++never;
+                if (endCount >= 2) {
+                    ++dupDeliv;
+                    dupRx += endCount - 1;
+                }
+                postTx += kv.second.postTx;
+                postRx += kv.second.postRx;
+                l3Route += kv.second.l3DropRoute;
+                l3Ttl += kv.second.l3DropTtl;
+                l3Other += kv.second.l3DropOther;
+            }
+            std::cout << "##REINJ## " << seed << ' ' << proto
+                      << " events=" << g_reinjEvents
+                      << " parsed=" << g_reinjParsed
+                      << " ofDelivered=" << g_reinjOfDelivered
+                      << " pkts=" << pkts
+                      << " pktsDelivBefore=" << delivBefore
+                      << " pktsDelivAfterOnly=" << delivAfterOnly
+                      << " pktsNever=" << never
+                      << " pktsDupDeliv=" << dupDeliv
+                      << " dupRx=" << dupRx
+                      << " postTx=" << postTx
+                      << " postRx=" << postRx
+                      << " l3DropRoute=" << l3Route
+                      << " l3DropTtl=" << l3Ttl
+                      << " l3DropOther=" << l3Other << '\n';
         }
     }
 

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -347,12 +347,22 @@ std::map<std::pair<Address, uint32_t>, ReinjInfo> g_reinj;
 uint64_t g_reinjEvents = 0;       // MacReinject trace fires (== reinjected)
 uint64_t g_reinjParsed = 0;       // fires where the (flow, seq) parse succeeded
 uint64_t g_reinjOfDelivered = 0;  // fires with the key already delivered
+// #386 probe finding (comment 5233656930): the detector re-injects any non-ant
+// IP payload, and seed 2 of the invariance probe carried 2 events the SeqTs
+// identity could not name — most plausibly ICMP (TTL-exceeded travels the same
+// unicast hops as data). Classify the parse failures instead of failing the
+// books: protocol 1 vs everything else. Recorded, not "fixed" — changing what
+// NotifyTxError re-injects would be a protocol-behaviour change, not
+// instrumentation.
+uint64_t g_reinjUnparsedIcmp = 0;   // parse failures with ip.protocol == 1
+uint64_t g_reinjUnparsedOther = 0;  // any other parse failure
 
 // (flow, seq) off a packet whose front is the UDP header (the form the
 // MacReinject trace and the Ipv4L3Protocol traces hand over — IP header
-// separate). False on anything that is not a SeqTs CBR datagram; on the UDP
-// arm every non-ant data packet is one, so parsed != events is an
-// instrumentation bug and scenario_check FAILs it.
+// separate). False on anything that is not a SeqTs CBR datagram; the
+// MacReinject listener classifies those (unparsedIcmp/unparsedOther), and
+// scenario_check FAILs only when parsed + unparsed != events — the books must
+// close, but a non-data re-injection is a finding, not an error.
 bool ReinjKeyFromUdp(const Ipv4Header& ip, Ptr<const Packet> p,
                      Address& flow, uint32_t& seq) {
     if (ip.GetProtocol() != 17) return false;
@@ -382,7 +392,13 @@ void CountMacReinject(const Ipv4Header& ip, Ptr<const Packet> p) {
     ++g_reinjEvents;
     Address flow;
     uint32_t seq = 0;
-    if (!ReinjKeyFromUdp(ip, p, flow, seq)) return;
+    if (!ReinjKeyFromUdp(ip, p, flow, seq)) {
+        // Classify, don't drop on the floor: parsed + unparsed must equal
+        // events or the books don't close (scenario_check FAILs that).
+        if (ip.GetProtocol() == 1) ++g_reinjUnparsedIcmp;
+        else ++g_reinjUnparsedOther;
+        return;
+    }
     ++g_reinjParsed;
     uint32_t rxNow = 0;
     const auto f = g_rxCount.find(flow);
@@ -973,6 +989,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     g_rxCount.clear();       // #386
     g_reinj.clear();         // #386
     g_reinjEvents = g_reinjParsed = g_reinjOfDelivered = 0;  // #386
+    g_reinjUnparsedIcmp = g_reinjUnparsedOther = 0;          // #386
     g_dataHopTx = g_dataHopRx = g_macDataDrops = 0;  // #215
     g_ackedDataHops = 0;  // #377
     // #217
@@ -1919,8 +1936,10 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         // exclusion floor above (unackedRx vs reinjected), plus what re-injected
         // packets then DO. Event view: `events` MUST equal `reinjected` (the
         // trace fires at the same site that increments the adapter counter —
-        // scenario_check FAILs a mismatch), `parsed` must equal `events` on the
-        // UDP arm, `ofDelivered` counts re-injections of packets already at the
+        // scenario_check FAILs a mismatch); parsed + unparsedIcmp +
+        // unparsedOther must equal `events` (the books close; the unparsed
+        // counts are the probe's non-data-re-injection finding, WARNed not
+        // FAILed); `ofDelivered` counts re-injections of packets already at the
         // destination AT RE-INJECTION TIME (the floor's direct counterpart).
         // Packet view (distinct keys): pktsDelivBefore (delivered before first
         // re-injection) / pktsDelivAfterOnly (delivered late, only after) /
@@ -1961,6 +1980,8 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
             std::cout << "##REINJ## " << seed << ' ' << proto
                       << " events=" << g_reinjEvents
                       << " parsed=" << g_reinjParsed
+                      << " unparsedIcmp=" << g_reinjUnparsedIcmp
+                      << " unparsedOther=" << g_reinjUnparsedOther
                       << " ofDelivered=" << g_reinjOfDelivered
                       << " pkts=" << pkts
                       << " pktsDelivBefore=" << delivBefore

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -335,7 +335,15 @@ TypeId RoutingProtocol::GetTypeId() {
                             "A neighbour/route entry was added or removed "
                             "(dest, neighbour, added).",
                             MakeTraceSourceAccessor(&RoutingProtocol::m_routeChangedTrace),
-                            "ns3::anthocnet::RoutingProtocol::RouteChangedCallback");
+                            "ns3::anthocnet::RoutingProtocol::RouteChangedCallback")
+            .AddTraceSource("MacReinject",
+                            "A MAC retry-limit-dropped data packet was "
+                            "re-injected into the pending queue (#46/#386). "
+                            "Fired once per re-injection, immediately before "
+                            "Enqueue; the packet is the queued form (UDP "
+                            "header + payload, no IP header).",
+                            MakeTraceSourceAccessor(&RoutingProtocol::m_macReinjectTrace),
+                            "ns3::anthocnet::RoutingProtocol::MacReinjectCallback");
     return tid;
 }
 
@@ -1203,6 +1211,10 @@ void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI
         entry.ecb = m_cachedEcb;
         entry.holdReason = HOLD_REPAIR;  // #21: held during local repair (#46)
         ++m_macReinjectedPackets;        // #215: this MAC failure was not terminal
+        // #386: same site as the counter, so a listener's event count and
+        // MacReinjectedPackets() agree by construction (scenario_check asserts
+        // events == reinjected on exactly that ground).
+        m_macReinjectTrace(ipHeader, pkt);
         m_queue.Enqueue(entry);
         FlushQueue(dataDest);
     }

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -75,6 +75,13 @@ public:
     typedef void (*AntTxCallback)(uint8_t type, uint8_t direction, bool broadcast);
     typedef void (*AntRxCallback)(uint8_t type, uint8_t direction);
     typedef void (*RouteChangedCallback)(uint32_t dest, uint32_t neighbor, bool added);
+    // #386: a MAC retry-limit-dropped data packet was re-injected into the
+    // pending queue (#46). `header` is the packet's Ipv4 header as captured off
+    // the failed MPDU; `packet` is the queued form (UDP header + payload, no IP
+    // header — RouteInput's convention). Fired once per re-injection, at the
+    // same site that increments MacReinjectedPackets(), so a listener's event
+    // count and that counter agree by construction.
+    typedef void (*MacReinjectCallback)(const Ipv4Header& header, Ptr<const Packet> packet);
 
     // core::IRouterObserver
     void onAntSent(::anthocnet::core::AntType type,
@@ -376,6 +383,8 @@ private:
     TracedCallback<uint8_t, uint8_t, bool> m_txAntTrace;
     TracedCallback<uint8_t, uint8_t> m_rxAntTrace;
     TracedCallback<uint32_t, uint32_t, bool> m_routeChangedTrace;
+    // #386: MAC-failure re-injection (see MacReinjectCallback above).
+    TracedCallback<const Ipv4Header&, Ptr<const Packet>> m_macReinjectTrace;
 };
 
 } // namespace anthocnet


### PR DESCRIPTION
For #386 (first v1.5.0 work item). Design and both probe readings were [pre-registered on the issue before implementation](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5233250913).

## What

The #46 MAC failure detector re-injects retry-limit-dropped data packets. The inclusion–exclusion bound says **≥59 % of those re-injections are of packets that already arrived** (59.6 % gaussmarkov / 58.8 % rwp) — but a bound is a floor, and no aggregate can say what re-injected packets then *do*, which is what the #377 drop-identity residue is sensitive to. This measures both, per packet:

- **Adapter** (zero `core/` lines): a `MacReinject` trace source fired in `NotifyTxError` on the same statement group as the existing `++m_macReinjectedPackets` — so **`events == ##DROPID## reinjected` by construction**, enforced as a cross-book FAIL in `scenario_check`.
- **Harness**: identity is (flow, seq) from `SeqTsSizeHeader` — the key the sink already records. `ofDelivered` reads the delivery count *at the moment the trace fires* (conservative by construction); end-of-run classification emits one `##REINJ##` row per seed: `pktsDelivBefore` / `pktsDelivAfterOnly` / `pktsNever` (sum = `pkts`), duplicate-delivery inflation (`pktsDupDeliv`, `dupRx`), post-re-injection MAC hops (`postTx`/`postRx`), and L3 drop causes for tracked keys.
- **Absence is the encoding** (#382): baselines emit no row (no detector); TCP emits none (no SeqTs identity on a byte stream); the `EnableMacFailureDetector=false` arm emits the row with every field 0 — a measured zero.
- **Ships with its gates** (#229/#230 rule, same commit): workflow compact re-emit grep, six `scenario_check` assertions, staying-quiet + firing test fixtures (73 cases pass), `metrics.md` section.

## Merge gate — pre-registered invariance probe

**Do not merge on green CI alone.** Per the pre-registration: two `paper-benchmark` dispatches at identical inputs, parent commit vs this branch, `gaussmarkov × nakagami`, `runs=5`, all four protocols. Pass: every existing block (`##BENCH##`, `##RUN##`, `##DROPID##`, `##HOLD##`, `# drops`, `# paths`, `# stddev`) **byte-identical** after stripping `##REINJ##` lines; the branch adds exactly 5 `##REINJ##` rows, anthocnet only. Any digit of any existing metric differing — or a `##REINJ##` row for a baseline, or `parsed ≠ events` — blocks the merge.

## Risk decided in advance

The `Ipv4L3Protocol "Drop"` trace signature is believed stable across 3.36–3.48 but CI-verified only. If any matrix version rejects it, the l3Drop stage is **cut from this PR** (it is wired for clean amputation: own callback, own connect line, trailing fields the `REINJ_LINE` regex ignores) — not #ifdef-gated.

## Verification here

No local ns-3 build — CI's five-version matrix is the first compile. `test_scenario_check.py`: 73 cases pass. `protocol-review` invariant checks: PASS (no NS headers in core/, no wire-format surface, no core logic). The behavioural verification is the invariance probe above, run pre-merge.

Refs #386, #46, #377, #388, #215, #217, #229, #230, #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_