### PR TITLE
feat(bench): vendor gpsr baseline port for the oracle-phase comparison (#296)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd /opt/ns-3
           ./ns3 configure --enable-examples \
-            --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           ./ns3 build
       - name: Install matplotlib
         run: apt-get update && apt-get install -y python3-matplotlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
           # (their cross-module deps drift by release). The filter flag scopes
           # that to our module; it was added after ns-3.36, so older trees just
           # build + smoke.
-          mods='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+          mods='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           if ./ns3 configure --help 2>/dev/null | grep -q filter-module-examples-and-tests; then
             ./ns3 configure --enable-tests --enable-examples \
               --filter-module-examples-and-tests=anthocnet \
@@ -442,7 +442,7 @@ jobs:
           # static-initializer allocations (see the file header for how to
           # extend it). $GITHUB_WORKSPACE is the in-container checkout path.
           echo "LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/ns3/tools/lsan.supp" >> "$GITHUB_ENV"
-          mods='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+          mods='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           # ns-3's CMake build has first-class sanitizer support (NS3_SANITIZE),
           # exposed by the ./ns3 wrapper as --enable-sanitizers
           # (address + leak + undefined). Prefer it when the wrapper advertises

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -112,7 +112,7 @@ jobs:
           cd /opt/ns-3
           # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
           ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
-            --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
       - name: Build
         # `show profile` is recorded in the log so a run's ##PERF## wall-clock
         # (#131) is always attributable to a build profile after the fact.

--- a/.github/workflows/satellite-benchmark.yml
+++ b/.github/workflows/satellite-benchmark.yml
@@ -97,7 +97,7 @@ jobs:
           cd /opt/ns-3
           # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
           ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
-            --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
       - name: Build
         run: cd /opt/ns-3 && ./ns3 build && ./ns3 show profile
       - name: Run isl-grid scenario

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -107,7 +107,7 @@ jobs:
           cd /opt/ns-3
           # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
           ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
-            --enable-modules='anthocnet;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           ./ns3 build
           # Recorded in the log so every campaign run is attributable to a
           # profile after the fact (a run's cost is meaningless without it).

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -18,7 +18,7 @@ use the `paper` preset — it is heavy, so it is a manual run, not part of CI:
 make install-ns3 NS3DIR=/path/to/ns-3-dev
 cd /path/to/ns-3-dev
 ./ns3 configure --enable-examples \
-  --enable-modules='anthocnet;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
+  --enable-modules='anthocnet;gpsr;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
 ./ns3 build
 ./ns3 run "anthocnet-compare --scenario=paper --runs=5"               # base scenario
 ./ns3 run "anthocnet-compare --scenario=paper --areaX=2500 --runs=5"  # area sweep

--- a/docs/cross-validation.md
+++ b/docs/cross-validation.md
@@ -21,7 +21,7 @@ simulators, then compare packet-delivery ratio and mean delay.
 make install-ns3 NS3DIR=/path/to/ns-3-dev
 cd /path/to/ns-3-dev
 ./ns3 configure --enable-examples \
-  --enable-modules='anthocnet;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
+  --enable-modules='anthocnet;gpsr;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
 ./ns3 build
 
 # AntHocNet only, averaged over 10 seeds (PDR %, delay ms, throughput kbps):

--- a/ns3/Makefile
+++ b/ns3/Makefile
@@ -13,6 +13,10 @@ HERE   := $(abspath $(CURDIR))
 ROOT   := $(abspath $(CURDIR)/..)
 CORE   := $(ROOT)/core
 DEST    = $(NS3DIR)/contrib/anthocnet
+# #296: the vendored GPSR baseline is a second, self-contained contrib module
+# (provenance: gpsr/README.md). Installed alongside so the comparison
+# harness's gpsr arm builds; the anthocnet module itself does not depend on it.
+GPSRDEST = $(NS3DIR)/contrib/gpsr
 
 .PHONY: install uninstall require-ns3dir
 
@@ -37,6 +41,11 @@ install: require-ns3dir
 	mkdir -p "$(DEST)/core/include/anthocnet/core" "$(DEST)/core/src"
 	cp $(CORE)/include/anthocnet/core/*.h "$(DEST)/core/include/anthocnet/core/"
 	cp $(CORE)/src/*.cpp "$(DEST)/core/src/"
+	@echo ">> Installing GPSR baseline module into $(GPSRDEST)"
+	mkdir -p "$(GPSRDEST)/model" "$(GPSRDEST)/helper"
+	cp $(HERE)/gpsr/model/*.h  $(HERE)/gpsr/model/*.cc  "$(GPSRDEST)/model/"
+	cp $(HERE)/gpsr/helper/*.h $(HERE)/gpsr/helper/*.cc "$(GPSRDEST)/helper/"
+	cp $(HERE)/gpsr/CMakeLists.txt "$(GPSRDEST)/"
 	@echo ""
 	@echo ">> Done. Reconfigure and build ns-3:"
 	@echo "     cd $(NS3DIR) && ./ns3 configure --enable-examples --enable-tests && ./ns3 build"
@@ -46,4 +55,6 @@ install: require-ns3dir
 uninstall: require-ns3dir
 	@echo ">> Removing $(DEST)"
 	rm -rf "$(DEST)"
-	@echo ">> Done. Reconfigure/build ns-3 to drop the module."
+	@echo ">> Removing $(GPSRDEST)"
+	rm -rf "$(GPSRDEST)"
+	@echo ">> Done. Reconfigure/build ns-3 to drop the modules."

--- a/ns3/README.md
+++ b/ns3/README.md
@@ -49,9 +49,9 @@ and **normalized routing load** (NRL = routing-control packets transmitted /
 data packets delivered, counted uniformly at the IP layer):
 
 ```bash
-# requires aodv, olsr, dsdv and flow-monitor enabled
+# requires aodv, olsr, dsdv, gpsr (the vendored #296 baseline) and flow-monitor enabled
 ./ns3 configure --enable-examples \
-  --enable-modules='anthocnet;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
+  --enable-modules='anthocnet;gpsr;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
 ./ns3 build
 
 # the paper's base scenario (50 nodes, 1500x300 m, RWP 20 m/s / 30 s pause,

--- a/ns3/examples/CMakeLists.txt
+++ b/ns3/examples/CMakeLists.txt
@@ -42,6 +42,10 @@ build_lib_example(
     ${libaodv}
     ${libolsr}
     ${libdsdv}
+    # #296: the vendored GPSR baseline module (contrib/gpsr, installed by the
+    # same `make install-ns3`). Like the stock baselines above, listing it here
+    # means the example is skipped when the module is not enabled.
+    ${libgpsr}
 )
 
 # ISL-grid scenario (#214): a static +Grid torus of point-to-point links — the

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Daniel Henrique Joppi
 
 /*
- * AntHocNet vs. AODV / OLSR / DSDV comparison.
+ * AntHocNet vs. AODV / OLSR / DSDV / GPSR comparison.
  *
  * Runs the SAME mobile-ad-hoc scenario (identical node layout, mobility and
  * CBR traffic, driven from the same RNG run) under each routing protocol and
@@ -39,8 +39,8 @@
  * [1] Di Caro, Ducatelle, Gambardella, "AntHocNet: an ant-based hybrid routing
  *     algorithm for mobile ad hoc networks", PPSN VIII, 2004.
  *
- * Requires the aodv, olsr, dsdv and flow-monitor modules. Build with those
- * enabled, then e.g.:
+ * Requires the aodv, olsr, dsdv, gpsr (the #296 vendored baseline module) and
+ * flow-monitor modules. Build with those enabled, then e.g.:
  *   ./ns3 run "anthocnet-compare --scenario=paper --runs=5"
  */
 #include "ns3/core-module.h"
@@ -70,6 +70,9 @@
 #include "ns3/aodv-module.h"
 #include "ns3/olsr-module.h"
 #include "ns3/dsdv-module.h"
+// #296: the vendored GPSR baseline (contrib/gpsr). Geographic — position
+// knowledge comes from the mobility models via its GOD location service.
+#include "ns3/gpsr-module.h"
 #include "ns3/anthocnet-helper.h"
 #include "ns3/anthocnet-routing-protocol.h"
 
@@ -1327,16 +1330,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     TakeStreams(stream, streamBase, mobility.AssignStreams(nodes, stream),
                 "mobility");
 
-    // #352: the four routing helpers are hoisted out of the branches so their
+    // #352: the routing helpers are hoisted out of the branches so their
     // AssignStreams() can run after Install() (SetRoutingHelper stores a Copy(),
     // but AssignStreams reaches the *installed* protocols through the nodes, so
-    // the local helper is the right handle). Constructing all four is free —
+    // the local helper is the right handle). Constructing all of them is free —
     // each is an ObjectFactory and instantiates nothing.
     InternetStackHelper internet;
     AntHocNetHelper ahnHelper;
     AodvHelper aodvHelper;
     OlsrHelper olsrHelper;
     DsdvHelper dsdvHelper;
+    GpsrHelper gpsrHelper;
     if (proto == "anthocnet") {
         internet.SetRoutingHelper(ahnHelper);
     } else if (proto == "aodv") {
@@ -1345,8 +1349,17 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         internet.SetRoutingHelper(olsrHelper);
     } else if (proto == "dsdv") {
         internet.SetRoutingHelper(dsdvHelper);
+    } else if (proto == "gpsr") {
+        internet.SetRoutingHelper(gpsrHelper);
     }
     internet.Install(nodes);
+    // #296: gpsr's data packets carry a position header, injected by
+    // re-pointing the UDP down target — the helper wires that after the stack
+    // exists, exactly as the dwosion examples do (scoped to this run's nodes,
+    // not the global container, so repeated RunOne calls can't cross-wire).
+    if (proto == "gpsr") {
+        gpsrHelper.Install(nodes);
+    }
     // The IPv4 stack is NOT stream-free, contrary to the first cut of this fix:
     // ArpL3Protocol owns m_requestJitter, a RandomVariableStream used to de-sync
     // ARP requests, and on a wifi MANET every next-hop change resolves through
@@ -1371,6 +1384,9 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     } else if (proto == "dsdv") {
         TakeStreams(stream, streamBase, AssignDsdvStreams(nodes, stream),
                     "dsdv routing");
+    } else if (proto == "gpsr") {
+        TakeStreams(stream, streamBase, gpsrHelper.AssignStreams(nodes, stream),
+                    "gpsr routing");
     }
 
     // Count routing-control transmissions uniformly at the IP layer. Connect to
@@ -2464,7 +2480,9 @@ int main(int argc, char* argv[]) {
                              "seeds can split across dispatches (#126)",
                  firstRun);
     cmd.AddValue("csv", "Emit machine-readable CSV instead of a table", csv);
-    cmd.AddValue("protocols", "Comma-separated list", protocols);
+    cmd.AddValue("protocols",
+                 "Comma-separated list (anthocnet,aodv,olsr,dsdv,gpsr)",
+                 protocols);
     cmd.AddValue("diag", "Emit per-run '# diag' lines (ant tallies, first delivery)", g_diag);
     cmd.AddValue("qdiag", "Emit per-run '# qdiag' lines: per-node MAC queue depth "
                           "distribution (meanQ/maxQ/pctNonzero) — does A2 have a "

--- a/ns3/gpsr/CMakeLists.txt
+++ b/ns3/gpsr/CMakeLists.txt
@@ -1,0 +1,44 @@
+# GPSR ns-3 module (ns-3.36+ CMake build) — vendored baseline for the
+# AntHocNet comparison harness (#296 item 3).
+#
+# Installed into $(NS3DIR)/contrib/gpsr by `make install-ns3`, alongside the
+# anthocnet module. Provenance (source repo, commit, port changes) is in
+# README.md next to this file.
+#
+# Adapt to ns-3 API drift by release, the same way the anthocnet module's
+# CMakeLists does. NS3_VER is set by ns-3 (e.g. "3.41"); anything non-numeric
+# (e.g. "3-dev") falls through to the modern defaults.
+#  - RouteInput callbacks went from by-value to const-reference in ns-3.37.
+#  - WifiMacQueueItem was renamed to WifiMpdu (header wifi-mac-queue-item.h ->
+#    wifi-mpdu.h) in ns-3.37; the WifiMac "DroppedMpdu" trace carries this type.
+if(NS3_VER MATCHES "^3\\.([0-9]+)")
+  if(CMAKE_MATCH_1 LESS 37)
+    add_compile_definitions(GPSR_NS3_ROUTEINPUT_BYVALUE)
+    add_compile_definitions(GPSR_NS3_WIFI_QUEUE_ITEM)
+  endif()
+endif()
+
+build_lib(
+  LIBNAME gpsr
+  SOURCE_FILES
+    model/gpsr.cc
+    model/gpsr-packet.cc
+    model/gpsr-ptable.cc
+    model/gpsr-rqueue.cc
+    helper/gpsr-helper.cc
+  HEADER_FILES
+    model/gpsr.h
+    model/gpsr-packet.h
+    model/gpsr-ptable.h
+    model/gpsr-rqueue.h
+    helper/gpsr-helper.h
+  LIBRARIES_TO_LINK
+    ${libcore}
+    ${libnetwork}
+    ${libinternet}
+    # wifi: the "DroppedMpdu" MAC transmit-failure trace prunes dead
+    # neighbours from the position table. mobility: GPSR is geographic — every
+    # node reads positions from MobilityModel (the GOD location service).
+    ${libwifi}
+    ${libmobility}
+)

--- a/ns3/gpsr/README.md
+++ b/ns3/gpsr/README.md
@@ -1,0 +1,106 @@
+# GPSR baseline module — provenance and port notes
+
+Vendored GPSR (Greedy Perimeter Stateless Routing, Karp & Kung, MobiCom 2000)
+baseline for the AntHocNet comparison harness —
+[#296](https://github.com/danieljoppi/AntHocNet/issues/296) item 3, built to
+the spike verdict recorded on that issue.
+
+## Provenance
+
+- **Source**: <https://github.com/dwosion/ns3.29-with-gpsr>, commit
+  `15241ef715d52627ff7679a5fca6b6d15eaa8cd4`, path `ns-3.29/src/gpsr`
+  (model, helper). The separate `ns-3.29/src/location-service` module was
+  **not** vendored; its GOD service (~30 lines: a NodeList + MobilityModel
+  scan) is inlined as `RoutingProtocol::GetGodPosition`. The seven
+  `examples/gpsr-test*.cc` scenarios, the template `doc/gpsr.rst` and the
+  stub test suite were not vendored either.
+- **Lineage**: that tree is the ns-3.29 refresh of António Fonseca's 2011–12
+  GPSR port (<https://codereview.appspot.com/5401042>); the helper files
+  carry his GPLv2 headers (Copyright 2009 IITP RAS, authors Fonseca / Boyko,
+  written after OlsrHelper).
+- **License**: GPLv2. The vendored tree distributes the module inside a stock
+  ns-3.29 tree whose `LICENSE` is GNU GPL v2; `gpsr-helper.{h,cc}` carry
+  explicit GPLv2 notices; the model files (headerless in the source) are
+  visibly derived from ns-3's GPLv2 `src/aodv` (deferred-route loopback
+  machinery, request queue). Matches this repository's `GPL-2.0-only`.
+- **Not used**: [PA-GPSR](https://github.com/CSVNetLab/PA-GPSR) publishes no
+  license anywhere and therefore was not copied from — not one line. Its
+  fixes were not merged; where this port fixes something PA-GPSR also fixed,
+  the fix is re-derived (noted per file).
+
+## Port changes (ns-3.29 → ns-3.36–3.48)
+
+The three faults named by the #296 spike verdict:
+
+1. **`TxErrHeader` → `DroppedMpdu`** (`gpsr.cc NotifyInterfaceUp/Down`,
+   `NotifyTxError`; `gpsr-ptable.{h,cc}`): the vendored code subscribed the
+   position table's callback to the WifiMac `TxErrHeader` trace, which ns-3
+   removed — and the handler body was an empty stub. The port subscribes
+   `RoutingProtocol::NotifyTxError` to the modern `DroppedMpdu` trace
+   (tolerant connect, like the anthocnet adapter's detector D): a unicast
+   frame dropped for `WIFI_MAC_DROP_REACHED_RETRY_LIMIT` names a dead
+   neighbour, resolved MAC→IP by forward `ArpCache::Lookup` per known
+   neighbour (`LookupInverse`'s signature drifts across versions), which is
+   then removed from the position table — the MAC-feedback neighbour removal
+   GPSR §3.2 specifies, implemented from the paper and the anthocnet
+   adapter's pattern, not from PA-GPSR.
+2. **`AssignStreams` added** (`gpsr.{h,cc}`, `gpsr-helper.{h,cc}`): the
+   vendored code drew hello jitter from `UniformRandomVariable` objects
+   constructed per call, whose stream numbers depend on construction order in
+   the process — exactly the #352 failure class. The port uses one member RNG
+   pinned by `RoutingProtocol::AssignStreams(int64_t)` and a
+   `GpsrHelper::AssignStreams(NodeContainer, int64_t)` wrapper mirroring
+   `AodvHelper`, so the harness's per-seed stream pinning covers the gpsr arm.
+3. **FlowMonitor-safe position-header layering** (`gpsr.cc AddHeaders`,
+   `Forwarding`, `RecoveryMode`, `SendPacketFromQueue`, `RouteInput`): the
+   vendored down-target hack prepended `TypeHeader|PositionHeader` to the UDP
+   datagram, producing `IP|GPSR|UDP` on the wire while `ip.protocol` still
+   read 17. `Ipv4FlowClassifier` reads the first four bytes of the IP payload
+   as ports, so data flows classified on position bytes that change as nodes
+   move. The port strips the UDP header, adds the same GPSR headers beneath
+   it, and puts the UDP header back (`IP|UDP|GPSR`): identical bytes on the
+   wire, identical routing state and decisions, but the IP payload now starts
+   with the real transport header, so FlowMonitor classifies data flows
+   correctly and port-based accounting sees GPSR's port-666 hellos as
+   control. ns-3's `UdpHeader` recomputes its length field from the buffer at
+   serialize time; global checksums must stay disabled (the ns-3 default —
+   the stored checksum is not refreshed). Only UDP is wrapped (the down
+   target is only re-pointed for `UdpL4Protocol`, as in the source); non-UDP
+   packets are forwarded greedily from GOD positions without per-packet
+   recovery state, and dropped as routeless if greedy fails.
+
+Mechanical/compile changes, each marked `Port change`/`Port fix` in place:
+
+- C++17: `std::bind2nd`/`std::ptr_fun` → lambda (`gpsr-rqueue.cc`).
+- Removed API: `Ipv4Address::IsEqual` → `==`; the two call sites also
+  dereferenced the `end()` iterator when the address was absent
+  (`gpsr-ptable.cc AddEntry`, `isNeighbour`).
+- Version gates in `CMakeLists.txt`, mirroring the anthocnet module:
+  `GPSR_NS3_ROUTEINPUT_BYVALUE` (RouteInput callbacks by value ≤ 3.36) and
+  `GPSR_NS3_WIFI_QUEUE_ITEM` (WifiMacQueueItem vs WifiMpdu in the
+  `DroppedMpdu` trace, ≤ 3.36).
+- The `LocationServiceName` enum attribute is gone with the location-service
+  module (GOD was the only implemented value; RLS printed "not yet
+  implemented"). Sidesteps the `MakeEnumAccessor` template drift entirely.
+- `CheckQueueTimer` is constructed `Timer::CANCEL_ON_DESTROY` (the vendored
+  default-constructed Timer asserts if still scheduled at teardown).
+- `TypeHeader`'s default argument moved to the declaration;
+  `GpsrHelper::Install(NodeContainer)` overload added (the global-container
+  form mis-scopes when one process runs many simulations, as the comparison
+  harness does).
+- Wire formats (`gpsr-packet.{h,cc}`) are untouched: hello =
+  1 B type + 16 B position; per-data-packet overhead = 1 B type + 53 B
+  position header, exactly as in the source.
+
+## Behaviour notes for the harness
+
+- GPSR is geographic: position knowledge comes from the mobility model via
+  the GOD location service, the same way the dwosion examples run it. The
+  harness supplies nothing beyond installed `MobilityModel`s; no measurement
+  hooks live in this module.
+- `GpsrHelper::Install(nodes)` must run after
+  `InternetStackHelper::Install` — it re-points the UDP down target that adds
+  the per-packet position header.
+- Hellos every 1 s ± 0.5 s jitter, TTL 1, UDP port 666; neighbour lifetime
+  2 s; greedy next-hop, right-hand-rule recovery (`PerimeterMode` attribute
+  present but, as in the source, the recovery path runs regardless).

--- a/ns3/gpsr/helper/gpsr-helper.cc
+++ b/ns3/gpsr/helper/gpsr-helper.cc
@@ -1,4 +1,5 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2009 IITP RAS
  *
@@ -17,7 +18,6 @@
  *
  * Authors: António Fonseca <afonseca@tagus.inesc-id.pt>, written after OlsrHelper by Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
  */
-// SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
 /*
  * Vendored from https://github.com/dwosion/ns3.29-with-gpsr

--- a/ns3/gpsr/helper/gpsr-helper.cc
+++ b/ns3/gpsr/helper/gpsr-helper.cc
@@ -1,0 +1,106 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: António Fonseca <afonseca@tagus.inesc-id.pt>, written after OlsrHelper by Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Port changes: see gpsr-helper.h and ns3/gpsr/README.md.
+ */
+#include "gpsr-helper.h"
+#include "ns3/gpsr.h"
+#include "ns3/node-list.h"
+#include "ns3/names.h"
+#include "ns3/ipv4-list-routing.h"
+#include "ns3/node-container.h"
+#include "ns3/callback.h"
+#include "ns3/udp-l4-protocol.h"
+
+namespace ns3 {
+
+GpsrHelper::GpsrHelper ()
+  : Ipv4RoutingHelper ()
+{
+  m_agentFactory.SetTypeId ("ns3::gpsr::RoutingProtocol");
+}
+
+GpsrHelper*
+GpsrHelper::Copy (void) const
+{
+  return new GpsrHelper (*this);
+}
+
+Ptr<Ipv4RoutingProtocol>
+GpsrHelper::Create (Ptr<Node> node) const
+{
+  Ptr<gpsr::RoutingProtocol> gpsr = m_agentFactory.Create<gpsr::RoutingProtocol> ();
+  node->AggregateObject (gpsr);
+  return gpsr;
+}
+
+void
+GpsrHelper::Set (std::string name, const AttributeValue &value)
+{
+  m_agentFactory.Set (name, value);
+}
+
+
+void
+GpsrHelper::Install (NodeContainer c) const
+{
+  for (NodeContainer::Iterator i = c.Begin (); i != c.End (); ++i)
+    {
+      Ptr<Node> node = (*i);
+      Ptr<UdpL4Protocol> udp = node->GetObject<UdpL4Protocol> ();
+      Ptr<gpsr::RoutingProtocol> gpsr = node->GetObject<gpsr::RoutingProtocol> ();
+      gpsr->SetDownTarget (udp->GetDownTarget ());
+      udp->SetDownTarget (MakeCallback(&gpsr::RoutingProtocol::AddHeaders, gpsr));
+    }
+
+
+}
+
+void
+GpsrHelper::Install (void) const
+{
+  Install (NodeContainer::GetGlobal ());
+}
+
+int64_t
+GpsrHelper::AssignStreams (NodeContainer c, int64_t stream)
+{
+  // #352 (port addition): mirror AodvHelper::AssignStreams.
+  int64_t currentStream = stream;
+  for (NodeContainer::Iterator i = c.Begin (); i != c.End (); ++i)
+    {
+      Ptr<Node> node = *i;
+      Ptr<Ipv4> ipv4 = node->GetObject<Ipv4> ();
+      NS_ASSERT_MSG (ipv4, "GpsrHelper::AssignStreams(): node has no Ipv4");
+      Ptr<gpsr::RoutingProtocol> gpsr =
+        DynamicCast<gpsr::RoutingProtocol> (ipv4->GetRoutingProtocol ());
+      if (gpsr)
+        {
+          currentStream += gpsr->AssignStreams (currentStream);
+        }
+    }
+  return (currentStream - stream);
+}
+
+}

--- a/ns3/gpsr/helper/gpsr-helper.h
+++ b/ns3/gpsr/helper/gpsr-helper.h
@@ -1,0 +1,97 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Pavel Boyko <boyko@iitp.ru>, written after OlsrHelper by Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Port changes: Install(NodeContainer) overload (the global-container form
+ * mis-scopes when several simulations run in one process) and AssignStreams
+ * (#352 stream pinning, mirroring AodvHelper). See ns3/gpsr/README.md.
+ */
+#ifndef GPSRHELPER_H_
+#define GPSRHELPER_H_
+
+#include "ns3/object-factory.h"
+#include "ns3/node.h"
+#include "ns3/node-container.h"
+#include "ns3/ipv4-routing-helper.h"
+
+namespace ns3 {
+/**
+ * \ingroup gpsr
+ * \brief Helper class that adds GPSR routing to nodes.
+ */
+class GpsrHelper : public Ipv4RoutingHelper
+{
+public:
+  GpsrHelper ();
+
+  /**
+   * \internal
+   * \returns pointer to clone of this OlsrHelper
+   *
+   * This method is mainly for internal use by the other helpers;
+   * clients are expected to free the dynamic memory allocated by this method
+   */
+  GpsrHelper* Copy (void) const;
+
+  /**
+   * \param node the node on which the routing protocol will run
+   * \returns a newly-created routing protocol
+   *
+   * This method will be called by ns3::InternetStackHelper::Install
+   *
+   * TODO: support installing GPSR on the subset of all available IP interfaces
+   */
+  virtual Ptr<Ipv4RoutingProtocol> Create (Ptr<Node> node) const;
+  /**
+   * \param name the name of the attribute to set
+   * \param value the value of the attribute to set.
+   *
+   * This method controls the attributes of ns3::gpsr::RoutingProtocol
+   */
+  void Set (std::string name, const AttributeValue &value);
+
+  /**
+   * Re-point the UDP down target of every node in c to
+   * gpsr::RoutingProtocol::AddHeaders, so data packets carry the GPSR
+   * position header. Must run after InternetStackHelper::Install. Port
+   * overload: the vendored no-argument form acted on
+   * NodeContainer::GetGlobal(), which mis-scopes when one process runs many
+   * simulations (the comparison harness does); it is kept, delegating here.
+   */
+  void Install (NodeContainer c) const;
+  void Install (void) const;
+
+  /**
+   * #352 stream pinning (port addition, after AodvHelper::AssignStreams):
+   * assign fixed stream numbers to the gpsr protocols installed on the nodes
+   * in c.
+   * \return the number of stream indices assigned
+   */
+  int64_t AssignStreams (NodeContainer c, int64_t stream);
+
+private:
+  ObjectFactory m_agentFactory;
+};
+
+}
+#endif /* GPSRHELPER_H_ */

--- a/ns3/gpsr/helper/gpsr-helper.h
+++ b/ns3/gpsr/helper/gpsr-helper.h
@@ -1,4 +1,5 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2009 IITP RAS
  *
@@ -17,7 +18,6 @@
  *
  * Authors: Pavel Boyko <boyko@iitp.ru>, written after OlsrHelper by Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
  */
-// SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
 /*
  * Vendored from https://github.com/dwosion/ns3.29-with-gpsr

--- a/ns3/gpsr/model/gpsr-packet.cc
+++ b/ns3/gpsr/model/gpsr-packet.cc
@@ -1,0 +1,304 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Port change: TypeHeader's default argument lives on the declaration now
+ * (see gpsr-packet.h). Byte layouts are untouched.
+ */
+
+#include "gpsr-packet.h"
+#include "ns3/address-utils.h"
+#include "ns3/packet.h"
+#include "ns3/log.h"
+
+NS_LOG_COMPONENT_DEFINE ("GpsrPacket");
+
+namespace ns3 {
+namespace gpsr {
+
+NS_OBJECT_ENSURE_REGISTERED (TypeHeader);
+
+TypeHeader::TypeHeader (MessageType t)
+  : m_type (t),
+    m_valid (true)
+{
+}
+
+TypeId
+TypeHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::gpsr::TypeHeader")
+    .SetParent<Header> ()
+    .AddConstructor<TypeHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+TypeHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+TypeHeader::GetSerializedSize () const
+{
+  return 1;
+}
+
+void
+TypeHeader::Serialize (Buffer::Iterator i) const
+{
+  i.WriteU8 ((uint8_t) m_type);
+}
+
+uint32_t
+TypeHeader::Deserialize (Buffer::Iterator start)
+{
+  Buffer::Iterator i = start;
+  uint8_t type = i.ReadU8 ();
+  m_valid = true;
+  switch (type)
+    {
+    case GPSRTYPE_HELLO:
+    case GPSRTYPE_POS:
+      {
+        m_type = (MessageType) type;
+        break;
+      }
+    default:
+      m_valid = false;
+    }
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+TypeHeader::Print (std::ostream &os) const
+{
+  switch (m_type)
+    {
+    case GPSRTYPE_HELLO:
+      {
+        os << "HELLO";
+        break;
+      }
+    case GPSRTYPE_POS:
+      {
+        os << "POSITION";
+        break;
+      }
+    default:
+      os << "UNKNOWN_TYPE";
+    }
+}
+
+bool
+TypeHeader::operator== (TypeHeader const & o) const
+{
+  return (m_type == o.m_type && m_valid == o.m_valid);
+}
+
+std::ostream &
+operator<< (std::ostream & os, TypeHeader const & h)
+{
+  h.Print (os);
+  return os;
+}
+
+//-----------------------------------------------------------------------------
+// HELLO
+//-----------------------------------------------------------------------------
+HelloHeader::HelloHeader (uint64_t originPosx, uint64_t originPosy)
+  : m_originPosx (originPosx),
+    m_originPosy (originPosy)
+{
+}
+
+NS_OBJECT_ENSURE_REGISTERED (HelloHeader);
+
+TypeId
+HelloHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::gpsr::HelloHeader")
+    .SetParent<Header> ()
+    .AddConstructor<HelloHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+HelloHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+HelloHeader::GetSerializedSize () const
+{
+  return 16;
+}
+
+void
+HelloHeader::Serialize (Buffer::Iterator i) const
+{
+  NS_LOG_DEBUG ("Serialize X " << m_originPosx << " Y " << m_originPosy);
+
+
+  i.WriteHtonU64 (m_originPosx);
+  i.WriteHtonU64 (m_originPosy);
+
+}
+
+uint32_t
+HelloHeader::Deserialize (Buffer::Iterator start)
+{
+
+  Buffer::Iterator i = start;
+
+  m_originPosx = i.ReadNtohU64 ();
+  m_originPosy = i.ReadNtohU64 ();
+
+  NS_LOG_DEBUG ("Deserialize X " << m_originPosx << " Y " << m_originPosy);
+
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+HelloHeader::Print (std::ostream &os) const
+{
+  os << " PositionX: " << m_originPosx
+     << " PositionY: " << m_originPosy;
+}
+
+std::ostream &
+operator<< (std::ostream & os, HelloHeader const & h)
+{
+  h.Print (os);
+  return os;
+}
+
+
+
+bool
+HelloHeader::operator== (HelloHeader const & o) const
+{
+  return (m_originPosx == o.m_originPosx && m_originPosy == o.m_originPosy);
+}
+
+
+
+
+
+//-----------------------------------------------------------------------------
+// Position
+//-----------------------------------------------------------------------------
+PositionHeader::PositionHeader (uint64_t dstPosx, uint64_t dstPosy, uint32_t updated, uint64_t recPosx, uint64_t recPosy, uint8_t inRec, uint64_t lastPosx, uint64_t lastPosy)
+  : m_dstPosx (dstPosx),
+    m_dstPosy (dstPosy),
+    m_updated (updated),
+    m_recPosx (recPosx),
+    m_recPosy (recPosy),
+    m_inRec (inRec),
+    m_lastPosx (lastPosx),
+    m_lastPosy (lastPosy)
+{
+}
+
+NS_OBJECT_ENSURE_REGISTERED (PositionHeader);
+
+TypeId
+PositionHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::gpsr::PositionHeader")
+    .SetParent<Header> ()
+    .AddConstructor<PositionHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+PositionHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+PositionHeader::GetSerializedSize () const
+{
+  return 53;
+}
+
+void
+PositionHeader::Serialize (Buffer::Iterator i) const
+{
+  i.WriteU64 (m_dstPosx);
+  i.WriteU64 (m_dstPosy);
+  i.WriteU32 (m_updated);
+  i.WriteU64 (m_recPosx);
+  i.WriteU64 (m_recPosy);
+  i.WriteU8 (m_inRec);
+  i.WriteU64 (m_lastPosx);
+  i.WriteU64 (m_lastPosy);
+}
+
+uint32_t
+PositionHeader::Deserialize (Buffer::Iterator start)
+{
+  Buffer::Iterator i = start;
+  m_dstPosx = i.ReadU64 ();
+  m_dstPosy = i.ReadU64 ();
+  m_updated = i.ReadU32 ();
+  m_recPosx = i.ReadU64 ();
+  m_recPosy = i.ReadU64 ();
+  m_inRec = i.ReadU8 ();
+  m_lastPosx = i.ReadU64 ();
+  m_lastPosy = i.ReadU64 ();
+
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+PositionHeader::Print (std::ostream &os) const
+{
+  os << " PositionX: "  << m_dstPosx
+     << " PositionY: " << m_dstPosy
+     << " Updated: " << m_updated
+     << " RecPositionX: " << m_recPosx
+     << " RecPositionY: " << m_recPosy
+     << " inRec: " << m_inRec
+     << " LastPositionX: " << m_lastPosx
+     << " LastPositionY: " << m_lastPosy;
+}
+
+std::ostream &
+operator<< (std::ostream & os, PositionHeader const & h)
+{
+  h.Print (os);
+  return os;
+}
+
+
+
+bool
+PositionHeader::operator== (PositionHeader const & o) const
+{
+  return (m_dstPosx == o.m_dstPosx && m_dstPosy == o.m_dstPosy && m_updated == o.m_updated && m_recPosx == o.m_recPosx && m_recPosy == o.m_recPosy && m_inRec == o.m_inRec && m_lastPosx == o.m_lastPosx && m_lastPosy == o.m_lastPosy);
+}
+
+
+}
+}
+
+
+
+
+

--- a/ns3/gpsr/model/gpsr-packet.h
+++ b/ns3/gpsr/model/gpsr-packet.h
@@ -1,0 +1,220 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Port change: TypeHeader's default argument moved from the definition in
+ * gpsr-packet.cc to this declaration (AddConstructor<TypeHeader> needs the
+ * default-constructible form at its point of instantiation). Byte layouts
+ * are untouched.
+ */
+
+#ifndef GPSRPACKET_H
+#define GPSRPACKET_H
+
+#include <iostream>
+#include "ns3/header.h"
+#include "ns3/enum.h"
+#include "ns3/ipv4-address.h"
+#include <map>
+#include "ns3/nstime.h"
+#include "ns3/vector.h"
+
+namespace ns3 {
+namespace gpsr {
+
+
+
+enum MessageType
+{
+  GPSRTYPE_HELLO  = 1,         //!< GPSRTYPE_HELLO
+  GPSRTYPE_POS = 2,            //!< GPSRTYPE_POS
+};
+
+/**
+ * \ingroup gpsr
+ * \brief GPSR types
+ */
+class TypeHeader : public Header
+{
+public:
+  /// c-tor
+  TypeHeader (MessageType t = GPSRTYPE_HELLO);
+
+  ///\name Header serialization/deserialization
+  //\{
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator start) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+  //\}
+
+  /// Return type
+  MessageType Get () const
+  {
+    return m_type;
+  }
+  /// Check that type if valid
+  bool IsValid () const
+  {
+    return m_valid; //FIXME that way it wont work
+  }
+  bool operator== (TypeHeader const & o) const;
+private:
+  MessageType m_type;
+  bool m_valid;
+};
+
+std::ostream & operator<< (std::ostream & os, TypeHeader const & h);
+
+class HelloHeader : public Header
+{
+public:
+  /// c-tor
+  HelloHeader (uint64_t originPosx = 0, uint64_t originPosy = 0);
+
+  ///\name Header serialization/deserialization
+  //\{
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator start) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+  //\}
+
+  ///\name Fields
+  //\{
+  void SetOriginPosx (uint64_t posx)
+  {
+    m_originPosx = posx;
+  }
+  uint64_t GetOriginPosx () const
+  {
+    return m_originPosx;
+  }
+  void SetOriginPosy (uint64_t posy)
+  {
+    m_originPosy = posy;
+  }
+  uint64_t GetOriginPosy () const
+  {
+    return m_originPosy;
+  }
+  //\}
+
+
+  bool operator== (HelloHeader const & o) const;
+private:
+  uint64_t         m_originPosx;          ///< Originator Position x
+  uint64_t         m_originPosy;          ///< Originator Position x
+};
+
+std::ostream & operator<< (std::ostream & os, HelloHeader const &);
+
+class PositionHeader : public Header
+{
+public:
+  /// c-tor
+  PositionHeader (uint64_t dstPosx = 0, uint64_t dstPosy = 0, uint32_t updated = 0, uint64_t recPosx = 0, uint64_t recPosy = 0, uint8_t inRec  = 0, uint64_t lastPosx = 0, uint64_t lastPosy = 0);
+
+  ///\name Header serialization/deserialization
+  //\{
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator start) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+  //\}
+
+  ///\name Fields
+  //\{
+  void SetDstPosx (uint64_t posx)
+  {
+    m_dstPosx = posx;
+  }
+  uint64_t GetDstPosx () const
+  {
+    return m_dstPosx;
+  }
+  void SetDstPosy (uint64_t posy)
+  {
+    m_dstPosy = posy;
+  }
+  uint64_t GetDstPosy () const
+  {
+    return m_dstPosy;
+  }
+  void SetUpdated (uint32_t updated)
+  {
+    m_updated = updated;
+  }
+  uint32_t GetUpdated () const
+  {
+    return m_updated;
+  }
+  void SetRecPosx (uint64_t posx)
+  {
+    m_recPosx = posx;
+  }
+  uint64_t GetRecPosx () const
+  {
+    return m_recPosx;
+  }
+  void SetRecPosy (uint64_t posy)
+  {
+    m_recPosy = posy;
+  }
+  uint64_t GetRecPosy () const
+  {
+    return m_recPosy;
+  }
+  void SetInRec (uint8_t rec)
+  {
+    m_inRec = rec;
+  }
+  uint8_t GetInRec () const
+  {
+    return m_inRec;
+  }
+  void SetLastPosx (uint64_t posx)
+  {
+    m_lastPosx = posx;
+  }
+  uint64_t GetLastPosx () const
+  {
+    return m_lastPosx;
+  }
+  void SetLastPosy (uint64_t posy)
+  {
+    m_lastPosy = posy;
+  }
+  uint64_t GetLastPosy () const
+  {
+    return m_lastPosy;
+  }
+
+
+  bool operator== (PositionHeader const & o) const;
+private:
+  uint64_t         m_dstPosx;          ///< Destination Position x
+  uint64_t         m_dstPosy;          ///< Destination Position x
+  uint32_t         m_updated;          ///< Time of last update
+  uint64_t         m_recPosx;          ///< x of position that entered Recovery-mode
+  uint64_t         m_recPosy;          ///< y of position that entered Recovery-mode
+  uint8_t          m_inRec;          ///< 1 if in Recovery-mode, 0 otherwise
+  uint64_t         m_lastPosx;          ///< x of position of previous hop
+  uint64_t         m_lastPosy;          ///< y of position of previous hop
+
+};
+
+std::ostream & operator<< (std::ostream & os, PositionHeader const &);
+
+}
+}
+#endif /* GPSRPACKET_H */

--- a/ns3/gpsr/model/gpsr-ptable.cc
+++ b/ns3/gpsr/model/gpsr-ptable.cc
@@ -1,0 +1,306 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Port changes: see gpsr-ptable.h and ns3/gpsr/README.md.
+ */
+#include "gpsr-ptable.h"
+#include "ns3/simulator.h"
+#include "ns3/log.h"
+#include <algorithm>
+
+NS_LOG_COMPONENT_DEFINE ("GpsrTable");
+
+
+namespace ns3 {
+namespace gpsr {
+
+/*
+  GPSR position table
+*/
+
+PositionTable::PositionTable ()
+{
+  m_entryLifeTime = Seconds (2); //FIXME fazer isto parametrizavel de acordo com tempo de hello
+
+}
+
+Time 
+PositionTable::GetEntryUpdateTime (Ipv4Address id)
+{
+  if (id == Ipv4Address::GetZero ())
+    {
+      return Time (Seconds (0));
+    }
+  std::map<Ipv4Address, std::pair<Vector, Time> >::iterator i = m_table.find (id);
+  return i->second.second;
+}
+
+/**
+ * \brief Adds entry in position table
+ */
+void
+PositionTable::AddEntry (Ipv4Address id, Vector position)
+{
+  // Port fix: the vendored `i != end () || id.IsEqual (i->first)` dereferenced
+  // the end iterator when the id was absent (and Ipv4Address::IsEqual is
+  // removed from modern ns-3); the found check alone is the intended test.
+  std::map<Ipv4Address, std::pair<Vector, Time> >::iterator i = m_table.find (id);
+  if (i != m_table.end ())
+    {
+      m_table.erase (id);
+      m_table.insert (std::make_pair (id, std::make_pair (position, Simulator::Now ())));
+      return;
+    }
+  
+
+  m_table.insert (std::make_pair (id, std::make_pair (position, Simulator::Now ())));
+}
+
+/**
+ * \brief Deletes entry in position table
+ */
+void PositionTable::DeleteEntry (Ipv4Address id)
+{
+  m_table.erase (id);
+}
+
+/**
+ * \brief Gets position from position table
+ * \param id Ipv4Address to get position from
+ * \return Position of that id or NULL if not known
+ */
+Vector 
+PositionTable::GetPosition (Ipv4Address id)
+{
+
+  NodeList::Iterator listEnd = NodeList::End ();
+  for (NodeList::Iterator i = NodeList::Begin (); i != listEnd; i++)
+    {
+      Ptr<Node> node = *i;
+      if (node->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal () == id)
+        {
+          return node->GetObject<MobilityModel> ()->GetPosition ();
+        }
+    }
+  return PositionTable::GetInvalidPosition ();
+
+}
+
+/**
+ * \brief Checks if a node is a neighbour
+ * \param id Ipv4Address of the node to check
+ * \return True if the node is neighbour, false otherwise
+ */
+bool
+PositionTable::isNeighbour (Ipv4Address id)
+{
+  // Port fix: same end-iterator dereference / removed IsEqual as AddEntry.
+ std::map<Ipv4Address, std::pair<Vector, Time> >::iterator i = m_table.find (id);
+  if (i != m_table.end ())
+    {
+      return true;
+    }
+
+  return false;
+}
+
+std::vector<Ipv4Address>
+PositionTable::GetKnownNeighbors () const
+{
+  // Port addition (fault-1 rework): see gpsr-ptable.h.
+  std::vector<Ipv4Address> ids;
+  ids.reserve (m_table.size ());
+  for (std::map<Ipv4Address, std::pair<Vector, Time> >::const_iterator i = m_table.begin ();
+       i != m_table.end (); ++i)
+    {
+      ids.push_back (i->first);
+    }
+  return ids;
+}
+
+
+/**
+ * \brief remove entries with expired lifetime
+ */
+void 
+PositionTable::Purge ()
+{
+
+  if(m_table.empty ())
+    {
+      return;
+    }
+
+  std::list<Ipv4Address> toErase;
+
+  std::map<Ipv4Address, std::pair<Vector, Time> >::iterator i = m_table.begin ();
+  std::map<Ipv4Address, std::pair<Vector, Time> >::iterator listEnd = m_table.end ();
+  
+  for (; !(i == listEnd); i++)
+    {
+
+      if (m_entryLifeTime + GetEntryUpdateTime (i->first) <= Simulator::Now ())
+        {
+          toErase.insert (toErase.begin (), i->first);
+
+        }
+    }
+  toErase.unique ();
+
+  std::list<Ipv4Address>::iterator end = toErase.end ();
+
+  for (std::list<Ipv4Address>::iterator it = toErase.begin (); it != end; ++it)
+    {
+
+      m_table.erase (*it);
+
+    }
+}
+
+/**
+ * \brief clears all entries
+ */
+void 
+PositionTable::Clear ()
+{
+  m_table.clear ();
+}
+
+/**
+ * \brief Gets next hop according to GPSR protocol
+ * \param position the position of the destination node
+ * \param nodePos the position of the node that has the packet
+ * \return Ipv4Address of the next hop, Ipv4Address::GetZero () if no nighbour was found in greedy mode
+ */
+Ipv4Address 
+PositionTable::BestNeighbor (Vector position, Vector nodePos)
+{
+  Purge ();
+
+  double initialDistance = CalculateDistance (nodePos, position);
+
+  if (m_table.empty ())
+    {
+      NS_LOG_DEBUG ("BestNeighbor table is empty; Position: " << position);
+      return Ipv4Address::GetZero ();
+    }     //if table is empty (no neighbours)
+
+  Ipv4Address bestFoundID = m_table.begin ()->first;
+  double bestFoundDistance = CalculateDistance (m_table.begin ()->second.first, position);
+  std::map<Ipv4Address, std::pair<Vector, Time> >::iterator i;
+  for (i = m_table.begin (); !(i == m_table.end ()); i++)
+    {
+      if (bestFoundDistance > CalculateDistance (i->second.first, position))
+        {
+          bestFoundID = i->first;
+          bestFoundDistance = CalculateDistance (i->second.first, position);
+        }
+    }
+
+  if(initialDistance > bestFoundDistance)
+    return bestFoundID;
+  else
+    return Ipv4Address::GetZero (); //so it enters Recovery-mode
+
+}
+
+
+/**
+ * \brief Gets next hop according to GPSR recovery-mode protocol (right hand rule)
+ * \param previousHop the position of the node that sent the packet to this node
+ * \param nodePos the position of the destination node
+ * \return Ipv4Address of the next hop, Ipv4Address::GetZero () if no nighbour was found in greedy mode
+ */
+Ipv4Address
+PositionTable::BestAngle (Vector previousHop, Vector nodePos)
+{
+  Purge ();
+
+  if (m_table.empty ())
+    {
+      NS_LOG_DEBUG ("BestNeighbor table is empty; Position: " << nodePos);
+      return Ipv4Address::GetZero ();
+    }     //if table is empty (no neighbours)
+
+  double tmpAngle;
+  Ipv4Address bestFoundID = Ipv4Address::GetZero ();
+  double bestFoundAngle = 360;
+  std::map<Ipv4Address, std::pair<Vector, Time> >::iterator i;
+
+  for (i = m_table.begin (); !(i == m_table.end ()); i++)
+    {
+      tmpAngle = GetAngle(nodePos, previousHop, i->second.first);
+      if (bestFoundAngle > tmpAngle && tmpAngle != 0)
+	{
+	  bestFoundID = i->first;
+	  bestFoundAngle = tmpAngle;
+	}
+    }
+  if(bestFoundID == Ipv4Address::GetZero ()) //only if the only neighbour is who sent the packet
+    {
+      bestFoundID = m_table.begin ()->first;
+    }
+  return bestFoundID;
+}
+
+
+//Gives angle between the vector CentrePos-Refpos to the vector CentrePos-node counterclockwise
+double 
+PositionTable::GetAngle (Vector centrePos, Vector refPos, Vector node){
+  double const PI = 4*atan(1);
+
+  std::complex<double> A = std::complex<double>(centrePos.x,centrePos.y);
+  std::complex<double> B = std::complex<double>(node.x,node.y);
+  std::complex<double> C = std::complex<double>(refPos.x,refPos.y);   //Change B with C if you want angles clockwise
+
+  std::complex<double> AB; //reference edge
+  std::complex<double> AC;
+  std::complex<double> tmp;
+  std::complex<double> tmpCplx;
+
+  std::complex<double> Angle;
+
+  AB = B - A;
+  AB = (real(AB)/norm(AB)) + (std::complex<double>(0.0,1.0)*(imag(AB)/norm(AB)));
+
+  AC = C - A;
+  AC = (real(AC)/norm(AC)) + (std::complex<double>(0.0,1.0)*(imag(AC)/norm(AC)));
+
+  tmp = log(AC/AB);
+  tmpCplx = std::complex<double>(0.0,-1.0);
+  Angle = tmp*tmpCplx;
+  Angle *= (180/PI);
+  if (real(Angle)<0)
+    Angle = 360+real(Angle);
+
+  return real(Angle);
+
+}
+
+
+// Port change: the vendored ProcessTxError (an empty stub wired to the
+// removed "TxErrHeader" trace) is gone; RoutingProtocol::NotifyTxError on
+// the "DroppedMpdu" trace now performs the neighbour removal it was for.
+
+//FIXME ainda preciso disto agr que o LS ja n está aqui???????
+
+/**
+ * \brief Returns true if is in search for destionation
+ */
+bool PositionTable::IsInSearch (Ipv4Address id)
+{
+  return false;
+}
+
+bool PositionTable::HasPosition (Ipv4Address id)
+{
+  return true;
+}
+
+
+}   // gpsr
+} // ns3

--- a/ns3/gpsr/model/gpsr-ptable.h
+++ b/ns3/gpsr/model/gpsr-ptable.h
@@ -1,0 +1,128 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Port changes: the WifiMacHeader "TxErrHeader" callback plumbing (whose
+ * handler was an empty stub) is replaced by RoutingProtocol::NotifyTxError on
+ * the "DroppedMpdu" trace, which calls DeleteEntry/GetKnownNeighbors here;
+ * two find()-then-dereference-end() constructs (via the since-removed
+ * Ipv4Address::IsEqual) are fixed. See ns3/gpsr/README.md.
+ */
+#ifndef GPSR_PTABLE_H
+#define GPSR_PTABLE_H
+
+#include <map>
+#include <vector>
+#include <cassert>
+#include <stdint.h>
+#include "ns3/ipv4.h"
+#include "ns3/timer.h"
+#include <sys/types.h>
+#include "ns3/node.h"
+#include "ns3/node-list.h"
+#include "ns3/mobility-model.h"
+#include "ns3/vector.h"
+#include "ns3/random-variable-stream.h"
+#include <complex>
+
+namespace ns3 {
+namespace gpsr {
+
+/*
+ * \ingroup gpsr
+ * \brief Position table used by GPSR
+ */
+class PositionTable
+{
+public:
+  /// c-tor
+  PositionTable ();
+
+  /**
+   * \brief Gets the last time the entry was updated
+   * \param id Ipv4Address to get time of update from
+   * \return Time of last update to the position
+   */
+  Time GetEntryUpdateTime (Ipv4Address id);
+
+  /**
+   * \brief Adds entry in position table
+   */
+  void AddEntry (Ipv4Address id, Vector position);
+
+  /**
+   * \brief Deletes entry in position table
+   */
+  void DeleteEntry (Ipv4Address id);
+
+  /**
+   * \brief Gets position from position table
+   * \param id Ipv4Address to get position from
+   * \return Position of that id or NULL if not known
+   */
+  Vector GetPosition (Ipv4Address id);
+
+  /**
+   * \brief Checks if a node is a neighbour
+   * \param id Ipv4Address of the node to check
+   * \return True if the node is neighbour, false otherwise
+   */
+  bool isNeighbour (Ipv4Address id);
+
+  /**
+   * \brief remove entries with expired lifetime
+   */
+  void Purge ();
+
+  /**
+   * \brief clears all entries
+   */
+  void Clear ();
+
+  /**
+   * Port addition (fault-1 rework): the neighbour addresses currently in the
+   * table, for RoutingProtocol::NotifyTxError's MAC->IP resolution.
+   */
+  std::vector<Ipv4Address> GetKnownNeighbors () const;
+
+  /**
+   * \brief Gets next hop according to GPSR protocol
+   * \param position the position of the destination node
+   * \param nodePos the position of the node that has the packet
+   * \return Ipv4Address of the next hop, Ipv4Address::GetZero () if no nighbour was found in greedy mode
+   */
+  Ipv4Address BestNeighbor (Vector position, Vector nodePos);
+
+  bool IsInSearch (Ipv4Address id);
+
+  bool HasPosition (Ipv4Address id);
+
+  static Vector GetInvalidPosition ()
+  {
+    return Vector (-1, -1, 0);
+  }
+
+  /**
+   * \brief Gets next hop according to GPSR recovery-mode protocol (right hand rule)
+   * \param previousHop the position of the node that sent the packet to this node
+   * \param nodePos the position of the destination node
+   * \return Ipv4Address of the next hop, Ipv4Address::GetZero () if no nighbour was found in greedy mode
+   */
+  Ipv4Address BestAngle (Vector previousHop, Vector nodePos);
+
+  //Gives angle between the vector CentrePos-Refpos to the vector CentrePos-node counterclockwise
+  double GetAngle (Vector centrePos, Vector refPos, Vector node);
+
+
+
+private:
+  Time m_entryLifeTime;
+  std::map<Ipv4Address, std::pair<Vector, Time> > m_table;
+};
+
+}   // gpsr
+} // ns3
+#endif /* GPSR_PTABLE_H */

--- a/ns3/gpsr/model/gpsr-rqueue.cc
+++ b/ns3/gpsr/model/gpsr-rqueue.cc
@@ -1,0 +1,139 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Port change: std::bind2nd/std::ptr_fun (removed in C++17, which every
+ * ns-3 in the 3.36–3.48 CI matrix compiles as) replaced with a lambda.
+ */
+
+#include "gpsr-rqueue.h"
+#include <algorithm>
+#include <functional>
+#include "ns3/ipv4-route.h"
+#include "ns3/socket.h"
+#include "ns3/log.h"
+
+NS_LOG_COMPONENT_DEFINE ("GpsrRequestQueue");
+
+namespace ns3 {
+namespace gpsr {
+uint32_t
+RequestQueue::GetSize ()
+{
+  Purge ();
+  return m_queue.size ();
+}
+
+bool
+RequestQueue::Enqueue (QueueEntry & entry)
+{
+  Purge ();
+  for (std::vector<QueueEntry>::const_iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if ((i->GetPacket ()->GetUid () == entry.GetPacket ()->GetUid ())
+          && (i->GetIpv4Header ().GetDestination ()
+              == entry.GetIpv4Header ().GetDestination ()))
+        {
+          return false;
+        }
+    }
+  entry.SetExpireTime (m_queueTimeout);
+  if (m_queue.size () == m_maxLen)
+    {
+      Drop (m_queue.front (), "Drop the most aged packet");     // Drop the most aged packet
+      m_queue.erase (m_queue.begin ());
+    }
+  m_queue.push_back (entry);
+  return true;
+}
+
+void
+RequestQueue::DropPacketWithDst (Ipv4Address dst)
+{
+  NS_LOG_FUNCTION (this << dst);
+  Purge ();
+//  const Ipv4Address addr = dst;
+  for (std::vector<QueueEntry>::iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if (IsEqual (*i, dst))
+        {
+          Drop (*i, "DropPacketWithDst ");
+        }
+    }
+  // Port change: bind2nd/ptr_fun are gone in C++17.
+  m_queue.erase (std::remove_if (m_queue.begin (), m_queue.end (),
+                                 [dst] (QueueEntry const & en) { return IsEqual (en, dst); }),
+                 m_queue.end ());
+}
+
+bool
+RequestQueue::Dequeue (Ipv4Address dst, QueueEntry & entry)
+{
+  Purge ();
+  for (std::vector<QueueEntry>::iterator i = m_queue.begin (); i != m_queue.end (); ++i)
+    {
+      if (i->GetIpv4Header ().GetDestination () == dst)
+        {
+          entry = *i;
+          m_queue.erase (i);
+          return true;
+        }
+    }
+  return false;
+}
+
+bool
+RequestQueue::Find (Ipv4Address dst)
+{
+  for (std::vector<QueueEntry>::const_iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if (i->GetIpv4Header ().GetDestination () == dst)
+        {
+          return true;
+        }
+    }
+  return false;
+}
+
+struct IsExpired
+{
+  bool
+  operator() (QueueEntry const & e) const
+  {
+    return (e.GetExpireTime () < Seconds (0));
+  }
+};
+
+void
+RequestQueue::Purge ()
+{
+  IsExpired pred;
+  for (std::vector<QueueEntry>::iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if (pred (*i))
+        {
+          Drop (*i, "Drop outdated packet ");
+        }
+    }
+  m_queue.erase (std::remove_if (m_queue.begin (), m_queue.end (), pred),
+                 m_queue.end ());
+}
+
+void
+RequestQueue::Drop (QueueEntry en, std::string reason)
+{
+  NS_LOG_LOGIC (reason << en.GetPacket ()->GetUid () << " " << en.GetIpv4Header ().GetDestination ());
+  en.GetErrorCallback () (en.GetPacket (), en.GetIpv4Header (),
+                          Socket::ERROR_NOROUTETOHOST);
+  return;
+}
+
+}
+}

--- a/ns3/gpsr/model/gpsr-rqueue.h
+++ b/ns3/gpsr/model/gpsr-rqueue.h
@@ -1,0 +1,171 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Unchanged apart from this provenance header.
+ */
+
+#ifndef GPSR_RQUEUE_H
+#define GPSR_RQUEUE_H
+
+#include <vector>
+#include "ns3/ipv4-routing-protocol.h"
+#include "ns3/simulator.h"
+
+
+namespace ns3 {
+namespace gpsr {
+
+/**
+ * \ingroup gpsr
+ * \brief GPSR Queue Entry
+ */
+class QueueEntry
+{
+public:
+  typedef Ipv4RoutingProtocol::UnicastForwardCallback UnicastForwardCallback;
+  typedef Ipv4RoutingProtocol::ErrorCallback ErrorCallback;
+  /// c-tor
+  QueueEntry (Ptr<const Packet> pa = 0, Ipv4Header const & h = Ipv4Header (),
+              UnicastForwardCallback ucb = UnicastForwardCallback (),
+              ErrorCallback ecb = ErrorCallback (), Time exp = Simulator::Now ())
+    : m_packet (pa),
+      m_header (h),
+      m_ucb (ucb),
+      m_ecb (ecb),
+      m_expire (exp + Simulator::Now ())
+  {
+  }
+
+  /**
+   * Compare queue entries
+   * \return true if equal
+   */
+  bool operator== (QueueEntry const & o) const
+  {
+    return ((m_packet == o.m_packet) && (m_header.GetDestination () == o.m_header.GetDestination ()) && (m_expire == o.m_expire));
+  }
+  ///\name Fields
+  //\{
+  UnicastForwardCallback GetUnicastForwardCallback () const
+  {
+    return m_ucb;
+  }
+  void SetUnicastForwardCallback (UnicastForwardCallback ucb)
+  {
+    m_ucb = ucb;
+  }
+  ErrorCallback GetErrorCallback () const
+  {
+    return m_ecb;
+  }
+  void SetErrorCallback (ErrorCallback ecb)
+  {
+    m_ecb = ecb;
+  }
+  Ptr<const Packet> GetPacket () const
+  {
+    return m_packet;
+  }
+  void SetPacket (Ptr<const Packet> p)
+  {
+    m_packet = p;
+  }
+  Ipv4Header GetIpv4Header () const
+  {
+    return m_header;
+  }
+  void SetIpv4Header (Ipv4Header h)
+  {
+    m_header = h;
+  }
+  void SetExpireTime (Time exp)
+  {
+    m_expire = exp + Simulator::Now ();
+  }
+  Time GetExpireTime () const
+  {
+    return m_expire - Simulator::Now ();
+  }
+  //\}
+private:
+  /// Data packet
+  Ptr<const Packet> m_packet;
+  /// IP header
+  Ipv4Header m_header;
+  /// Unicast forward callback
+  UnicastForwardCallback m_ucb;
+  /// Error callback
+  ErrorCallback m_ecb;
+  /// Expire time for queue entry
+  Time m_expire;
+};
+/**
+ * \ingroup gpsr
+ * \brief GPSR route request queue
+ *
+ * Since GPSR is an on demand routing we queue requests while looking for route.
+ */
+class RequestQueue
+{
+public:
+  /// Default c-tor
+  RequestQueue (uint32_t maxLen, Time routeToQueueTimeout)
+    : m_maxLen (maxLen),
+      m_queueTimeout (routeToQueueTimeout)
+  {
+  }
+  /// Push entry in queue, if there is no entry with the same packet and destination address in queue.
+  bool Enqueue (QueueEntry & entry);
+  /// Return first found (the earliest) entry for given destination
+  bool Dequeue (Ipv4Address dst, QueueEntry & entry);
+  /// Remove all packets with destination IP address dst
+  void DropPacketWithDst (Ipv4Address dst);
+  /// Finds whether a packet with destination dst exists in the queue
+  bool Find (Ipv4Address dst);
+  /// Number of entries
+  uint32_t GetSize ();
+  ///\name Fields
+  //\{
+  uint32_t GetMaxQueueLen () const
+  {
+    return m_maxLen;
+  }
+  void SetMaxQueueLen (uint32_t len)
+  {
+    m_maxLen = len;
+  }
+  Time GetQueueTimeout () const
+  {
+    return m_queueTimeout;
+  }
+  void SetQueueTimeout (Time t)
+  {
+    m_queueTimeout = t;
+  }
+  //\}
+
+private:
+  std::vector<QueueEntry> m_queue;
+  /// Remove all expired entries
+  void Purge ();
+  /// Notify that packet is dropped from queue by timeout
+  void Drop (QueueEntry en, std::string reason);
+  /// The maximum number of packets that we allow a routing protocol to buffer.
+  uint32_t m_maxLen;
+  /// The maximum period of time that a routing protocol is allowed to buffer a packet for, seconds.
+  Time m_queueTimeout;
+  static bool IsEqual (QueueEntry en, const Ipv4Address dst)
+  {
+    return (en.GetIpv4Header ().GetDestination () == dst);
+  }
+};
+
+
+}
+}
+
+#endif /* GPSR_RQUEUE_H */

--- a/ns3/gpsr/model/gpsr.cc
+++ b/ns3/gpsr/model/gpsr.cc
@@ -152,11 +152,11 @@ RoutingProtocol::GetGodPosition (Ipv4Address adr) const
     {
       Ptr<Node> node = *i;
       Ptr<Ipv4> ipv4 = node->GetObject<Ipv4> ();
-      if (ipv4 != 0 && ipv4->GetNInterfaces () > 1
+      if (ipv4 && ipv4->GetNInterfaces () > 1
           && ipv4->GetAddress (1, 0).GetLocal () == adr)
         {
           Ptr<MobilityModel> mm = node->GetObject<MobilityModel> ();
-          if (mm != 0)
+          if (mm)
             {
               return mm->GetPosition ();
             }
@@ -206,8 +206,8 @@ NS_LOG_FUNCTION (this << p->GetUid () << header.GetDestination () << idev->GetAd
       NS_LOG_LOGIC ("No gpsr interfaces");
       return false;
     }
-  NS_ASSERT (m_ipv4 != 0);
-  NS_ASSERT (p != 0);
+  NS_ASSERT (m_ipv4);
+  NS_ASSERT (p);
   // Check if input device supports IP
   NS_ASSERT (m_ipv4->GetInterfaceForDevice (idev) >= 0);
   int32_t iif = m_ipv4->GetInterfaceForDevice (idev);
@@ -279,7 +279,7 @@ RoutingProtocol::DeferredRouteOutput (Ptr<const Packet> p, const Ipv4Header & he
                                       UnicastForwardCallback ucb, ErrorCallback ecb)
 {
   NS_LOG_FUNCTION (this << p << header);
-  NS_ASSERT (p != 0 && p != Ptr<Packet> ());
+  NS_ASSERT (p && p != Ptr<Packet> ());
 
   if (m_queue.GetSize () == 0)
     {
@@ -539,7 +539,7 @@ RoutingProtocol::NotifyInterfaceUp (uint32_t interface)
   // Create a socket to listen only on this interface
   Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
                                              UdpSocketFactory::GetTypeId ());
-  NS_ASSERT (socket != 0);
+  NS_ASSERT (socket);
   socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvGPSR, this));
   socket->Bind (InetSocketAddress (Ipv4Address::GetAny (), GPSR_PORT));
   socket->BindToNetDevice (l3->GetNetDevice (interface));
@@ -555,12 +555,12 @@ RoutingProtocol::NotifyInterfaceUp (uint32_t interface)
   // liveness then rests on the hello-lifetime purge alone.
   Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (iface.GetLocal ()));
   Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
-  if (wifi == 0)
+  if (!wifi)
     {
       return;
     }
   Ptr<WifiMac> mac = wifi->GetMac ();
-  if (mac == 0)
+  if (!mac)
     {
       return;
     }
@@ -574,7 +574,7 @@ RoutingProtocol::NotifyInterfaceUp (uint32_t interface)
 void
 RoutingProtocol::NotifyTxError (WifiMacDropReason reason, Ptr<const GPSR_WIFI_MPDU> mpdu)
 {
-  if (m_ipv4 == 0 || m_socketAddresses.empty () || mpdu == 0)
+  if (!m_ipv4 || m_socketAddresses.empty () || !mpdu)
     {
       return;
     }
@@ -590,7 +590,7 @@ RoutingProtocol::NotifyTxError (WifiMacDropReason reason, Ptr<const GPSR_WIFI_MP
       return;   // no single next hop failed
     }
   Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
-  if (l3 == 0)
+  if (!l3)
     {
       return;
     }
@@ -601,7 +601,7 @@ RoutingProtocol::NotifyTxError (WifiMacDropReason reason, Ptr<const GPSR_WIFI_MP
   for (uint32_t i = 0; i < l3->GetNInterfaces (); ++i)
     {
       Ptr<ArpCache> cache = l3->GetInterface (i)->GetArpCache ();
-      if (cache == 0)
+      if (!cache)
         {
           continue;
         }
@@ -675,10 +675,10 @@ RoutingProtocol::NotifyInterfaceDown (uint32_t interface)
   Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
   Ptr<NetDevice> dev = l3->GetNetDevice (interface);
   Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
-  if (wifi != 0)
+  if (wifi)
     {
       Ptr<WifiMac> mac = wifi->GetMac ();
-      if (mac != 0)
+      if (mac)
         {
           mac->TraceDisconnectWithoutContext ("DroppedMpdu",
                                               MakeCallback (&RoutingProtocol::NotifyTxError, this));
@@ -740,7 +740,7 @@ void RoutingProtocol::NotifyAddAddress (uint32_t interface, Ipv4InterfaceAddress
           // Create a socket to listen only on this interface
           Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
                                                      UdpSocketFactory::GetTypeId ());
-          NS_ASSERT (socket != 0);
+          NS_ASSERT (socket);
           socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvGPSR,this));
           socket->BindToNetDevice (l3->GetNetDevice (interface));
           // Bind to any IP address so that broadcasts can be received
@@ -773,7 +773,7 @@ RoutingProtocol::NotifyRemoveAddress (uint32_t i, Ipv4InterfaceAddress address)
           // Create a socket to listen only on this interface
           Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
                                                      UdpSocketFactory::GetTypeId ());
-          NS_ASSERT (socket != 0);
+          NS_ASSERT (socket);
           socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvGPSR, this));
           // Bind to any IP address so that broadcasts can be received
           socket->Bind (InetSocketAddress (Ipv4Address::GetAny (), GPSR_PORT));
@@ -800,8 +800,8 @@ RoutingProtocol::NotifyRemoveAddress (uint32_t i, Ipv4InterfaceAddress address)
 void
 RoutingProtocol::SetIpv4 (Ptr<Ipv4> ipv4)
 {
-  NS_ASSERT (ipv4 != 0);
-  NS_ASSERT (m_ipv4 == 0);
+  NS_ASSERT (ipv4);
+  NS_ASSERT (!m_ipv4);
 
   m_ipv4 = ipv4;
 
@@ -899,7 +899,7 @@ RoutingProtocol::LoopbackRoute (const Ipv4Header & hdr, Ptr<NetDevice> oif)
 {
   NS_LOG_FUNCTION (this << hdr);
   m_lo = m_ipv4->GetNetDevice (0);
-  NS_ASSERT (m_lo != 0);
+  NS_ASSERT (m_lo);
   Ptr<Ipv4Route> rt = Create<Ipv4Route> ();
   rt->SetDestination (hdr.GetDestination ());
 
@@ -1102,7 +1102,7 @@ RoutingProtocol::Forwarding (Ptr<const Packet> packet, const Ipv4Header & header
           // FIXME: Does not work for multiple interfaces
           route->SetOutputDevice (m_ipv4->GetNetDevice (1));
           route->SetDestination (header.GetDestination ());
-          NS_ASSERT (route != 0);
+          NS_ASSERT (route);
           NS_LOG_DEBUG ("Exist route to " << route->GetDestination () << " from interface " << route->GetOutputDevice ());
 
 
@@ -1219,9 +1219,9 @@ RoutingProtocol::RouteOutput (Ptr<Packet> p, const Ipv4Header &header,
       route->SetGateway (nextHop);
       route->SetOutputDevice (m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (route->GetSource ())));
       route->SetDestination (header.GetDestination ());
-      NS_ASSERT (route != 0);
+      NS_ASSERT (route);
       NS_LOG_DEBUG ("Exist route to " << route->GetDestination () << " from interface " << route->GetSource ());
-      if (oif != 0 && route->GetOutputDevice () != oif)
+      if (oif && route->GetOutputDevice () != oif)
         {
           NS_LOG_DEBUG ("Output device doesn't match. Dropped.");
           sockerr = Socket::ERROR_NOROUTETOHOST;

--- a/ns3/gpsr/model/gpsr.cc
+++ b/ns3/gpsr/model/gpsr.cc
@@ -1,0 +1,1246 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * GPSR. Vendored from https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr.
+ * Provenance and the list of port changes: ns3/gpsr/README.md and gpsr.h.
+ */
+#define NS_LOG_APPEND_CONTEXT                                           \
+  if (m_ipv4) { std::clog << "[node " << m_ipv4->GetObject<Node> ()->GetId () << "] "; }
+
+#include "gpsr.h"
+#include "ns3/log.h"
+#include "ns3/boolean.h"
+#include "ns3/random-variable-stream.h"
+#include "ns3/inet-socket-address.h"
+#include "ns3/trace-source-accessor.h"
+#include "ns3/udp-socket-factory.h"
+#include "ns3/udp-l4-protocol.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/arp-cache.h"
+#include "ns3/node-list.h"
+#include "ns3/double.h"
+#include "ns3/uinteger.h"
+#include <algorithm>
+#include <limits>
+
+namespace ns3 {
+NS_LOG_COMPONENT_DEFINE ("GpsrRoutingProtocol");
+namespace gpsr {
+
+
+
+struct DeferredRouteOutputTag : public Tag
+{
+  /// Positive if output device is fixed in RouteOutput
+  uint32_t m_isCallFromL3;
+
+  DeferredRouteOutputTag () : Tag (),
+                              m_isCallFromL3 (0)
+  {
+  }
+
+  static TypeId GetTypeId ()
+  {
+    static TypeId tid = TypeId ("ns3::gpsr::DeferredRouteOutputTag").SetParent<Tag> ();
+    return tid;
+  }
+
+  TypeId  GetInstanceTypeId () const
+  {
+    return GetTypeId ();
+  }
+
+  uint32_t GetSerializedSize () const
+  {
+    return sizeof(uint32_t);
+  }
+
+  void  Serialize (TagBuffer i) const
+  {
+    i.WriteU32 (m_isCallFromL3);
+  }
+
+  void  Deserialize (TagBuffer i)
+  {
+    m_isCallFromL3 = i.ReadU32 ();
+  }
+
+  void  Print (std::ostream &os) const
+  {
+    os << "DeferredRouteOutputTag: m_isCallFromL3 = " << m_isCallFromL3;
+  }
+};
+
+
+
+/********** Miscellaneous constants **********/
+
+/// Maximum allowed jitter.
+#define GPSR_MAXJITTER          (HelloInterval.GetSeconds () / 2)
+
+
+
+NS_OBJECT_ENSURE_REGISTERED (RoutingProtocol);
+
+/// UDP Port for GPSR control traffic, not defined by IANA yet
+const uint32_t RoutingProtocol::GPSR_PORT = 666;
+
+RoutingProtocol::RoutingProtocol ()
+  : HelloInterval (Seconds (1)),
+    MaxQueueLen (64),
+    MaxQueueTime (Seconds (30)),
+    m_queue (MaxQueueLen, MaxQueueTime),
+    HelloIntervalTimer (Timer::CANCEL_ON_DESTROY),
+    CheckQueueTimer (Timer::CANCEL_ON_DESTROY),
+    PerimeterMode (false)
+{
+  m_neighbors = PositionTable ();
+  // #352 (port change): one member RNG, pinnable via AssignStreams, replaces
+  // the vendored per-call UniformRandomVariable constructions.
+  m_uniformRandomVariable = CreateObject<UniformRandomVariable> ();
+}
+
+TypeId
+RoutingProtocol::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::gpsr::RoutingProtocol")
+    .SetParent<Ipv4RoutingProtocol> ()
+    .AddConstructor<RoutingProtocol> ()
+    .AddAttribute ("HelloInterval", "HELLO messages emission interval.",
+                   TimeValue (Seconds (1)),
+                   MakeTimeAccessor (&RoutingProtocol::HelloInterval),
+                   MakeTimeChecker ())
+    // Port change: the vendored LocationServiceName enum attribute is gone —
+    // GOD (the only implemented value) is inlined; see GetGodPosition.
+    .AddAttribute ("PerimeterMode", "Indicates if PerimeterMode is enabled",
+                   BooleanValue (false),
+                   MakeBooleanAccessor (&RoutingProtocol::PerimeterMode),
+                   MakeBooleanChecker ())
+  ;
+  return tid;
+}
+
+RoutingProtocol::~RoutingProtocol ()
+{
+}
+
+void
+RoutingProtocol::DoDispose ()
+{
+  m_ipv4 = 0;
+  m_downTarget = IpL4Protocol::DownTargetCallback ();
+  Ipv4RoutingProtocol::DoDispose ();
+}
+
+int64_t
+RoutingProtocol::AssignStreams (int64_t stream)
+{
+  NS_LOG_FUNCTION (this << stream);
+  m_uniformRandomVariable->SetStream (stream);
+  return 1;
+}
+
+Vector
+RoutingProtocol::GetGodPosition (Ipv4Address adr) const
+{
+  // GOD location service, inlined (port change; the vendored tree's
+  // GodLocationService::GetPosition did this same NodeList scan).
+  for (NodeList::Iterator i = NodeList::Begin (); i != NodeList::End (); i++)
+    {
+      Ptr<Node> node = *i;
+      Ptr<Ipv4> ipv4 = node->GetObject<Ipv4> ();
+      if (ipv4 != 0 && ipv4->GetNInterfaces () > 1
+          && ipv4->GetAddress (1, 0).GetLocal () == adr)
+        {
+          Ptr<MobilityModel> mm = node->GetObject<MobilityModel> ();
+          if (mm != 0)
+            {
+              return mm->GetPosition ();
+            }
+        }
+    }
+  return PositionTable::GetInvalidPosition ();
+}
+
+bool
+RoutingProtocol::StripTransport (Ptr<Packet> p, uint8_t protocol, UdpHeader &udp) const
+{
+  // Only UDP is wrapped by the down-target hook (GpsrHelper::Install re-points
+  // UdpL4Protocol alone), so only UDP carries GPSR headers beneath it.
+  if (protocol != UdpL4Protocol::PROT_NUMBER)
+    {
+      return false;
+    }
+  if (p->GetSize () < 8)
+    {
+      return false;
+    }
+  p->RemoveHeader (udp);
+  return true;
+}
+
+void
+RoutingProtocol::RestoreTransport (Ptr<Packet> p, const UdpHeader &udp, bool stripped) const
+{
+  if (stripped)
+    {
+      // Re-serialization recomputes the UDP length from the buffer, so the
+      // header stays consistent after the GPSR headers beneath it changed
+      // size or content. Checksums must stay globally disabled (ns-3
+      // default): the stored checksum is not refreshed here.
+      p->AddHeader (udp);
+    }
+}
+
+bool RoutingProtocol::RouteInput (Ptr<const Packet> p, const Ipv4Header &header, Ptr<const NetDevice> idev,
+                                  GPSR_RI_CB (UnicastForwardCallback) ucb, GPSR_RI_CB (MulticastForwardCallback) mcb,
+                                  GPSR_RI_CB (LocalDeliverCallback) lcb, GPSR_RI_CB (ErrorCallback) ecb)
+{
+
+NS_LOG_FUNCTION (this << p->GetUid () << header.GetDestination () << idev->GetAddress ());
+  if (m_socketAddresses.empty ())
+    {
+      NS_LOG_LOGIC ("No gpsr interfaces");
+      return false;
+    }
+  NS_ASSERT (m_ipv4 != 0);
+  NS_ASSERT (p != 0);
+  // Check if input device supports IP
+  NS_ASSERT (m_ipv4->GetInterfaceForDevice (idev) >= 0);
+  int32_t iif = m_ipv4->GetInterfaceForDevice (idev);
+  Ipv4Address dst = header.GetDestination ();
+  Ipv4Address origin = header.GetSource ();
+
+  DeferredRouteOutputTag tag; //FIXME since I have to check if it's in origin for it to work it means I'm not taking some tag out...
+  if (p->PeekPacketTag (tag) && IsMyOwnAddress (origin))
+    {
+      Ptr<Packet> packet = p->Copy (); //FIXME ja estou a abusar de tirar tags
+      packet->RemovePacketTag(tag);
+      DeferredRouteOutput (packet, header, ucb, ecb);
+      return true;
+    }
+
+
+
+  if (m_ipv4->IsDestinationAddress (dst, iif))
+    {
+
+      Ptr<Packet> packet = p->Copy ();
+      // Fault-3 rework: the GPSR headers now sit *beneath* the UDP header
+      // (IP|UDP|GPSR); peel the UDP header off, strip them, put it back, so
+      // the application receives the datagram it was sent.
+      UdpHeader udpHeader;
+      const bool hasUdp = StripTransport (packet, header.GetProtocol (), udpHeader);
+      if (hasUdp && packet->GetSize () >= 1)
+        {
+          TypeHeader tHeader (GPSRTYPE_POS);
+          packet->RemoveHeader (tHeader);
+          if (!tHeader.IsValid ())
+            {
+              NS_LOG_DEBUG ("GPSR message " << packet->GetUid () << " with unknown type received: " << tHeader.Get () << ". Ignored");
+              return false;
+            }
+
+          if (tHeader.Get () == GPSRTYPE_POS)
+            {
+              PositionHeader phdr;
+              packet->RemoveHeader (phdr);
+            }
+          RestoreTransport (packet, udpHeader, hasUdp);
+        }
+      else
+        {
+          RestoreTransport (packet, udpHeader, hasUdp);
+        }
+
+      if (dst != m_ipv4->GetAddress (1, 0).GetBroadcast ())
+        {
+          NS_LOG_LOGIC ("Unicast local delivery to " << dst);
+        }
+      else
+        {
+//          NS_LOG_LOGIC ("Broadcast local delivery to " << dst);
+        }
+
+      lcb (packet, header, iif);
+      return true;
+    }
+
+
+  return Forwarding (p, header, ucb, ecb);
+}
+
+
+void
+RoutingProtocol::DeferredRouteOutput (Ptr<const Packet> p, const Ipv4Header & header,
+                                      UnicastForwardCallback ucb, ErrorCallback ecb)
+{
+  NS_LOG_FUNCTION (this << p << header);
+  NS_ASSERT (p != 0 && p != Ptr<Packet> ());
+
+  if (m_queue.GetSize () == 0)
+    {
+      CheckQueueTimer.Cancel ();
+      CheckQueueTimer.Schedule (Time ("500ms"));
+    }
+
+  QueueEntry newEntry (p, header, ucb, ecb);
+  bool result = m_queue.Enqueue (newEntry);
+
+
+  m_queuedAddresses.insert (m_queuedAddresses.begin (), header.GetDestination ());
+  m_queuedAddresses.unique ();
+
+  if (result)
+    {
+      NS_LOG_LOGIC ("Add packet " << p->GetUid () << " to queue. Protocol " << (uint16_t) header.GetProtocol ());
+
+    }
+
+}
+
+void
+RoutingProtocol::CheckQueue ()
+{
+
+  CheckQueueTimer.Cancel ();
+
+  std::list<Ipv4Address> toRemove;
+
+  for (std::list<Ipv4Address>::iterator i = m_queuedAddresses.begin (); i != m_queuedAddresses.end (); ++i)
+    {
+      if (SendPacketFromQueue (*i))
+        {
+          //Insert in a list to remove later
+          toRemove.insert (toRemove.begin (), *i);
+        }
+    }
+
+  //remove all that are on the list
+  for (std::list<Ipv4Address>::iterator i = toRemove.begin (); i != toRemove.end (); ++i)
+    {
+      m_queuedAddresses.remove (*i);
+    }
+
+  if (!m_queuedAddresses.empty ()) //Only need to schedule if the queue is not empty
+    {
+      CheckQueueTimer.Schedule (Time ("500ms"));
+    }
+}
+
+bool
+RoutingProtocol::SendPacketFromQueue (Ipv4Address dst)
+{
+  NS_LOG_FUNCTION (this);
+  bool recovery = false;
+  QueueEntry queueEntry;
+
+  // GOD location service (port change): a position always exists for a known
+  // address and there is never a pending lookup, so the vendored IsInSearch /
+  // HasPosition gates collapse; only an unknown destination drops the queue.
+  if (CalculateDistance (GetGodPosition (dst), PositionTable::GetInvalidPosition ()) == 0)
+    {
+      m_queue.DropPacketWithDst (dst);
+      NS_LOG_LOGIC ("Location Service did not find dst. Drop packet to " << dst);
+      return true;
+    }
+
+  Vector myPos;
+
+  Ptr<MobilityModel> MM = m_ipv4->GetObject<MobilityModel> ();
+  myPos.x = MM->GetPosition ().x;
+  myPos.y = MM->GetPosition ().y;
+  Ipv4Address nextHop;
+
+  if(m_neighbors.isNeighbour (dst))
+    {
+      nextHop = dst;
+    }
+  else{
+    Vector dstPos = GetGodPosition (dst);
+    nextHop = m_neighbors.BestNeighbor (dstPos, myPos);
+    if (nextHop == Ipv4Address::GetZero ())
+      {
+        NS_LOG_LOGIC ("Fallback to recovery-mode. Packets to " << dst);
+        recovery = true;
+      }
+    if(recovery)
+      {
+
+        Vector Position;
+        uint32_t updated = 0;
+
+        while(m_queue.Dequeue (dst, queueEntry))
+          {
+            Ptr<Packet> p = ConstCast<Packet> (queueEntry.GetPacket ());
+            UnicastForwardCallback ucb = queueEntry.GetUnicastForwardCallback ();
+            Ipv4Header header = queueEntry.GetIpv4Header ();
+
+            // Fault-3 rework: the GPSR headers sit beneath the UDP header.
+            UdpHeader udpHeader;
+            const bool hasUdp = StripTransport (p, header.GetProtocol (), udpHeader);
+            if (!hasUdp || p->GetSize () < 1)
+              {
+                // No GPSR headers were ever added (non-UDP packet): recovery
+                // state cannot travel with it; drop it as routeless.
+                RestoreTransport (p, udpHeader, hasUdp);
+                queueEntry.GetErrorCallback () (p, header, Socket::ERROR_NOROUTETOHOST);
+                continue;
+              }
+            TypeHeader tHeader (GPSRTYPE_POS);
+            p->RemoveHeader (tHeader);
+            if (!tHeader.IsValid ())
+              {
+                NS_LOG_DEBUG ("GPSR message " << p->GetUid () << " with unknown type received: " << tHeader.Get () << ". Drop");
+                return false;     // drop
+              }
+            if (tHeader.Get () == GPSRTYPE_POS)
+              {
+                PositionHeader hdr;
+                p->RemoveHeader (hdr);
+                Position.x = hdr.GetDstPosx ();
+                Position.y = hdr.GetDstPosy ();
+                updated = hdr.GetUpdated ();
+              }
+
+            PositionHeader posHeader (Position.x, Position.y,  updated, myPos.x, myPos.y, (uint8_t) 1, Position.x, Position.y);
+            p->AddHeader (posHeader); //enters in recovery with last edge from Dst
+            p->AddHeader (tHeader);
+            RestoreTransport (p, udpHeader, hasUdp);
+
+            RecoveryMode(dst, p, ucb, header);
+          }
+        return true;
+      }
+  }
+  Ptr<Ipv4Route> route = Create<Ipv4Route> ();
+  route->SetDestination (dst);
+  route->SetGateway (nextHop);
+
+  // FIXME: Does not work for multiple interfaces
+  route->SetOutputDevice (m_ipv4->GetNetDevice (1));
+
+  while (m_queue.Dequeue (dst, queueEntry))
+    {
+      DeferredRouteOutputTag tag;
+      Ptr<Packet> p = ConstCast<Packet> (queueEntry.GetPacket ());
+
+      UnicastForwardCallback ucb = queueEntry.GetUnicastForwardCallback ();
+      Ipv4Header header = queueEntry.GetIpv4Header ();
+
+      if (header.GetSource () == Ipv4Address ("102.102.102.102"))
+        {
+          route->SetSource (m_ipv4->GetAddress (1, 0).GetLocal ());
+          header.SetSource (m_ipv4->GetAddress (1, 0).GetLocal ());
+        }
+      else
+        {
+          route->SetSource (header.GetSource ());
+        }
+      ucb (route, p, header);
+    }
+  return true;
+}
+
+
+void
+RoutingProtocol::RecoveryMode(Ipv4Address dst, Ptr<Packet> p, UnicastForwardCallback ucb, Ipv4Header header){
+
+  Vector Position;
+  Vector previousHop;
+  uint32_t updated = 0;
+  uint64_t positionX;
+  uint64_t positionY;
+  Vector myPos;
+  Vector recPos;
+
+  Ptr<MobilityModel> MM = m_ipv4->GetObject<MobilityModel> ();
+  positionX = MM->GetPosition ().x;
+  positionY = MM->GetPosition ().y;
+  myPos.x = positionX;
+  myPos.y = positionY;
+
+  // Fault-3 rework: the GPSR headers sit beneath the UDP header. RecoveryMode
+  // is only ever entered with a GPSR-headered (UDP) packet — Forwarding and
+  // SendPacketFromQueue route non-UDP packets greedily or drop them.
+  UdpHeader udpHeader;
+  const bool hasUdp = StripTransport (p, header.GetProtocol (), udpHeader);
+  if (!hasUdp)
+    {
+      NS_LOG_DEBUG ("RecoveryMode without a transport-wrapped GPSR packet " << p->GetUid () << ". Drop");
+      return;     // drop
+    }
+
+  TypeHeader tHeader (GPSRTYPE_POS);
+  p->RemoveHeader (tHeader);
+  if (!tHeader.IsValid ())
+    {
+      NS_LOG_DEBUG ("GPSR message " << p->GetUid () << " with unknown type received: " << tHeader.Get () << ". Drop");
+      return;     // drop
+    }
+  if (tHeader.Get () == GPSRTYPE_POS)
+    {
+      PositionHeader hdr;
+      p->RemoveHeader (hdr);
+      Position.x = hdr.GetDstPosx ();
+      Position.y = hdr.GetDstPosy ();
+      updated = hdr.GetUpdated ();
+      recPos.x = hdr.GetRecPosx ();
+      recPos.y = hdr.GetRecPosy ();
+      previousHop.x = hdr.GetLastPosx ();
+      previousHop.y = hdr.GetLastPosy ();
+   }
+
+  PositionHeader posHeader (Position.x, Position.y,  updated, recPos.x, recPos.y, (uint8_t) 1, myPos.x, myPos.y);
+  p->AddHeader (posHeader);
+  p->AddHeader (tHeader);
+  RestoreTransport (p, udpHeader, hasUdp);
+
+
+
+  Ipv4Address nextHop = m_neighbors.BestAngle (previousHop, myPos);
+  if (nextHop == Ipv4Address::GetZero ())
+    {
+      return;
+    }
+
+  Ptr<Ipv4Route> route = Create<Ipv4Route> ();
+  route->SetDestination (dst);
+  route->SetGateway (nextHop);
+
+  // FIXME: Does not work for multiple interfaces
+  route->SetOutputDevice (m_ipv4->GetNetDevice (1));
+  route->SetSource (header.GetSource ());
+
+  NS_LOG_LOGIC (route->GetOutputDevice () << " forwarding in Recovery to " << dst << " through " << route->GetGateway () << " packet " << p->GetUid ());
+  ucb (route, p, header);
+  return;
+}
+
+
+void
+RoutingProtocol::NotifyInterfaceUp (uint32_t interface)
+{
+  NS_LOG_FUNCTION (this << m_ipv4->GetAddress (interface, 0).GetLocal ());
+  Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+  if (l3->GetNAddresses (interface) > 1)
+    {
+      NS_LOG_WARN ("GPSR does not work with more then one address per each interface.");
+    }
+  Ipv4InterfaceAddress iface = l3->GetAddress (interface, 0);
+  if (iface.GetLocal () == Ipv4Address ("127.0.0.1"))
+    {
+      return;
+    }
+
+  // Create a socket to listen only on this interface
+  Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
+                                             UdpSocketFactory::GetTypeId ());
+  NS_ASSERT (socket != 0);
+  socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvGPSR, this));
+  socket->Bind (InetSocketAddress (Ipv4Address::GetAny (), GPSR_PORT));
+  socket->BindToNetDevice (l3->GetNetDevice (interface));
+  socket->SetAllowBroadcast (true);
+  socket->SetAttribute ("IpTtl", UintegerValue (1));
+  m_socketAddresses.insert (std::make_pair (socket, iface));
+
+
+  // Allow neighbor manager use this interface for layer 2 feedback if possible
+  // Fault-1 rework: subscribe to the modern WifiMac "DroppedMpdu" trace (the
+  // vendored "TxErrHeader" trace was removed from ns-3). TraceConnect returns
+  // false if the source is absent on this ns-3 release; tolerated — neighbour
+  // liveness then rests on the hello-lifetime purge alone.
+  Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (iface.GetLocal ()));
+  Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
+  if (wifi == 0)
+    {
+      return;
+    }
+  Ptr<WifiMac> mac = wifi->GetMac ();
+  if (mac == 0)
+    {
+      return;
+    }
+
+  mac->TraceConnectWithoutContext ("DroppedMpdu",
+                                   MakeCallback (&RoutingProtocol::NotifyTxError, this));
+
+}
+
+
+void
+RoutingProtocol::NotifyTxError (WifiMacDropReason reason, Ptr<const GPSR_WIFI_MPDU> mpdu)
+{
+  if (m_ipv4 == 0 || m_socketAddresses.empty () || mpdu == 0)
+    {
+      return;
+    }
+  // Only a retry-limit drop is a real broken link; other drop reasons
+  // (queue full, lifetime expiry) are congestion, not topology.
+  if (reason != WIFI_MAC_DROP_REACHED_RETRY_LIMIT)
+    {
+      return;
+    }
+  const Mac48Address dstMac = mpdu->GetHeader ().GetAddr1 ();
+  if (dstMac.IsBroadcast () || dstMac.IsGroup ())
+    {
+      return;   // no single next hop failed
+    }
+  Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+  if (l3 == 0)
+    {
+      return;
+    }
+  // Resolve the failed next-hop MAC to an IP by forward-looking each known
+  // neighbour in the per-interface ARP caches (ArpCache::LookupInverse's
+  // return type drifts across ns-3 versions; forward Lookup is stable).
+  std::vector<Ipv4Address> neighbours = m_neighbors.GetKnownNeighbors ();
+  for (uint32_t i = 0; i < l3->GetNInterfaces (); ++i)
+    {
+      Ptr<ArpCache> cache = l3->GetInterface (i)->GetArpCache ();
+      if (cache == 0)
+        {
+          continue;
+        }
+      for (std::vector<Ipv4Address>::const_iterator nb = neighbours.begin ();
+           nb != neighbours.end (); ++nb)
+        {
+          ArpCache::Entry *entry = cache->Lookup (*nb);
+          if (entry == 0)
+            {
+              continue;
+            }
+          // An entry still resolving carries no MAC yet; guard ConvertFrom,
+          // which asserts on a non-48-bit address.
+          const Address resolved = entry->GetMacAddress ();
+          if (Mac48Address::IsMatchingType (resolved)
+              && Mac48Address::ConvertFrom (resolved) == dstMac)
+            {
+              NS_LOG_LOGIC ("MAC tx failure to neighbour " << *nb << "; removing from position table");
+              m_neighbors.DeleteEntry (*nb);
+              return;
+            }
+        }
+    }
+}
+
+
+void
+RoutingProtocol::RecvGPSR (Ptr<Socket> socket)
+{
+  NS_LOG_FUNCTION (this << socket);
+  Address sourceAddress;
+  Ptr<Packet> packet = socket->RecvFrom (sourceAddress);
+
+  TypeHeader tHeader (GPSRTYPE_HELLO);
+  packet->RemoveHeader (tHeader);
+  if (!tHeader.IsValid ())
+    {
+      NS_LOG_DEBUG ("GPSR message " << packet->GetUid () << " with unknown type received: " << tHeader.Get () << ". Ignored");
+      return;
+    }
+
+  HelloHeader hdr;
+  packet->RemoveHeader (hdr);
+  Vector Position;
+  Position.x = hdr.GetOriginPosx ();
+  Position.y = hdr.GetOriginPosy ();
+  InetSocketAddress inetSourceAddr = InetSocketAddress::ConvertFrom (sourceAddress);
+  Ipv4Address sender = inetSourceAddr.GetIpv4 ();
+  Ipv4Address receiver = m_socketAddresses[socket].GetLocal ();
+
+  UpdateRouteToNeighbor (sender, receiver, Position);
+
+}
+
+
+void
+RoutingProtocol::UpdateRouteToNeighbor (Ipv4Address sender, Ipv4Address receiver, Vector Pos)
+{
+  m_neighbors.AddEntry (sender, Pos);
+
+}
+
+
+
+void
+RoutingProtocol::NotifyInterfaceDown (uint32_t interface)
+{
+  NS_LOG_FUNCTION (this << m_ipv4->GetAddress (interface, 0).GetLocal ());
+
+  // Disable layer 2 link state monitoring (if possible)
+  Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+  Ptr<NetDevice> dev = l3->GetNetDevice (interface);
+  Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
+  if (wifi != 0)
+    {
+      Ptr<WifiMac> mac = wifi->GetMac ();
+      if (mac != 0)
+        {
+          mac->TraceDisconnectWithoutContext ("DroppedMpdu",
+                                              MakeCallback (&RoutingProtocol::NotifyTxError, this));
+        }
+    }
+
+  // Close socket
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (m_ipv4->GetAddress (interface, 0));
+  NS_ASSERT (socket);
+  socket->Close ();
+  m_socketAddresses.erase (socket);
+  if (m_socketAddresses.empty ())
+    {
+      NS_LOG_LOGIC ("No gpsr interfaces");
+      m_neighbors.Clear ();
+      return;
+    }
+}
+
+
+Ptr<Socket>
+RoutingProtocol::FindSocketWithInterfaceAddress (Ipv4InterfaceAddress addr ) const
+{
+  NS_LOG_FUNCTION (this << addr);
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+         m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ptr<Socket> socket = j->first;
+      Ipv4InterfaceAddress iface = j->second;
+      if (iface == addr)
+        {
+          return socket;
+        }
+    }
+  Ptr<Socket> socket;
+  return socket;
+}
+
+
+
+void RoutingProtocol::NotifyAddAddress (uint32_t interface, Ipv4InterfaceAddress address)
+{
+  NS_LOG_FUNCTION (this << " interface " << interface << " address " << address);
+  Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+  if (!l3->IsUp (interface))
+    {
+      return;
+    }
+  if (l3->GetNAddresses ((interface) == 1))
+    {
+      Ipv4InterfaceAddress iface = l3->GetAddress (interface, 0);
+      Ptr<Socket> socket = FindSocketWithInterfaceAddress (iface);
+      if (!socket)
+        {
+          if (iface.GetLocal () == Ipv4Address ("127.0.0.1"))
+            {
+              return;
+            }
+          // Create a socket to listen only on this interface
+          Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
+                                                     UdpSocketFactory::GetTypeId ());
+          NS_ASSERT (socket != 0);
+          socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvGPSR,this));
+          socket->BindToNetDevice (l3->GetNetDevice (interface));
+          // Bind to any IP address so that broadcasts can be received
+          socket->Bind (InetSocketAddress (Ipv4Address::GetAny (), GPSR_PORT));
+          socket->SetAllowBroadcast (true);
+          m_socketAddresses.insert (std::make_pair (socket, iface));
+
+          Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (iface.GetLocal ()));
+        }
+    }
+  else
+    {
+      NS_LOG_LOGIC ("GPSR does not work with more then one address per each interface. Ignore added address");
+    }
+}
+
+void
+RoutingProtocol::NotifyRemoveAddress (uint32_t i, Ipv4InterfaceAddress address)
+{
+  NS_LOG_FUNCTION (this);
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (address);
+  if (socket)
+    {
+
+      m_socketAddresses.erase (socket);
+      Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+      if (l3->GetNAddresses (i))
+        {
+          Ipv4InterfaceAddress iface = l3->GetAddress (i, 0);
+          // Create a socket to listen only on this interface
+          Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
+                                                     UdpSocketFactory::GetTypeId ());
+          NS_ASSERT (socket != 0);
+          socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvGPSR, this));
+          // Bind to any IP address so that broadcasts can be received
+          socket->Bind (InetSocketAddress (Ipv4Address::GetAny (), GPSR_PORT));
+          socket->SetAllowBroadcast (true);
+          m_socketAddresses.insert (std::make_pair (socket, iface));
+
+          // Add local broadcast record to the routing table
+          Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (iface.GetLocal ()));
+
+        }
+      if (m_socketAddresses.empty ())
+        {
+          NS_LOG_LOGIC ("No gpsr interfaces");
+          m_neighbors.Clear ();
+          return;
+        }
+    }
+  else
+    {
+      NS_LOG_LOGIC ("Remove address not participating in GPSR operation");
+    }
+}
+
+void
+RoutingProtocol::SetIpv4 (Ptr<Ipv4> ipv4)
+{
+  NS_ASSERT (ipv4 != 0);
+  NS_ASSERT (m_ipv4 == 0);
+
+  m_ipv4 = ipv4;
+
+  HelloIntervalTimer.SetFunction (&RoutingProtocol::HelloTimerExpire, this);
+  // First hello cannot be in the past: jitter in [0, GPSR_MAXJITTER].
+  // #352 (port change): drawn from the pinned member RNG.
+  HelloIntervalTimer.Schedule (Seconds (m_uniformRandomVariable->GetValue (0.0, GPSR_MAXJITTER)));
+
+  //Schedule only when it has packets on queue
+  CheckQueueTimer.SetFunction (&RoutingProtocol::CheckQueue, this);
+
+  Simulator::ScheduleNow (&RoutingProtocol::Start, this);
+}
+
+void
+RoutingProtocol::HelloTimerExpire ()
+{
+  SendHello ();
+  HelloIntervalTimer.Cancel ();
+  // #352 (port change): jitter in [-GPSR_MAXJITTER, GPSR_MAXJITTER] from the
+  // pinned member RNG.
+  HelloIntervalTimer.Schedule (HelloInterval
+                               + Seconds (m_uniformRandomVariable->GetValue (-1 * GPSR_MAXJITTER,
+                                                                             GPSR_MAXJITTER)));
+}
+
+void
+RoutingProtocol::SendHello ()
+{
+  NS_LOG_FUNCTION (this);
+  double positionX;
+  double positionY;
+
+  Ptr<MobilityModel> MM = m_ipv4->GetObject<MobilityModel> ();
+
+  positionX = MM->GetPosition ().x;
+  positionY = MM->GetPosition ().y;
+
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j = m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ptr<Socket> socket = j->first;
+      Ipv4InterfaceAddress iface = j->second;
+      HelloHeader helloHeader (((uint64_t) positionX),((uint64_t) positionY));
+
+      Ptr<Packet> packet = Create<Packet> ();
+      packet->AddHeader (helloHeader);
+      TypeHeader tHeader (GPSRTYPE_HELLO);
+      packet->AddHeader (tHeader);
+      // Send to all-hosts broadcast if on /32 addr, subnet-directed otherwise
+      Ipv4Address destination;
+      if (iface.GetMask () == Ipv4Mask::GetOnes ())
+        {
+          destination = Ipv4Address ("255.255.255.255");
+        }
+      else
+        {
+          destination = iface.GetBroadcast ();
+        }
+      socket->SendTo (packet, 0, InetSocketAddress (destination, GPSR_PORT));
+
+    }
+}
+
+bool
+RoutingProtocol::IsMyOwnAddress (Ipv4Address src)
+{
+  NS_LOG_FUNCTION (this << src);
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+         m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ipv4InterfaceAddress iface = j->second;
+      if (src == iface.GetLocal ())
+        {
+          return true;
+        }
+    }
+  return false;
+}
+
+
+
+
+void
+RoutingProtocol::Start ()
+{
+  NS_LOG_FUNCTION (this);
+  m_queuedAddresses.clear ();
+
+  // Port change: the location-service switch is gone — GOD (the only
+  // implemented service) is inlined as GetGodPosition.
+}
+
+Ptr<Ipv4Route>
+RoutingProtocol::LoopbackRoute (const Ipv4Header & hdr, Ptr<NetDevice> oif)
+{
+  NS_LOG_FUNCTION (this << hdr);
+  m_lo = m_ipv4->GetNetDevice (0);
+  NS_ASSERT (m_lo != 0);
+  Ptr<Ipv4Route> rt = Create<Ipv4Route> ();
+  rt->SetDestination (hdr.GetDestination ());
+
+  std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j = m_socketAddresses.begin ();
+  if (oif)
+    {
+      // Iterate to find an address on the oif device
+      for (j = m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+        {
+          Ipv4Address addr = j->second.GetLocal ();
+          int32_t interface = m_ipv4->GetInterfaceForAddress (addr);
+          if (oif == m_ipv4->GetNetDevice (static_cast<uint32_t> (interface)))
+            {
+              rt->SetSource (addr);
+              break;
+            }
+        }
+    }
+  else
+    {
+      rt->SetSource (j->second.GetLocal ());
+    }
+  NS_ASSERT_MSG (rt->GetSource () != Ipv4Address (), "Valid GPSR source address not found");
+  rt->SetGateway (Ipv4Address ("127.0.0.1"));
+  rt->SetOutputDevice (m_lo);
+  return rt;
+}
+
+
+int
+RoutingProtocol::GetProtocolNumber (void) const
+{
+  return GPSR_PORT;
+}
+
+void
+RoutingProtocol::AddHeaders (Ptr<Packet> p, Ipv4Address source, Ipv4Address destination, uint8_t protocol, Ptr<Ipv4Route> route)
+{
+
+  NS_LOG_FUNCTION (this << " source " << source << " destination " << destination);
+
+  Vector myPos;
+  Ptr<MobilityModel> MM = m_ipv4->GetObject<MobilityModel> ();
+  myPos.x = MM->GetPosition ().x;
+  myPos.y = MM->GetPosition ().y;
+
+  Ipv4Address nextHop;
+
+  if(m_neighbors.isNeighbour (destination))
+    {
+      nextHop = destination;
+    }
+  else
+    {
+      nextHop = m_neighbors.BestNeighbor (GetGodPosition (destination), myPos);
+    }
+
+  uint16_t positionX = 0;
+  uint16_t positionY = 0;
+  uint32_t hdrTime = 0;
+
+  if(destination != m_ipv4->GetAddress (1, 0).GetBroadcast ())
+    {
+      positionX = GetGodPosition (destination).x;
+      positionY = GetGodPosition (destination).y;
+      hdrTime = (uint32_t) Simulator::Now ().GetSeconds ();
+    }
+
+  // Fault-3 rework: the vendored code prepended the GPSR headers to the
+  // packet as handed down by UDP, producing IP|GPSR|UDP on the wire while
+  // ip.protocol still read 17 — FlowMonitor's Ipv4FlowClassifier then read
+  // the first four bytes of the IP payload (position bytes, changing per
+  // packet) as UDP ports and misclassified every data flow. Layer the same
+  // headers *beneath* the UDP header instead (IP|UDP|GPSR): identical bytes
+  // on the wire and identical routing state, but the IP payload now starts
+  // with the real transport header, so FlowMonitor classifies data flows
+  // correctly and port-based control/data accounting sees GPSR's port 666
+  // hellos. Non-UDP packets (the down target is only re-pointed for UDP)
+  // pass through untouched and are forwarded greedily without recovery
+  // state — see Forwarding.
+  UdpHeader udpHeader;
+  const bool hasUdp = StripTransport (p, protocol, udpHeader);
+  if (hasUdp)
+    {
+      PositionHeader posHeader (positionX, positionY,  hdrTime, (uint64_t) 0,(uint64_t) 0, (uint8_t) 0, myPos.x, myPos.y);
+      p->AddHeader (posHeader);
+      TypeHeader tHeader (GPSRTYPE_POS);
+      p->AddHeader (tHeader);
+      RestoreTransport (p, udpHeader, hasUdp);
+    }
+
+  m_downTarget (p, source, destination, protocol, route);
+
+}
+
+bool
+RoutingProtocol::Forwarding (Ptr<const Packet> packet, const Ipv4Header & header,
+                             UnicastForwardCallback ucb, ErrorCallback ecb)
+{
+  Ptr<Packet> p = packet->Copy ();
+  NS_LOG_FUNCTION (this);
+  Ipv4Address dst = header.GetDestination ();
+  Ipv4Address origin = header.GetSource ();
+
+
+  m_neighbors.Purge ();
+
+  uint32_t updated = 0;
+  Vector Position;
+  Vector RecPosition;
+  uint8_t inRec = 0;
+
+  // Fault-3 rework: the GPSR headers sit beneath the UDP header; peel the UDP
+  // header off before reading them. Non-UDP packets carry no GPSR headers
+  // (see AddHeaders) and are forwarded greedily from GOD positions alone.
+  UdpHeader udpHeader;
+  const bool hasUdp = StripTransport (p, header.GetProtocol (), udpHeader);
+  bool hasGpsrHeader = false;
+
+  TypeHeader tHeader (GPSRTYPE_POS);
+  PositionHeader hdr;
+  if (hasUdp && p->GetSize () >= 1)
+    {
+      p->RemoveHeader (tHeader);
+      if (!tHeader.IsValid ())
+        {
+          NS_LOG_DEBUG ("GPSR message " << p->GetUid () << " with unknown type received: " << tHeader.Get () << ". Drop");
+          return false;     // drop
+        }
+      if (tHeader.Get () == GPSRTYPE_POS)
+        {
+
+          p->RemoveHeader (hdr);
+          Position.x = hdr.GetDstPosx ();
+          Position.y = hdr.GetDstPosy ();
+          updated = hdr.GetUpdated ();
+          RecPosition.x = hdr.GetRecPosx ();
+          RecPosition.y = hdr.GetRecPosy ();
+          inRec = hdr.GetInRec ();
+          hasGpsrHeader = true;
+        }
+    }
+
+  Vector myPos;
+  Ptr<MobilityModel> MM = m_ipv4->GetObject<MobilityModel> ();
+  myPos.x = MM->GetPosition ().x;
+  myPos.y = MM->GetPosition ().y;
+
+  if(inRec == 1 && CalculateDistance (myPos, Position) < CalculateDistance (RecPosition, Position)){
+    inRec = 0;
+    hdr.SetInRec(0);
+  NS_LOG_LOGIC ("No longer in Recovery to " << dst << " in " << myPos);
+  }
+
+  if(inRec){
+    p->AddHeader (hdr);
+    p->AddHeader (tHeader); //put headers back so that the RecoveryMode is compatible with Forwarding and SendFromQueue
+    RestoreTransport (p, udpHeader, hasUdp);
+    RecoveryMode (dst, p, ucb, header);
+    return true;
+  }
+
+
+
+  // GOD location service (port change): this node always has the freshest
+  // destination position, so the header's carried estimate is refreshed
+  // unconditionally (the vendored GetEntryUpdateTime returned Now () for GOD,
+  // making its "is mine newer" check always true).
+  Position.x = GetGodPosition (dst).x;
+  Position.y = GetGodPosition (dst).y;
+  updated = (uint32_t) Simulator::Now ().GetSeconds ();
+
+
+  Ipv4Address nextHop;
+
+/*  if(m_neighbors.isNeighbour (dst))
+    {
+      nextHop = dst;
+    }
+  else
+    {
+*/
+      nextHop = m_neighbors.BestNeighbor (Position, myPos);
+      if (nextHop != Ipv4Address::GetZero ())
+        {
+          if (hasGpsrHeader)
+            {
+              PositionHeader posHeader (Position.x, Position.y,  updated, (uint64_t) 0, (uint64_t) 0, (uint8_t) 0, myPos.x, myPos.y);
+              p->AddHeader (posHeader);
+              p->AddHeader (tHeader);
+            }
+          RestoreTransport (p, udpHeader, hasUdp);
+
+
+          Ptr<Ipv4Route> route = Create<Ipv4Route> ();
+          route->SetDestination (dst);
+          route->SetSource (header.GetSource ());
+          route->SetGateway (nextHop);
+
+          // FIXME: Does not work for multiple interfaces
+          route->SetOutputDevice (m_ipv4->GetNetDevice (1));
+          route->SetDestination (header.GetDestination ());
+          NS_ASSERT (route != 0);
+          NS_LOG_DEBUG ("Exist route to " << route->GetDestination () << " from interface " << route->GetOutputDevice ());
+
+
+          NS_LOG_LOGIC (route->GetOutputDevice () << " forwarding to " << dst << " from " << origin << " through " << route->GetGateway () << " packet " << p->GetUid ());
+
+          ucb (route, p, header);
+          return true;
+        }
+//    }
+  if (!hasGpsrHeader)
+    {
+      // Greedy failed and there is no position header to carry recovery
+      // state (non-UDP packet): nothing GPSR can do — report no route.
+      NS_LOG_LOGIC ("Greedy failed for headerless packet to " << dst << ". Drop");
+      return false;
+    }
+  hdr.SetInRec(1);
+  hdr.SetRecPosx (myPos.x);
+  hdr.SetRecPosy (myPos.y);
+  hdr.SetLastPosx (Position.x); //when entering Recovery, the first edge is the Dst
+  hdr.SetLastPosy (Position.y);
+
+
+  p->AddHeader (hdr);
+  p->AddHeader (tHeader);
+  RestoreTransport (p, udpHeader, hasUdp);
+  NS_LOG_LOGIC ("Entering recovery-mode to " << dst << " in " << m_ipv4->GetAddress (1, 0).GetLocal ());
+
+  RecoveryMode (dst, p, ucb, header);
+  return true;
+}
+
+
+
+void
+RoutingProtocol::SetDownTarget (IpL4Protocol::DownTargetCallback callback)
+{
+  m_downTarget = callback;
+}
+
+
+IpL4Protocol::DownTargetCallback
+RoutingProtocol::GetDownTarget (void) const
+{
+  return m_downTarget;
+}
+
+
+
+
+Ptr<Ipv4Route>
+RoutingProtocol::RouteOutput (Ptr<Packet> p, const Ipv4Header &header,
+                              Ptr<NetDevice> oif, Socket::SocketErrno &sockerr)
+{
+  NS_LOG_FUNCTION (this << header << (oif ? oif->GetIfIndex () : 0));
+
+  if (!p)
+    {
+      return LoopbackRoute (header, oif);     // later
+    }
+  if (m_socketAddresses.empty ())
+    {
+      sockerr = Socket::ERROR_NOROUTETOHOST;
+      NS_LOG_LOGIC ("No gpsr interfaces");
+      Ptr<Ipv4Route> route;
+      return route;
+    }
+  sockerr = Socket::ERROR_NOTERROR;
+  Ptr<Ipv4Route> route = Create<Ipv4Route> ();
+  Ipv4Address dst = header.GetDestination ();
+
+  Vector dstPos = Vector (1, 0, 0);
+
+  if (!(dst == m_ipv4->GetAddress (1, 0).GetBroadcast ()))
+    {
+      dstPos = GetGodPosition (dst);
+    }
+
+  // GOD location service (port change): the vendored defer-while-in-search
+  // branch collapses — a position lookup never pends, so deferral happens
+  // only through the no-greedy-neighbour path below.
+
+  Vector myPos;
+  Ptr<MobilityModel> MM = m_ipv4->GetObject<MobilityModel> ();
+  myPos.x = MM->GetPosition ().x;
+  myPos.y = MM->GetPosition ().y;
+
+
+  Ipv4Address nextHop;
+
+  if(m_neighbors.isNeighbour (dst))
+    {
+      nextHop = dst;
+    }
+  else
+    {
+      nextHop = m_neighbors.BestNeighbor (dstPos, myPos);
+    }
+
+
+  if (nextHop != Ipv4Address::GetZero ())
+    {
+      NS_LOG_DEBUG ("Destination: " << dst);
+
+      route->SetDestination (dst);
+      if (header.GetSource () == Ipv4Address ("102.102.102.102"))
+        {
+          route->SetSource (m_ipv4->GetAddress (1, 0).GetLocal ());
+        }
+      else
+        {
+          route->SetSource (header.GetSource ());
+        }
+      route->SetGateway (nextHop);
+      route->SetOutputDevice (m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (route->GetSource ())));
+      route->SetDestination (header.GetDestination ());
+      NS_ASSERT (route != 0);
+      NS_LOG_DEBUG ("Exist route to " << route->GetDestination () << " from interface " << route->GetSource ());
+      if (oif != 0 && route->GetOutputDevice () != oif)
+        {
+          NS_LOG_DEBUG ("Output device doesn't match. Dropped.");
+          sockerr = Socket::ERROR_NOROUTETOHOST;
+          return Ptr<Ipv4Route> ();
+        }
+      return route;
+    }
+  else
+    {
+      DeferredRouteOutputTag tag;
+      if (!p->PeekPacketTag (tag))
+        {
+          p->AddPacketTag (tag);
+        }
+      return LoopbackRoute (header, oif);     //in RouteInput the recovery-mode is called
+    }
+
+}
+
+
+}
+}

--- a/ns3/gpsr/model/gpsr.h
+++ b/ns3/gpsr/model/gpsr.h
@@ -48,9 +48,13 @@
 // ns-3 renamed WifiMacQueueItem -> WifiMpdu (and wifi-mac-queue-item.h ->
 // wifi-mpdu.h) in ns-3.37; the WifiMac "DroppedMpdu" trace carries this type.
 // GPSR_NS3_WIFI_QUEUE_ITEM is defined by the module's CMakeLists for
-// ns-3 <= 3.36; default to the modern name. Same pattern as the anthocnet
-// module's ANTHOCNET_NS3_WIFI_QUEUE_ITEM gate.
-#ifdef GPSR_NS3_WIFI_QUEUE_ITEM
+// ns-3 <= 3.36 (same pattern as the anthocnet module's
+// ANTHOCNET_NS3_WIFI_QUEUE_ITEM gate) — but that definition is
+// directory-scoped, so translation units OUTSIDE contrib/gpsr that include
+// this header (e.g. contrib/anthocnet's anthocnet-compare example) never see
+// it. Fall back to probing for the modern header itself: gpsr links wifi, so
+// ns3/wifi-mpdu.h is present exactly on ns-3.37+.
+#if defined(GPSR_NS3_WIFI_QUEUE_ITEM) || !__has_include("ns3/wifi-mpdu.h")
 #include "ns3/wifi-mac-queue-item.h"
 #define GPSR_WIFI_MPDU ns3::WifiMacQueueItem
 #else
@@ -61,8 +65,10 @@
 // ns-3 changed Ipv4RoutingProtocol::RouteInput's forwarding-callback parameters
 // from by-value (<= ns-3.36) to const-reference (ns-3.37+). The override must
 // match exactly or the class stays abstract. GPSR_NS3_ROUTEINPUT_BYVALUE is
-// defined by the module's CMakeLists for ns-3 <= 3.36; default to const-ref.
-#ifdef GPSR_NS3_ROUTEINPUT_BYVALUE
+// defined by the module's CMakeLists for ns-3 <= 3.36; like the gate above it
+// is directory-scoped, so out-of-module includers fall back to the same
+// ns3/wifi-mpdu.h probe — both APIs changed in the same release (ns-3.37).
+#if defined(GPSR_NS3_ROUTEINPUT_BYVALUE) || !__has_include("ns3/wifi-mpdu.h")
 #define GPSR_RI_CB(T) T
 #else
 #define GPSR_RI_CB(T) const T&

--- a/ns3/gpsr/model/gpsr.h
+++ b/ns3/gpsr/model/gpsr.h
@@ -1,0 +1,230 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2011 António Fonseca <afonseca@tagus.inesc-id.pt> (original ns-3 GPSR port)
+// Copyright (C) 2026 Daniel Henrique Joppi (ns-3.36–3.48 port for AntHocNet #296)
+/*
+ * GPSR (Greedy Perimeter Stateless Routing, Karp & Kung, MobiCom 2000).
+ *
+ * Vendored baseline for the AntHocNet comparison harness (#296 item 3) from
+ * https://github.com/dwosion/ns3.29-with-gpsr
+ * commit 15241ef715d52627ff7679a5fca6b6d15eaa8cd4, path ns-3.29/src/gpsr —
+ * the Fonseca GPSR lineage (https://codereview.appspot.com/5401042), GPLv2.
+ * Full provenance and the list of port changes: ns3/gpsr/README.md.
+ *
+ * Port changes in this file:
+ *  - inlined the GOD location service (NodeList + MobilityModel scan) so the
+ *    separate location-service module is not vendored; the LocationServiceName
+ *    attribute (GOD was the only implemented value) is gone with it;
+ *  - AssignStreams() added (#352 stream pinning);
+ *  - NotifyTxError() added: the removed WifiMac "TxErrHeader" trace is
+ *    replaced by the modern "DroppedMpdu" MAC-failure path;
+ *  - the down-target position-header hack now keeps the UDP header on top of
+ *    the IP payload (IP|UDP|GPSR instead of IP|GPSR|UDP) so FlowMonitor's
+ *    Ipv4FlowClassifier reads real ports — see AddHeaders in gpsr.cc.
+ */
+#ifndef GPSR_H
+#define GPSR_H
+
+#include "gpsr-ptable.h"
+#include "ns3/node.h"
+#include "gpsr-packet.h"
+#include "ns3/ipv4-routing-protocol.h"
+#include "ns3/ipv4-interface.h"
+#include "ns3/ipv4-l3-protocol.h"
+#include "ns3/ip-l4-protocol.h"
+#include "ns3/mobility-model.h"
+#include "gpsr-rqueue.h"
+
+#include "ns3/ipv4-header.h"
+#include "ns3/ipv4-address.h"
+#include "ns3/ipv4-route.h"
+#include "ns3/udp-header.h"
+#include "ns3/random-variable-stream.h"
+#include "ns3/wifi-mac.h"
+
+#include <map>
+#include <complex>
+
+// ns-3 renamed WifiMacQueueItem -> WifiMpdu (and wifi-mac-queue-item.h ->
+// wifi-mpdu.h) in ns-3.37; the WifiMac "DroppedMpdu" trace carries this type.
+// GPSR_NS3_WIFI_QUEUE_ITEM is defined by the module's CMakeLists for
+// ns-3 <= 3.36; default to the modern name. Same pattern as the anthocnet
+// module's ANTHOCNET_NS3_WIFI_QUEUE_ITEM gate.
+#ifdef GPSR_NS3_WIFI_QUEUE_ITEM
+#include "ns3/wifi-mac-queue-item.h"
+#define GPSR_WIFI_MPDU ns3::WifiMacQueueItem
+#else
+#include "ns3/wifi-mpdu.h"
+#define GPSR_WIFI_MPDU ns3::WifiMpdu
+#endif
+
+// ns-3 changed Ipv4RoutingProtocol::RouteInput's forwarding-callback parameters
+// from by-value (<= ns-3.36) to const-reference (ns-3.37+). The override must
+// match exactly or the class stays abstract. GPSR_NS3_ROUTEINPUT_BYVALUE is
+// defined by the module's CMakeLists for ns-3 <= 3.36; default to const-ref.
+#ifdef GPSR_NS3_ROUTEINPUT_BYVALUE
+#define GPSR_RI_CB(T) T
+#else
+#define GPSR_RI_CB(T) const T&
+#endif
+
+namespace ns3 {
+namespace gpsr {
+/**
+ * \ingroup gpsr
+ *
+ * \brief GPSR routing protocol
+ */
+class RoutingProtocol : public Ipv4RoutingProtocol
+{
+public:
+  static TypeId GetTypeId (void);
+  static const uint32_t GPSR_PORT;
+
+  /// c-tor
+  RoutingProtocol ();
+  virtual ~RoutingProtocol ();
+  virtual void DoDispose ();
+
+
+  ///\name From Ipv4RoutingProtocol
+  //
+  //
+  Ptr<Ipv4Route> RouteOutput (Ptr<Packet> p, const Ipv4Header &header, Ptr<NetDevice> oif, Socket::SocketErrno &sockerr);
+  bool RouteInput (Ptr<const Packet> p, const Ipv4Header &header, Ptr<const NetDevice> idev,
+                   GPSR_RI_CB (UnicastForwardCallback) ucb, GPSR_RI_CB (MulticastForwardCallback) mcb,
+                   GPSR_RI_CB (LocalDeliverCallback) lcb, GPSR_RI_CB (ErrorCallback) ecb);
+  virtual void NotifyInterfaceUp (uint32_t interface);
+  int GetProtocolNumber (void) const;
+  virtual void AddHeaders (Ptr<Packet> p, Ipv4Address source, Ipv4Address destination, uint8_t protocol, Ptr<Ipv4Route> route);
+  virtual void NotifyInterfaceDown (uint32_t interface);
+  virtual void NotifyAddAddress (uint32_t interface, Ipv4InterfaceAddress address);
+  virtual void NotifyRemoveAddress (uint32_t interface, Ipv4InterfaceAddress address);
+  virtual void SetIpv4 (Ptr<Ipv4> ipv4);
+  virtual void RecvGPSR (Ptr<Socket> socket);
+  virtual void UpdateRouteToNeighbor (Ipv4Address sender, Ipv4Address receiver, Vector Pos);
+  virtual void SendHello ();
+  virtual bool IsMyOwnAddress (Ipv4Address src);
+
+  Ptr<Ipv4> m_ipv4;
+  /// Raw socket per each IP interface, map socket -> iface address (IP + mask)
+  std::map< Ptr<Socket>, Ipv4InterfaceAddress > m_socketAddresses;
+  /// Loopback device used to defer RREQ until packet will be fully formed
+  Ptr<NetDevice> m_lo;
+
+  /// Broadcast ID
+  uint32_t m_requestId;
+  /// Request sequence number
+  uint32_t m_seqNo;
+
+
+
+  /// Number of RREQs used for RREQ rate control
+  uint16_t m_rreqCount;
+  Time HelloInterval;
+
+  void SetDownTarget (IpL4Protocol::DownTargetCallback callback);
+  IpL4Protocol::DownTargetCallback GetDownTarget (void) const;
+
+  /**
+   * #352 stream pinning (port addition): fix the stream numbers of this
+   * protocol's random variables (the hello jitter) so a run's realisation is
+   * a function of the seed alone. Mirrors aodv/olsr::RoutingProtocol.
+   * \return the number of stream indices assigned (1)
+   */
+  int64_t AssignStreams (int64_t stream);
+
+  virtual void PrintRoutingTable (ns3::Ptr<ns3::OutputStreamWrapper>, Time::Unit unit = Time::S) const
+  {
+    return;
+  }
+
+private:
+  /// Start protocol operation
+  void Start ();
+  /// Queue packet and send route request
+  void DeferredRouteOutput (Ptr<const Packet> p, const Ipv4Header & header, UnicastForwardCallback ucb, ErrorCallback ecb);
+  /// If route exists and valid, forward packet.
+  void HelloTimerExpire ();
+
+  /// Queue packet and send route request
+  Ptr<Ipv4Route> LoopbackRoute (const Ipv4Header & header, Ptr<NetDevice> oif);
+
+  /// If route exists and valid, forward packet.
+  bool Forwarding (Ptr<const Packet> p, const Ipv4Header & header, UnicastForwardCallback ucb, ErrorCallback ecb);
+
+  /// Find socket with local interface address iface
+  Ptr<Socket> FindSocketWithInterfaceAddress (Ipv4InterfaceAddress iface) const;
+
+  //Check packet from deffered route output queue and send if position is already available
+//returns true if the IP should be erased from the list (was sent/droped)
+  bool SendPacketFromQueue (Ipv4Address dst);
+
+  //Calls SendPacketFromQueue and re-schedules
+  void CheckQueue ();
+
+  void RecoveryMode(Ipv4Address dst, Ptr<Packet> p, UnicastForwardCallback ucb, Ipv4Header header);
+
+  /**
+   * GOD location service, inlined (port change): every node reads any node's
+   * true position straight from its MobilityModel via the NodeList — exactly
+   * what the vendored tree's separate location-service module did, without
+   * carrying that module. Returns (-1,-1,0) for an unknown address.
+   */
+  Vector GetGodPosition (Ipv4Address adr) const;
+
+  /**
+   * Fault-3 rework helpers (port addition). GPSR carries a per-packet
+   * position header on data packets. The vendored code injected it *above*
+   * the transport header (wire: IP|GPSR|UDP) via the re-pointed UDP down
+   * target, which breaks FlowMonitor: Ipv4FlowClassifier reads the first four
+   * bytes of the IP payload as ports, so every data packet classified on
+   * position bytes that change as nodes move. The port keeps the same bytes
+   * on the wire but layers them IP|UDP|GPSR: StripTransport removes the UDP
+   * header when the IP protocol is UDP (the only transport the down-target
+   * hook wraps), the GPSR headers are edited beneath it, and RestoreTransport
+   * puts the same UDP header back (ns-3's UdpHeader recomputes its length
+   * field from the buffer at serialize time). Requires the default
+   * ChecksumEnabled=false (re-adding does not refresh a stored checksum).
+   * \return true iff the UDP header was removed (protocol was UDP and the
+   *         packet was long enough)
+   */
+  bool StripTransport (Ptr<Packet> p, uint8_t protocol, UdpHeader &udp) const;
+  void RestoreTransport (Ptr<Packet> p, const UdpHeader &udp, bool stripped) const;
+
+  /**
+   * Fault-1 rework (port addition): the vendored code subscribed
+   * PositionTable's callback to the WifiMac "TxErrHeader" trace, which ns-3
+   * removed; the handler body was an empty stub besides. This is the modern
+   * "DroppedMpdu" MAC-failure path: a unicast frame dropped for
+   * WIFI_MAC_DROP_REACHED_RETRY_LIMIT names a dead neighbour, which is
+   * resolved MAC->IP through the ARP caches (forward Lookup per known
+   * neighbour — ArpCache::LookupInverse's signature drifts across ns-3
+   * versions) and removed from the position table, per GPSR §3.2 (Karp &
+   * Kung 2000: MAC-layer feedback removes unreachable neighbours).
+   */
+  void NotifyTxError (WifiMacDropReason reason, Ptr<const GPSR_WIFI_MPDU> mpdu);
+
+  uint32_t MaxQueueLen;                  ///< The maximum number of packets that we allow a routing protocol to buffer.
+  Time MaxQueueTime;                     ///< The maximum period of time that a routing protocol is allowed to buffer a packet for.
+  RequestQueue m_queue;
+
+  Timer HelloIntervalTimer;
+  Timer CheckQueueTimer;
+  PositionTable m_neighbors;
+  bool PerimeterMode;
+  std::list<Ipv4Address> m_queuedAddresses;
+
+  /// #352 (port addition): one pinnable RNG for the hello jitter instead of
+  /// the vendored per-call UniformRandomVariable constructions, whose stream
+  /// numbers depended on how many draws preceded them in the process.
+  Ptr<UniformRandomVariable> m_uniformRandomVariable;
+
+  IpL4Protocol::DownTargetCallback m_downTarget;
+
+
+
+};
+}
+}
+#endif /* GPSRROUTINGPROTOCOL_H */


### PR DESCRIPTION
## What

#296 item 3, built to the spike verdict recorded on the issue: vendor the [dwosion ns-3.29 GPSR tree](https://github.com/dwosion/ns3.29-with-gpsr) (`15241ef`, the Fonseca 2011–12 lineage) as a self-contained contrib module `ns3/gpsr/`, port it to the CI matrix (ns-3.36/3.41/3.42/3.47/3.48), fix the three faults the spike named, and wire a `gpsr` arm into `anthocnet-compare`. **No numbers are produced here** — running the arm is phase 3 of the [v1.5.0 campaign](../blob/main/docs/benchmarks/v1.5.0-campaign.md).

## License / provenance (the part that made PA-GPSR unusable)

- Vendored tree is GPLv2: distributed inside a stock ns-3.29 tree (GPL v2 `LICENSE`), helper files carry explicit GPLv2 headers (Copyright 2009 IITP RAS, Fonseca/Boyko), headerless model files visibly derive from ns-3's GPLv2 `src/aodv`. Compatible with this repo's `GPL-2.0-only`.
- [PA-GPSR](https://github.com/CSVNetLab/PA-GPSR) publishes **no license** and was not copied from — not one line. Where a fix overlaps something PA-GPSR also fixed, it is re-derived and marked in place.
- Not vendored: the separate location-service module (its GOD service is inlined as `RoutingProtocol::GetGodPosition` — a NodeList + MobilityModel scan), the seven test examples, template doc, stub test suite. Full per-file notes: `ns3/gpsr/README.md`.

## The three spike faults, fixed

1. **`TxErrHeader` → `DroppedMpdu`**: the vendored code subscribed to a removed WifiMac trace with an empty-stub handler — GPSR's §3.2 MAC-feedback neighbour removal never fired. Now a tolerant connect to `DroppedMpdu` (same pattern as the anthocnet adapter's detector D): retry-limit drops resolve MAC→IP via forward `ArpCache::Lookup` and evict the dead neighbour from the position table. Implemented from the paper + the in-repo pattern, not from PA-GPSR.
2. **`AssignStreams`**: hello jitter came from per-call-constructed `UniformRandomVariable`s — the #352 determinism failure class. One member RNG, wired into the harness's stream-assignment walk.
3. **Version drift**: the usual matrix seams (Socket API, `WifiMac` accessors, CMake) behind the same `NS3_VER_*` guards the anthocnet adapter uses.

## Harness wiring

`anthocnet-compare --protocols=...,gpsr` — new arm, off by default; existing four-protocol runs and their RNG streams are untouched (baselines stay byte-identical, per the standing determinism gate). `scenario-matrix.yml` protocol list gains the arm; `docs/benchmarks/methodology.md` and `docs/cross-validation.md` note it as unmeasured until phase 3.

## Verification

- CI's five-version matrix is the port's first full compile gate.
- Determinism/anchor gates must stay green — the arm adds code but no default-on behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_