### PR TITLE
feat(protocol): cap per-packet mac re-injections behind MaxReinjectPerPacket

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,12 +208,13 @@ class of defect as a missing one.
 
 ### 3.4 ns-3 attributes that are *not* `Config` fields
 
-Six of the 30 attributes configure the NS-3 adapter, not the algorithm. They are
+Seven of the 31 attributes configure the NS-3 adapter, not the algorithm. They are
 listed here so a sweep does not mistake one for a protocol parameter:
 
 | attribute | default | what it does |
 |---|---|---|
 | `EnableMacFailureDetector` | `true` | Enables the WifiMac transmit-failure detector (ADR-0008 detector D). The hello-timeout detector (A) always runs. |
+| `MaxReinjectPerPacket` | `0` (unlimited) | Issue [#386](https://github.com/danieljoppi/AntHocNet/issues/386) remedy: caps how many times a single data packet may be re-injected by the #46 MAC-failure detector across its whole path (a packet tag carries the count between hops — ns-3 metadata, never on the wire). Motivation: the #386 direct measurement found packets are re-injected ~2.1–2.3 times on average, with ~62 % of re-injections being of already-delivered packets, while the mechanism as a whole still rescues +6.4 pp PDR under fading — the cap aims to keep the rescue and cut the waste. **The default is decided by the v1.5.0 sweep** (cap ∈ {1, 2, ∞} × detector-off arms, 20 seeds); until then `0` = unlimited preserves the historical behaviour behind every published number, and the cap logic is unreachable at that default. |
 | `QueueTimeout` | `3 s` | How long a data packet may wait for a route before being dropped (#21 deliver-late vs discard trade). |
 | `ReconvHoldCap` | `1 s` | Caps how long a reconvergence-held packet may wait (issue #21 lever L2, #103/#104). Bounded by `QueueTimeout`. **This is an operating-point choice, not a neutral default**: the [#308 ablation](https://github.com/danieljoppi/AntHocNet/issues/308#issuecomment-5211529535) showed causally that the hold converts would-be drops into late deliveries, so the cap trades the `delay99` tail against the PDR advantage — and the [#309 sweep](https://github.com/danieljoppi/AntHocNet/issues/309) found `200 ms` beats AODV on every published metric with a far smaller tail, i.e. the 1 s default is delivery-biased and off the measured efficient frontier ([#371](https://github.com/danieljoppi/AntHocNet/issues/371)). Every published number was measured at 1 s; set `200 ms` if your workload prices the tail above the last points of PDR. The default itself changes no earlier than the v1.5.0 re-baseline. |
 | `RepairHoldCap` | `0 s` (disabled) | The same cap for repair-held packets. |

--- a/ns3/model/anthocnet-routing-protocol.cc
+++ b/ns3/model/anthocnet-routing-protocol.cc
@@ -22,6 +22,7 @@
 #include "ns3/arp-cache.h"
 #include "ns3/llc-snap-header.h"
 #include "ns3/udp-header.h"
+#include "ns3/tag.h"
 
 namespace ns3 {
 
@@ -60,6 +61,7 @@ RoutingProtocol::RoutingProtocol()
       m_sessionTtl(5.0),
       m_txFailureThreshold(3),
       m_enableMacFailureDetector(true),
+      m_maxReinjectPerPacket(0),
       m_repairWaitFactor(5.0),
       m_repairTimeout(1.0),
       m_hopTime(0.003),
@@ -186,6 +188,20 @@ TypeId RoutingProtocol::GetTypeId() {
                           BooleanValue(true),
                           MakeBooleanAccessor(&RoutingProtocol::m_enableMacFailureDetector),
                           MakeBooleanChecker())
+            .AddAttribute("MaxReinjectPerPacket",
+                          "Issue #386 remedy: caps how many times a single data "
+                          "packet may be re-injected by the #46 MAC-failure "
+                          "detector across its whole path (a packet tag carries "
+                          "the count with the packet, so the cap is path-global, "
+                          "not per-node). 0 = unlimited, the historical "
+                          "behaviour, and the cap logic is unreachable. "
+                          "Motivation: the #386 direct measurement — packets "
+                          "are re-injected ~2.1-2.3 times on average and ~62% "
+                          "of re-injections are of already-delivered packets. "
+                          "The default is decided by the v1.5.0 sweep.",
+                          UintegerValue(0),
+                          MakeUintegerAccessor(&RoutingProtocol::m_maxReinjectPerPacket),
+                          MakeUintegerChecker<uint32_t>())
             .AddAttribute("RepairWaitFactor",
                           "Local-repair wait as a multiple of the lost path's "
                           "estimated end-to-end delay ([1] section 3.5, D6).",
@@ -1144,6 +1160,32 @@ void RoutingProtocol::ReactiveRetryTimerExpire() {
 
 // --- MAC transmit-failure hook (ADR-0008 detector D) ------------------------
 
+// #386 remedy: counts how many times the #46 detector has re-injected this data
+// packet, across its whole path — a PacketTag travels with the packet between
+// hops inside the simulation, so the count is path-global, not per-node. Pure
+// ns-3 metadata: never serialized to the medium, invisible to Packet::GetSize()
+// and to every header parse. Consulted and stamped only when
+// MaxReinjectPerPacket != 0; at the default 0 the tag never exists.
+class ReinjCountTag : public Tag {
+public:
+    static TypeId GetTypeId() {
+        static TypeId tid = TypeId("ns3::anthocnet::ReinjCountTag")
+                                .SetParent<Tag>()
+                                .SetGroupName("AntHocNet")
+                                .AddConstructor<ReinjCountTag>();
+        return tid;
+    }
+    TypeId GetInstanceTypeId() const override { return GetTypeId(); }
+    uint32_t GetSerializedSize() const override { return 2; }
+    void Serialize(TagBuffer i) const override { i.WriteU16(m_count); }
+    void Deserialize(TagBuffer i) override { m_count = i.ReadU16(); }
+    void Print(std::ostream& os) const override { os << "reinjCount=" << m_count; }
+
+    uint16_t m_count = 0;
+};
+
+NS_OBJECT_ENSURE_REGISTERED(ReinjCountTag);
+
 void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI_MPDU> mpdu) {
     // Detector D is a latency optimisation over the mandatory hello-timeout
     // detector A (ADR-0008); it can be gated off for ablation (issue #46).
@@ -1204,6 +1246,30 @@ void RoutingProtocol::NotifyTxError(WifiMacDropReason reason, Ptr<const AHN_WIFI
     // route survived the prune (FlushQueue re-queues if none did). The retry
     // costs one extra TTL decrement, like any real retransmission path.
     if (haveData && ipHeader.GetTtl() > 1 && !m_cachedUcb.IsNull()) {
+        // #386 remedy: per-packet re-injection cap. Deliberately a split, not a
+        // merged path: at the default 0 (= unlimited, the historical behaviour)
+        // the packet is neither peeked for nor stamped with ReinjCountTag, so
+        // the hot path — and the packet's metadata — stays byte-identical to
+        // pre-#386 code. Only a non-zero cap ever touches the tag.
+        if (m_maxReinjectPerPacket != 0) {
+            ReinjCountTag tag;
+            const bool tagged = pkt->PeekPacketTag(tag);
+            const uint32_t count = tagged ? tag.m_count : 0u;
+            if (count >= m_maxReinjectPerPacket) {
+                // Cap reached: skip the re-injection exactly as if the detector
+                // had not matched (the prune + repair ant above still ran). No
+                // counter, no trace, no enqueue — the #386 books count actual
+                // re-injections only, so the sweep reads a capped skip through
+                // events, macTerminal and the standard metrics.
+                return;
+            }
+            // count < cap <= 2^32-1, so count+1 wraps uint16_t only for caps
+            // above 65535; saturate rather than wrap (the cap then never fires
+            // again for this packet, degrading to unlimited — harmless).
+            if (count < 0xffff) tag.m_count = static_cast<uint16_t>(count + 1);
+            if (tagged) pkt->ReplacePacketTag(tag);
+            else pkt->AddPacketTag(tag);
+        }
         QueueEntry entry;
         entry.packet = pkt;
         entry.header = ipHeader;

--- a/ns3/model/anthocnet-routing-protocol.h
+++ b/ns3/model/anthocnet-routing-protocol.h
@@ -320,6 +320,7 @@ private:
     double m_sessionTtl;
     uint32_t m_txFailureThreshold;
     bool m_enableMacFailureDetector;
+    uint32_t m_maxReinjectPerPacket;  ///< #386 remedy: path-global re-injection cap (0 = unlimited)
     double m_repairWaitFactor;
     double m_repairTimeout;
     double m_hopTime;                 ///< T_hop unloaded-hop reference (s), #88


### PR DESCRIPTION
The #386 remedy mechanism, per the maintainer's decision — shipped **default-OFF** (`MaxReinjectPerPacket = 0` = unlimited = the historical behaviour), with the operating point chosen by the pre-registered v1.5.0 sweep (cap ∈ {1, 2, ∞} × detector-OFF, 20 seeds), not assumed here.

## What

- **Attribute** `MaxReinjectPerPacket` (uint32, default 0) on the ns-3 adapter.
- **Mechanism**: a `ReinjCountTag` PacketTag rides with the re-injected copy, so the cap is **path-global** — a packet re-injected at one node and again downstream counts both. In-simulation metadata only: never in the byte `Buffer`, no wire bytes, no `kWireVersion`, no effect on `Packet::GetSize()` (which drives WifiPhy tx duration).
- **At the cap**: the re-injection is skipped exactly as if the detector had not matched — an early return *before* the counter and the `MacReinject` trace, so `events == reinjected` stays true by construction and `macTerminal` keeps its #215 meaning (a capped packet's MAC failure genuinely is terminal).
- **Byte-identity at the default, by structure**: the code splits on `m_maxReinjectPerPacket != 0`; at 0 the only new instruction is that single compare — no tag peek, no tag attach, the enqueued packet is the same object state as before. The invariance claim does not rest on PacketTag semantics.
- `##CONFIG##` records the attribute automatically (the dump iterates the TypeId); `docs/configuration.md` gains the row. NS-2 adapter untouched (behaves as cap=0; recorded asymmetry).

## Why cap=1 is the sweep's leading candidate (from the #386 books, not assumed)

`events/pkts` ≈ 2.1–2.3 and ~62 % of re-injections are of already-delivered packets, so cap=1 removes roughly half of the ~5,000–8,800 post-re-injection transmissions per run while keeping the first re-injection — where the rescue evidence (`pktsDelivAfterOnly`; the detector's +6.4 pp PDR) plausibly concentrates. Whether +6.4 pp survives the cap is the sweep's question.

## Merge gate — pre-registered invariance probe ([#386](https://github.com/danieljoppi/AntHocNet/issues/386#issuecomment-5235406683))

**Do not merge on green CI alone.** Two `paper-benchmark` dispatches at identical inputs, parent vs branch, attribute at default, `gaussmarkov × nakagami`, `runs=5`: the entire compact block must be byte-identical **including the `##REINJ##` rows** (stricter than #398's gate — an untouched default must not change what the detector does), excluding only `##PROV##`. Additionally one capped-arm run (`MaxReinjectPerPacket=1`) is read for **coherence only** (runs clean, books internally coherent, `##CONFIG##` shows the cap) — its performance numbers are reserved for the 20-seed sweep and will not be quoted.

## Verification here

No local ns-3 build — CI's five-version matrix is the first compile (`Tag`/`TagBuffer`/`PacketTag` APIs stable across 3.36–3.48; patterns match the existing `AntHeader`/`TxFailureThreshold` code). `protocol-review` invariants PASS: zero `core/` lines, no wire-format surface, docs updated in-diff. The uint16 tag count saturates at 65535 (degrades to unlimited; commented — sweep caps are single digits).

Refs #386, #46, #371, #293, #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_