### PR TITLE
feat(bench): promote the #386 soundness identities and correct the reorder gloss

### DIFF
--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -132,7 +132,7 @@ REINJ_LINE = re.compile(
     r"^\s*##REINJ##\s+(\d+)\s+([a-z][\w-]*)\s+events=(\d+)\s+parsed=(\d+)"
     r"\s+unparsedIcmp=(\d+)\s+unparsedOther=(\d+)"
     r"\s+ofDelivered=(\d+)\s+pkts=(\d+)\s+pktsDelivBefore=(\d+)"
-    r"\s+pktsDelivAfterOnly=(\d+)\s+pktsNever=(\d+)\b")
+    r"\s+pktsDelivAfterOnly=(\d+)\s+pktsNever=(\d+)\s+pktsDupDeliv=(\d+)\b")
 # #386: the knob the coherence rule reads. Preflight cannot see extraArgs (it
 # takes numeric scenario args only), so detector-off coherence is enforced
 # results-side from the ##CONFIG## attr dump of effective attribute values.
@@ -677,6 +677,14 @@ def check_reinj(path):
     next-hop arrivals (unackedRx), so the two sit on slightly different events
     and a small shortfall can be timing, not books. A large one means the
     direct counter and the bound disagree and #386's premise needs re-checking.
+
+    Two further identities were promoted to FAILs after reading 2, per the
+    amended pre-registration (#386 comment 5233754808): ofDelivered >=
+    pktsDelivBefore (a key delivered before its first re-injection contributes
+    at least one delivered-at-fire-time event) and pktsDupDeliv <=
+    pktsDelivBefore + pktsDelivAfterOnly (a duplicate-delivered key is a
+    delivered key). Both hold by construction of the (flow, seq) keying, so a
+    violation means the keying itself is unsound.
     """
     with open(path) as fh:
         text = fh.read()
@@ -702,6 +710,7 @@ def check_reinj(path):
         of_deliv, pkts = int(m.group(7)), int(m.group(8))
         before, after_only, never = (int(m.group(9)), int(m.group(10)),
                                      int(m.group(11)))
+        dup_deliv = int(m.group(12))
         tag = f"{base}/{proto}"
         if proto != "anthocnet":
             report("FAIL", f"{tag}: ##REINJ## row for a protocol with no "
@@ -736,6 +745,21 @@ def check_reinj(path):
                            f"(ofDelivered={of_deliv}/events={events}, "
                            f"{before}+{after_only}+{never} != pkts={pkts}) — "
                            "the partition must be exact (#386)")
+        # #386 reading-2 promotions (comment 5233754808): two identities the
+        # event and packet views must satisfy by construction; a violation is
+        # unsound keying, not noise.
+        if of_deliv < before:
+            report("FAIL", f"{tag}: ofDelivered={of_deliv} < "
+                           f"pktsDelivBefore={before} at seed {seed} — every "
+                           "already-delivered key contributes at least one "
+                           "delivered-at-fire-time event; the (flow,seq) "
+                           "keying is unsound (#386)")
+        if dup_deliv > before + after_only:
+            report("FAIL", f"{tag}: pktsDupDeliv={dup_deliv} > "
+                           f"pktsDelivBefore={before} + "
+                           f"pktsDelivAfterOnly={after_only} at seed {seed} — "
+                           "a duplicate-delivered key must be a delivered key "
+                           "(#386)")
         if detector_off and events > 0:
             report("FAIL", f"{tag}: events={events} at seed {seed} with "
                            "EnableMacFailureDetector=false in ##CONFIG## — "

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -1133,6 +1133,30 @@ def _reinj_incoherent_fires():
            f"a baseline ##REINJ## row was accepted\n{out}")
 
 
+@case("#386 ofDelivered below pktsDelivBefore FAILs — unsound keying")
+def _reinj_ofdeliv_floor_fires():
+    # Reading-2 promotion (comment 5233754808): a key delivered before its
+    # FIRST re-injection contributes >= 1 delivered-at-fire-time event, so
+    # ofDelivered >= pktsDelivBefore by construction. 1290 < 1300 can only be
+    # the event and packet views keyed differently. (The inclusion-exclusion
+    # floor WARN also fires here — 1290 < 1527 — which is correct and ignored.)
+    row = REINJ_CLEAN.replace("ofDelivered=1608", "ofDelivered=1290")
+    _levels, out = run_cell(ISL_CELL + DROPID_REINJ_ARM + row)
+    expect("keying is unsound" in out, "reinj-ofdeliv-floor",
+           f"ofDelivered < pktsDelivBefore was not flagged\n{out}")
+
+
+@case("#386 pktsDupDeliv above the delivered keys FAILs")
+def _reinj_dup_bound_fires():
+    # The other reading-2 promotion: a duplicate-delivered key must be a
+    # delivered key, so pktsDupDeliv <= pktsDelivBefore + pktsDelivAfterOnly.
+    # 1900 > 1300 + 520 counts duplicates on keys that were never delivered.
+    row = REINJ_CLEAN.replace("pktsDupDeliv=900", "pktsDupDeliv=1900")
+    _levels, out = run_cell(ISL_CELL + DROPID_REINJ_ARM + row)
+    expect("must be a delivered key" in out, "reinj-dup-bound",
+           f"pktsDupDeliv beyond the delivered keys was not flagged\n{out}")
+
+
 @case("#386 non-data re-injections with closing books WARN, never FAIL")
 def _reinj_unparsed_warns():
     # The invariance probe's actual finding (comment 5233656930): 2 events the

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -335,13 +335,18 @@ a property of independent per-frame fading, so on two-ray — where reception is
 a deterministic function of distance — the correction is a no-op, exactly as it
 should be.
 
-**Not closed for AntHocNet.** Its arm lands at `sum` **101.41**, over by 1.41
-pp. `hopLoss` is a per-hop tally while the identity is end-to-end, and a packet
-whose hop failed, was re-injected by #46 and then arrived by another route
-contributes to the first but is not an end-to-end loss. Tracked on
-[#386](https://github.com/danieljoppi/AntHocNet/issues/386), which also reads
-`unackedRx` against `reinjected` to bound how many re-injections are of packets
-that had already arrived (≥ 58.8 % per run under fading).
+**Closed for AntHocNet — the residue was re-injection (#377 → #386).** Its
+fading arm lands at `sum` ~**101–103** (1.41 pp over on the #377 probe): the
+per-hop books count a re-injected packet's *extra copies* — a packet whose hop
+failed, was re-injected by #46 and then travelled on contributes additional
+`hopTx`/`macDrops` entries while the identity is end-to-end and counts it once.
+That straddle is **expected and documented, not a books error**: the #386
+detector A/B measured the identity closing at **exactly 100.00** on both
+900 s Nakagami cells with `EnableMacFailureDetector=false` on identical seeds
+([#386 comment 5234323092](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5234323092)),
+so the whole overshoot is the detector's re-injection traffic. `##REINJ##`
+below is the per-packet accounting of the same mechanism; the hop-level bound
+(`unackedRx` vs `reinjected`, ≥ 58.8 % per run under fading) was its floor.
 
 **Absent under TCP, not zero.** Every counter is gated on `IsDataIp`, which
 tests for UDP on the data port, so a TCP cell would print all zeros — reading
@@ -412,6 +417,20 @@ WARNs when `ofDelivered` falls below the same-seed inclusion–exclusion floor
 `reinjected + unackedRx − macDrops` (WARN, not FAIL: the floor is built from
 *next-hop arrivals* while `ofDelivered` counts *sink deliveries*, so a small
 shortfall can be timing rather than broken books).
+
+**Measured reference (reading 2,
+[#386 comment 5234323092](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5234323092)).**
+On the 900 s Nakagami cells, both mobility models, 5 seeds each:
+`ofDelivered/events` ≈ **0.62–0.63** — the direct rate, above the hop-level
+inclusion–exclusion floor on **10/10** seeds; `dupRx` ≈ **0.5 per event**
+(duplicate deliveries are not suppressed); `pktsNever` ≈ **2–5 %** of
+re-injected keys. n=5 per cell is below the
+[#293](https://github.com/danieljoppi/AntHocNet/issues/293) publishable floor —
+treat these as the diagnostic reference the checks calibrate against, not as
+publishable points. The same reading measured the detector as an *operating
+point*: switching it off cost **−6.4 pp PDR** on 5/5 seeds in both cells, so
+the re-injection waste these fields expose is currently paid for delivery, not
+a free defect.
 
 The trailing `l3DropRoute`/`l3DropTtl`/`l3DropOther` fields attribute the
 L3-visible drops of re-injected keys (the pending-queue ageout's error callback
@@ -748,6 +767,16 @@ regression, in the same class as the #51 anchor floors:
   misattribution (tens of pp).
 - A negative share in any cause also FAILs: it means two causes are counting
   the same packet.
+- **One documented overshoot: the AntHocNet re-injection straddle on fading
+  cells.** An AntHocNet fading-cell sum of ~**101–103** is expected, not a
+  books error ([#377](https://github.com/danieljoppi/AntHocNet/issues/377)'s
+  closure): the per-hop books count a #46-re-injected packet's extra copies
+  while the identity is end-to-end. The #386 detector A/B pinned it — on
+  identical seeds the same cells read **exactly 100.00** with
+  `EnableMacFailureDetector=false`
+  ([#386 comment 5234323092](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5234323092)).
+  Read the overshoot against `##REINJ##`'s `postTx`/`dupRx`; it scales with
+  re-injection volume, not with any misattribution.
 
 If the check fails, **do not read the breakdown** — one of the three books is
 wrong (a drop path that fires no error callback, a trace hook that did not
@@ -1093,6 +1122,22 @@ matters is whether the reordering an application would feel is worth those
 gains — which is exactly the question [#179](https://github.com/danieljoppi/AntHocNet/issues/179) (`betaData` 2 → the thesis's 20)
 has to answer, and could not before this metric existed.
 
+> **Correction for fading cells (#386).** The gloss above holds on the
+> deterministic channels only. Under a fading channel AntHocNet's
+> `reorder_ratio` (measured **0.1788** rwp / **0.2408** gaussmarkov on the
+> 900 s Nakagami cells) is dominated by the
+> [#46](https://github.com/danieljoppi/AntHocNet/issues/46) MAC-failure
+> re-injection's **duplicate deliveries**, not by multipath spreading: the
+> #386 detector A/B on identical seeds collapses it to **0.0008** (rwp) /
+> **0.0007** (gaussmarkov) with
+> `EnableMacFailureDetector=false`, a ~250x drop from switching off a
+> mechanism that is not multipath
+> ([#386 comment 5234323092](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5234323092)).
+> The multipath reading stays valid off-fading — the matched two-ray cell
+> reads 0.0004, genuinely multipath-scale. On a fading cell, read
+> `reorder_ratio` as a re-injection-duplicate gauge (cross-check `##REINJ##`'s
+> `dupRx`) and use `reorder_buf_max` with the same caution.
+
 `FlowMonitor` reports per-flow counts and delays, never per-packet order, so
 these come from an application-level sequence number instead: the ns-3
 `OnOffApplication` sources set `EnableSeqTsSizeHeader`, and every `PacketSink`
@@ -1152,8 +1197,14 @@ Metrics*), applied to the receive stream of one flow at the sink:
    PDRs it would measure loss rather than reordering.
 
 Duplicates are not handled specially: `OnOffApplication` emits each sequence
-number once and IP-layer unicast forwarding does not duplicate, so a flow's
-received sequence numbers are unique.
+number once and IP-layer unicast forwarding does not duplicate. **On a fading
+cell that premise fails**: the #46 re-injection path retransmits packets whose
+first copy already arrived (delivered-but-ACK-lost), so the sink can receive
+the same `(flow, seq)` more than once — measured at `dupRx` ≈ 1500–2400 per
+900 s Nakagami run (#386 comment 5234323092). A duplicate arrives with
+`s < NextExp` and is therefore counted as reordered, which is the mechanism
+behind the fading correction above. Off-fading the uniqueness assumption holds
+and the columns read as documented.
 
 ### Instrumentation self-check
 


### PR DESCRIPTION
The two follow-ups promised in the [#386 reading-2 verdict](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5234323092). Docs and skill scripts only — **no harness or adapter code is touched**, so no invariance probe applies; verified against the diff (`metrics.md` + the two `scenario_check` scripts, 109/−10 lines).

## Commit 1 — `docs(bench)`: the fading reorder gloss was measured false, and now says so

`metrics.md` read a non-zero AntHocNet reorder ratio as *"stochastic multipath working as designed, not a fault"*. The reading-2 A/B falsified that for fading cells: the ratio reads **0.1788 (rwp) / 0.2408 (gaussmarkov)** with the MAC-failure detector on and collapses to **0.0008 / 0.0007** on identical seeds with `EnableMacFailureDetector=false` — a ~250× drop from switching off a mechanism that is not multipath. The section now attributes the fading-cell ratio to #46 re-injection duplicates (`dupRx` ~1500–2400/run; a duplicate arrives with `s < NextExp` and is counted RFC-4737-reordered), keeps the multipath reading for non-fading cells (two-ray 0.0004 is genuinely multipath-scale), and corrects the now-falsified "received sequence numbers are unique" premise.

Also records the #377 closure where the drop identity is documented: the AntHocNet fading-cell `sum` of ~101–103 is the re-injection straddle, expected — pinned by the detector-off arm reading exactly **100.00** in both cells. The `##REINJ##` section gains the measured reference (direct rate 0.62–0.63 at 900 s, above the hop-level floor 10/10 seeds; `pktsNever` 2–5 %; the +6.4 pp PDR operating-point fact), explicitly flagged n = 5 < the #293 floor — a diagnostic reference, not a publishable claim.

## Commit 2 — `feat(bench)`: the two soundness identities become gates

Promised in the [amended pre-registration](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5233754808): `check_reinj` gains two FAILs — `ofDelivered < pktsDelivBefore` (every already-delivered key contributes at least one delivered-at-fire-time event; violation means the (flow, seq) keying is unsound) and `pktsDupDeliv > pktsDelivBefore + pktsDelivAfterOnly` (a duplicate-delivered key must be a delivered key). One firing fixture each; the existing clean fixture verified to satisfy both and stay quiet. **76 gate tests pass** (was 74).

## Verification

`test_scenario_check.py` 76/76; ruff + py_compile clean; `protocol-review` invariants PASS (no core/, no wire format, no ns-3 code).

Refs #386, #377, #212, #46, #229, #230, #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_