### PR TITLE
ci(bench): rescue the per-merge benchmark-results artifact, and schedule #229 into phase 0

### DIFF
--- a/.github/workflows/rescue-artifacts.yml
+++ b/.github/workflows/rescue-artifacts.yml
@@ -10,6 +10,12 @@ name: Rescue run artifacts into docs (manual)
 # #259 extends the same rescue to the satellite suite: the `satellite-benchmark`
 # artifact's satellite-results.txt (human table + ##RUN## rows, not a CSV)
 # lands as docs/benchmarks/campaign/<runid>-sat.txt.
+#
+# #229 extends it to the per-merge `benchmarks` workflow: its
+# `benchmark-results` artifact carries the scenarios.csv with the drop_*_pct
+# columns that the job log swallows (run-scenarios.py keeps only CSV rows), so
+# the only drop-cause data the per-merge run produces dies with the artifact
+# unless rescued. Lands as docs/benchmarks/campaign/<runid>-merge.csv.
 on:
   workflow_dispatch:
     inputs:
@@ -18,6 +24,9 @@ on:
         default: '30031902395,30031904151'
       sat_run_ids:
         description: 'Comma-separated workflow run IDs whose satellite-benchmark artifact to rescue (#259); clear run_ids when rescuing only satellite runs'
+        default: ''
+      merge_run_ids:
+        description: 'Comma-separated workflow run IDs whose benchmark-results artifact (per-merge benchmarks workflow, #229) to rescue; clear the other inputs when rescuing only these'
         default: ''
 
 permissions:
@@ -95,6 +104,34 @@ jobs:
             cp "$dir/satellite-results.txt" "docs/benchmarks/campaign/${id}-${label}.txt"
           done
           rm -rf rescue-tmp
+      - name: Download per-merge benchmark artifacts and stage CSVs (#229)
+        if: github.event.inputs.merge_run_ids != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p docs/benchmarks/campaign
+          IFS=',' read -ra IDS <<< "${{ github.event.inputs.merge_run_ids }}"
+          for id in "${IDS[@]}"; do
+            id="$(echo "$id" | tr -d ' ')"
+            # The per-merge `benchmarks` workflow's scenarios.csv is the only
+            # place its drop_*_pct columns exist (the job log swallows them) —
+            # the -merge suffix distinguishes it from manual campaign CSVs.
+            label="merge"
+            dir="rescue-tmp/$id"
+            gh run download "$id" -R "$GITHUB_REPOSITORY" -n benchmark-results -D "$dir"
+            if [ ! -f "$dir/scenarios.csv" ]; then
+              echo "FAIL: no scenarios.csv in benchmark-results artifact of run $id"; exit 1
+            fi
+            rows=$(( $(wc -l < "$dir/scenarios.csv") - 1 ))
+            if [ "$rows" -lt 1 ]; then
+              echo "FAIL: scenarios.csv of run $id has no data rows"; exit 1
+            fi
+            echo "run $id ($label): $rows data rows"
+            cp "$dir/scenarios.csv" "docs/benchmarks/campaign/${id}-${label}.csv"
+          done
+          rm -rf rescue-tmp
       - name: Commit rescued results
         run: |
           git config user.name "github-actions[bot]"
@@ -103,6 +140,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "nothing new to commit"
           else
-            git commit -m "benchmarks: rescue campaign results from expiring artifacts (#122, #259) [skip ci]"
+            git commit -m "benchmarks: rescue campaign results from expiring artifacts (#122, #259, #229) [skip ci]"
             git push origin "HEAD:${{ github.ref_name }}"
           fi

--- a/docs/benchmarks/v1.5.0-campaign.md
+++ b/docs/benchmarks/v1.5.0-campaign.md
@@ -50,7 +50,16 @@ Cheap work that must land first, because it changes what the campaign can read.
    The regression floors were set against the 1 s hold cap. If the default flips,
    floors calibrated on the old default will either mis-fire or silently pass.
    Decide per anchor: re-derive, or state why it is default-independent.
-3. **Sweep pre-registration written on [#386](https://github.com/danieljoppi/AntHocNet/issues/386)**, stating readability
+3. **[#229](https://github.com/danieljoppi/AntHocNet/issues/229) — DSDV's
+   dense-regime queue drops land in no bucket** (−9.84 pp at `dense-small` in
+   the last committed measurement, and the fix the accounting rework never
+   touched: DSDV's internal `PacketQueue` sheds packets above every book). A
+   P1 identity defect in a published-page scenario cannot ride into the
+   re-baseline unfixed — phase 1's grid would republish a known-broken DSDV
+   breakdown. The settle measurement is cheap (rescue the per-merge
+   `benchmark-results` artifact, or one preflighted dense-small dispatch);
+   the fix is a DSDV drop-trace hook with the standing byte-identity probe.
+4. **Sweep pre-registration written on [#386](https://github.com/danieljoppi/AntHocNet/issues/386)**, stating readability
    per arm explicitly (which columns each arm may be read for) and the refutation
    conditions, before phase 2 dispatches.
 


### PR DESCRIPTION
Two connected changes from the [#229 verification](https://github.com/danieljoppi/AntHocNet/issues/229#issuecomment-5245493725). **There is a deadline attached: the artifact this makes rescuable expires 2026-08-17.**

## 1. `rescue-artifacts.yml` learns the per-merge `benchmark-results` artifact

New `merge_run_ids` input, mirroring the two existing rescue steps; lands as `docs/benchmarks/campaign/<runid>-merge.csv`. Why: the per-merge `benchmarks` run's `scenarios.csv` is the **only place its `drop_*_pct` columns exist** — `run-scenarios.py` swallows the harness stdout, the committed scenario pages carry no drop columns, artifacts are proxy-blocked from analysis sessions, and the existing rescue steps only accept the `scenario-matrix`/`satellite-benchmark` names. Immediate use: run [31390680067](https://github.com/danieljoppi/AntHocNet/actions/runs/31390680067) (at `30ec068`) holds the **first post-#388 dense-small drop-cause measurement in existence**, and it dies on 08-17 without this.

## 2. The campaign plan's phase 0 gains #229

Last committed dense-small measurement: DSDV `sum=90.16`, `drop_queue` exactly 0.00 — the filed defect alive at −9.84 pp — and the accounting rework mechanically could not have fixed it (DSDV's internal `PacketQueue` sheds packets above every book the identity reads). Phase 1's grid re-baseline must not republish a known-broken DSDV breakdown, so #229 joins #402 and the anchor review as a phase-0 prerequisite.

## Verification

YAML validated (`yaml.safe_load`); the new step is a structural mirror of the existing `scenario-matrix` step (same download/validate/stage/commit path, same fail-on-empty guards). Docs+workflow only; no harness surface.

After merge, dispatching `rescue-artifacts.yml` with `merge_run_ids=31390680067` (and the other inputs cleared) performs the actual rescue — noted here so the deadline survives context loss.

Refs #229, #122, #259, #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_