### PR TITLE
docs(bench): dupRx is app-layer duplicate traffic, not FlowMonitor inflation

### DIFF
--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -408,7 +408,7 @@ run):
 | `pktsDelivBefore` | delivered before their **first** re-injection (the waste-certain class) |
 | `pktsDelivAfterOnly` | never delivered before first re-injection, delivered by end of run (delivered late — the re-injection plausibly saved them) |
 | `pktsNever` | never delivered at all (dropped) |
-| `pktsDupDeliv` / `dupRx` | keys the sink delivered ≥ 2 times / total surplus deliveries (how much duplicate delivery inflates FlowMonitor's rx) |
+| `pktsDupDeliv` / `dupRx` | keys the sink delivered ≥ 2 times / total surplus deliveries — duplicate arrivals at the **application layer**, counted by the sink-side `(flow, seq)` books. The [#386 A/B arithmetic](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5235242703) shows FlowMonitor's `rxPackets` does **not** count them materially (a counted `dupRx` would have moved the ON−OFF PDR contrast by ~27 pp; measured +6.4), so FlowMonitor PDR reads unique delivery and `dupRx` measures real duplicate traffic, not metric inflation |
 | `postTx` / `postRx` | IP-layer hop transmissions / arrivals of re-injected keys **after** their first re-injection — the hops re-injected packets go on to consume (the wasted-work number); `postTx − postRx` is their post-re-injection in-medium loss |
 
 `pktsDelivBefore + pktsDelivAfterOnly + pktsNever = pkts` exactly;


### PR DESCRIPTION
One-line correction to the `##REINJ##` field table in `docs/benchmarks/metrics.md`, discharging the follow-up owed in [#386's correction comment](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5235242703).

The table described `pktsDupDeliv`/`dupRx` as *"how much duplicate delivery inflates FlowMonitor's rx"* — an unverified transfer from the sink-side (flow, seq) books to FlowMonitor's. The reading-2 A/B arithmetic contradicts it: a counted `dupRx` (~2205–2392/seed vs `tx` ≈ 8139) would have moved the detector ON−OFF PDR contrast by ~27 pp; the measured contrast is +6.4 pp. So FlowMonitor PDR reads unique delivery, **the +6.4 pp detector benefit is real delivery**, and `dupRx` measures genuine app-layer duplicate traffic — which the field table now says, with the arithmetic linked. The elimination caveat (partial counting small relative to 6.4 pp not excluded without reading FlowMonitor's dedup mechanics) is carried in the linked comment.

Docs-only, one line.

Refs #386, #398, #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_