### PR TITLE
ci(bench): clear rescue-artifacts' stale run_ids default — the API substitutes defaults for empty inputs

### DIFF
--- a/.github/workflows/rescue-artifacts.yml
+++ b/.github/workflows/rescue-artifacts.yml
@@ -20,8 +20,8 @@ on:
   workflow_dispatch:
     inputs:
       run_ids:
-        description: 'Comma-separated workflow run IDs whose scenario-matrix artifact to rescue'
-        default: '30031902395,30031904151'
+        description: 'Comma-separated workflow run IDs whose scenario-matrix artifact to rescue (the June #110 campaign was 30031902395,30031904151 — long expired; kept as labels in the step)'
+        default: ''
       sat_run_ids:
         description: 'Comma-separated workflow run IDs whose satellite-benchmark artifact to rescue (#259); clear run_ids when rescuing only satellite runs'
         default: ''


### PR DESCRIPTION
Two-line fix unblocking the #229 rescue retry, with the failure mechanism recorded ([diagnosis on #229](https://github.com/danieljoppi/AntHocNet/issues/229#issuecomment-5245894936)): **GitHub substitutes a `workflow_dispatch` input's default when the caller passes an empty string**, not only when the input is omitted — so "clear `run_ids`" was impossible through the API, and the first rescue attempt silently re-attempted the long-expired June #110 artifacts and died before the new `merge_run_ids` step ran.

`run_ids` now defaults to `''` like the other two inputs; the June IDs stay documented in the input description and the step's case labels.

After merge: re-dispatch `rescue-artifacts.yml` with `merge_run_ids=31390680067` — the only post-#388 dense-small drop-cause measurement in existence, expiring **2026-08-17** — then read the DSDV row for the #229 post-rework verdict.

YAML validated; workflow-only change.

Refs #229, #122, #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_