### PR TITLE
feat(bench): vendor aomdv baseline port for the oracle-phase comparison (#296) — builds, does not yet route

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd /opt/ns-3
           ./ns3 configure --enable-examples \
-            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;aomdv;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           ./ns3 build
       - name: Install matplotlib
         run: apt-get update && apt-get install -y python3-matplotlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
           # (their cross-module deps drift by release). The filter flag scopes
           # that to our module; it was added after ns-3.36, so older trees just
           # build + smoke.
-          mods='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+          mods='anthocnet;aomdv;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           if ./ns3 configure --help 2>/dev/null | grep -q filter-module-examples-and-tests; then
             ./ns3 configure --enable-tests --enable-examples \
               --filter-module-examples-and-tests=anthocnet \
@@ -442,7 +442,7 @@ jobs:
           # static-initializer allocations (see the file header for how to
           # extend it). $GITHUB_WORKSPACE is the in-container checkout path.
           echo "LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/ns3/tools/lsan.supp" >> "$GITHUB_ENV"
-          mods='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+          mods='anthocnet;aomdv;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           # ns-3's CMake build has first-class sanitizer support (NS3_SANITIZE),
           # exposed by the ./ns3 wrapper as --enable-sanitizers
           # (address + leak + undefined). Prefer it when the wrapper advertises

--- a/.github/workflows/paper-benchmark.yml
+++ b/.github/workflows/paper-benchmark.yml
@@ -112,7 +112,7 @@ jobs:
           cd /opt/ns-3
           # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
           ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
-            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;aomdv;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
       - name: Build
         # `show profile` is recorded in the log so a run's ##PERF## wall-clock
         # (#131) is always attributable to a build profile after the fact.

--- a/.github/workflows/satellite-benchmark.yml
+++ b/.github/workflows/satellite-benchmark.yml
@@ -97,7 +97,7 @@ jobs:
           cd /opt/ns-3
           # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
           ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
-            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;aomdv;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
       - name: Build
         run: cd /opt/ns-3 && ./ns3 build && ./ns3 show profile
       - name: Run isl-grid scenario

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -107,7 +107,7 @@ jobs:
           cd /opt/ns-3
           # $NS3_PROFILE_FLAG unquoted on purpose: empty must expand to nothing.
           ./ns3 configure $NS3_PROFILE_FLAG --enable-examples \
-            --enable-modules='anthocnet;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
+            --enable-modules='anthocnet;aomdv;gpsr;wifi;mobility;applications;csma;aodv;olsr;dsdv;flow-monitor;point-to-point'
           ./ns3 build
           # Recorded in the log so every campaign run is attributable to a
           # profile after the fact (a run's cost is meaningless without it).

--- a/ns3/Makefile
+++ b/ns3/Makefile
@@ -17,6 +17,9 @@ DEST    = $(NS3DIR)/contrib/anthocnet
 # (provenance: gpsr/README.md). Installed alongside so the comparison
 # harness's gpsr arm builds; the anthocnet module itself does not depend on it.
 GPSRDEST = $(NS3DIR)/contrib/gpsr
+# Vendored AOMDV baseline module (#296) — installed alongside anthocnet so the
+# comparison harness can link it. See aomdv/README.md for provenance.
+AOMDV_DEST = $(NS3DIR)/contrib/aomdv
 
 .PHONY: install uninstall require-ns3dir
 
@@ -46,6 +49,12 @@ install: require-ns3dir
 	cp $(HERE)/gpsr/model/*.h  $(HERE)/gpsr/model/*.cc  "$(GPSRDEST)/model/"
 	cp $(HERE)/gpsr/helper/*.h $(HERE)/gpsr/helper/*.cc "$(GPSRDEST)/helper/"
 	cp $(HERE)/gpsr/CMakeLists.txt "$(GPSRDEST)/"
+	@echo ">> Installing AOMDV baseline module into $(AOMDV_DEST)"
+	mkdir -p "$(AOMDV_DEST)/model" "$(AOMDV_DEST)/helper" "$(AOMDV_DEST)/test"
+	cp $(HERE)/aomdv/model/*.h  $(HERE)/aomdv/model/*.cc  "$(AOMDV_DEST)/model/"
+	cp $(HERE)/aomdv/helper/*.h $(HERE)/aomdv/helper/*.cc "$(AOMDV_DEST)/helper/"
+	cp $(HERE)/aomdv/test/*.cc "$(AOMDV_DEST)/test/"
+	cp $(HERE)/aomdv/CMakeLists.txt $(HERE)/aomdv/README.md "$(AOMDV_DEST)/"
 	@echo ""
 	@echo ">> Done. Reconfigure and build ns-3:"
 	@echo "     cd $(NS3DIR) && ./ns3 configure --enable-examples --enable-tests && ./ns3 build"
@@ -57,4 +66,6 @@ uninstall: require-ns3dir
 	rm -rf "$(DEST)"
 	@echo ">> Removing $(GPSRDEST)"
 	rm -rf "$(GPSRDEST)"
+	@echo ">> Removing $(AOMDV_DEST)"
+	rm -rf "$(AOMDV_DEST)"
 	@echo ">> Done. Reconfigure/build ns-3 to drop the modules."

--- a/ns3/README.md
+++ b/ns3/README.md
@@ -49,9 +49,9 @@ and **normalized routing load** (NRL = routing-control packets transmitted /
 data packets delivered, counted uniformly at the IP layer):
 
 ```bash
-# requires aodv, olsr, dsdv, gpsr (the vendored #296 baseline) and flow-monitor enabled
+# requires aodv, aomdv, olsr, dsdv, gpsr (the vendored #296 baselines) and flow-monitor enabled
 ./ns3 configure --enable-examples \
-  --enable-modules='anthocnet;gpsr;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
+  --enable-modules='anthocnet;aomdv;gpsr;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
 ./ns3 build
 
 # the paper's base scenario (50 nodes, 1500x300 m, RWP 20 m/s / 30 s pause,
@@ -161,11 +161,14 @@ ns3/
     anthocnet-adapters.{h,cc}          IClock/IRng ports over Simulator/RNG
   helper/anthocnet-helper.{h,cc}       Ipv4RoutingHelper
   examples/anthocnet-example.cc        minimal wifi adhoc demo
-  examples/anthocnet-compare.cc        vs AODV/OLSR/DSDV (FlowMonitor metrics)
+  examples/anthocnet-compare.cc        vs AODV/AOMDV/OLSR/DSDV (FlowMonitor metrics;
+                                       aomdv is opt-in via --protocols, #296)
   examples/isl-grid.cc                 +Grid torus of point-to-point ISLs (#214)
   test/anthocnet-test-suite.cc         header round-trip + multi-hop delivery
   CMakeLists.txt                       ns-3.36+ build
   wscript                              ns-3 < 3.36 build
+  aomdv/                               vendored AOMDV baseline module (#296;
+                                       provenance + license in aomdv/README.md)
 ```
 
 ## Notes

--- a/ns3/aomdv/CMakeLists.txt
+++ b/ns3/aomdv/CMakeLists.txt
@@ -1,0 +1,56 @@
+# AOMDV baseline ns-3 module (ns-3.36+ CMake build) — vendored for #296.
+#
+# Installed into $(NS3DIR)/contrib/aomdv by `make install-ns3`, alongside the
+# anthocnet module. Provenance: stock ns-3.36 src/aodv rebased with the AOMDV
+# delta from CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+# (GPLv2) — see README.md in this directory.
+#
+# Adapt to ns-3 API drift by release, mirroring the anthocnet module's
+# CMakeLists (same NS3_VER regex, same two pre-3.37 gates, same scoped-test-enum
+# gate). NS3_VER is set by ns-3 (e.g. "3.41"); anything non-numeric (e.g.
+# "3-dev") falls through to the modern defaults.
+#  - RouteInput callbacks went from by-value to const-reference in ns-3.37.
+#  - WifiMacQueueItem was renamed to WifiMpdu (header wifi-mac-queue-item.h ->
+#    wifi-mpdu.h) in ns-3.37; the WifiMac "DroppedMpdu" trace carries this type.
+#  - TestSuite/TestCase enums became scoped (enum class) in ns-3.42, and the
+#    deprecated unscoped aliases were removed in ns-3.47.
+if(NS3_VER MATCHES "^3\\.([0-9]+)")
+  if(CMAKE_MATCH_1 LESS 37)
+    add_compile_definitions(AOMDV_NS3_ROUTEINPUT_BYVALUE)
+    add_compile_definitions(AOMDV_NS3_WIFI_QUEUE_ITEM)
+  endif()
+  if(CMAKE_MATCH_1 GREATER_EQUAL 42)
+    add_compile_definitions(AOMDV_NS3_SCOPED_TEST_ENUMS)
+  endif()
+else()
+  add_compile_definitions(AOMDV_NS3_SCOPED_TEST_ENUMS)
+endif()
+
+build_lib(
+  LIBNAME aomdv
+  SOURCE_FILES
+    model/aomdv-id-cache.cc
+    model/aomdv-dpd.cc
+    model/aomdv-rtable.cc
+    model/aomdv-rqueue.cc
+    model/aomdv-packet.cc
+    model/aomdv-neighbor.cc
+    model/aomdv-routing-protocol.cc
+    helper/aomdv-helper.cc
+  HEADER_FILES
+    model/aomdv-id-cache.h
+    model/aomdv-dpd.h
+    model/aomdv-rtable.h
+    model/aomdv-rqueue.h
+    model/aomdv-packet.h
+    model/aomdv-neighbor.h
+    model/aomdv-routing-protocol.h
+    helper/aomdv-helper.h
+  LIBRARIES_TO_LINK
+    ${libinternet}
+    # wifi: the model subscribes to the WifiMac "DroppedMpdu" trace for MAC
+    # transmit-failure detection (inherited from the stock ns-3.36 aodv base).
+    ${libwifi}
+  TEST_SOURCES
+    test/aomdv-id-cache-test-suite.cc
+)

--- a/ns3/aomdv/README.md
+++ b/ns3/aomdv/README.md
@@ -1,0 +1,169 @@
+# AOMDV baseline module — provenance and license
+
+Vendored multipath on-demand baseline for the [#296](https://github.com/danieljoppi/AntHocNet/issues/296)
+oracle-phase comparison (epic item 2). This module is a **baseline for the
+benchmark harness only** — it is not part of the AntHocNet protocol, carries no
+AntHocNet measurement hooks, and follows the layout/build conventions of the
+`anthocnet` contrib module next door.
+
+## Construction (write-minimal port, per the #296 spike verdict)
+
+The port is **stock ns-3.36 `src/aodv` rebased with the AOMDV delta** from the
+CharithaS fork, exactly as the
+[feasibility spike](https://github.com/danieljoppi/AntHocNet/issues/296#issuecomment-5245550798)
+prescribed:
+
+- **Base**: `src/aodv` at tag `ns-3.36` of
+  https://github.com/nsnam/ns-3-dev-git (GPLv2, Copyright IITP RAS 2009).
+- **AOMDV delta**: `src/aomdv` of
+  https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+  at commit `54594e24daf7688bdcdb6a696bf821a08fd2d06a` (2017-06-17, the fork's
+  HEAD; an ns-3.26 tree). The delta was computed as (stock ns-3.26 aodv → fork
+  aomdv) after normalising the mechanical `aodv→aomdv` rename, then re-applied
+  onto stock ns-3.36 aodv by three-way merge (~1,540 changed delta lines,
+  concentrated in `routing-protocol` and `rtable` — matching the spike's
+  measured ~1,250-line estimate).
+- **Helper and id-cache test**: stock ns-3.36 `aodv-helper` /
+  `aodv-id-cache-test-suite` mechanically renamed (the fork ships neither).
+  `AomdvHelper::AssignStreams` and `aomdv::RoutingProtocol::AssignStreams` are
+  inherited from the stock base, so the harness's #352 RNG stream pinning works
+  on this arm like on stock aodv.
+
+## License verdict
+
+**GPLv2 throughout — compatible with ns-3 (GPLv2) and this vendoring.**
+Evidence:
+
+- The CharithaS repository is a full ns-3.26 tree carrying ns-3's root
+  `LICENSE` (GNU GPL v2).
+- Every `src/aomdv` source file carries the GPLv2 header of its stock aodv
+  parent (Copyright 2009 IITP RAS; authors Buchatskaia/Boyko), with the model
+  provenance lines: NS-2 AOMDV by the CMU/MONARCH group, tuned by Samir Das and
+  Mahesh Marina (University of Cincinnati); AOMDV-UU by Erik Nordström
+  (Uppsala University).
+- The stock ns-3.36 aodv base is GPLv2 (same headers).
+
+All original copyright headers are preserved in the vendored files.
+
+## What was changed relative to the fork (and why)
+
+- **`TxErrHeader` → `DroppedMpdu`**: the fork's ns-3.26 MAC-failure hook used
+  the removed `TxErrHeader` trace; the rebase inherits stock ns-3.36's
+  `DroppedMpdu` + `WifiMacQueueItem` path for free (the spike's known API fix).
+- **Cross-version gates** for the CI matrix (ns-3.36/3.41/3.42/3.47/3.48),
+  mirroring the anthocnet module's macros: `AOMDV_NS3_ROUTEINPUT_BYVALUE`
+  (RouteInput callbacks by-value ≤3.36, const-ref 3.37+),
+  `AOMDV_NS3_WIFI_QUEUE_ITEM` (`WifiMacQueueItem`→`WifiMpdu` rename in 3.37),
+  `AOMDV_NS3_SCOPED_TEST_ENUMS` (scoped TestSuite/TestCase enums 3.42+).
+- **3.36-base behaviours kept over fork regressions**: the fork (being
+  3.26-based) predates several stock aodv fixes; the rebase keeps the 3.36 side
+  wherever the fork's difference was not AOMDV semantics — notably the
+  `(IsAlive() || IsPermanent())` ARP-entry check in `aomdv-neighbor.cc`, the
+  socket bind order in `NotifyInterfaceUp`, and the AODV-port broadcast
+  short-circuit in `RouteInput`.
+- **Two trivial leak fixes** in `aomdv-id-cache.cc` (`new AOMDVRoute` +
+  `push_back(*route)` → value `push_back`), behaviour-identical.
+- **Nine fork defects fixed** (the fork is a 2017 course assignment,
+  single squashed commit, no example or validation; these made it structurally
+  unable to route — the value-semantics port lost ns-2's pointer-aliased
+  routing table, the same defect class as CONTEXT.md §6 items 1–2):
+  1. `RoutingTableEntry`'s constructor accepted `dst` but never stored it —
+     `m_dst` stayed default-initialized, breaking the destination-keyed table
+     and every path's `Ipv4Route` destination. Fixed with `m_dst (dst)` in the
+     init list (`aomdv-rtable.cc`).
+  2. Paths were inserted into **local copies** after `AddRoute`/`Update`/
+     `LookupRoute` (which copy), so no table entry ever carried a path and
+     `PathFind()` dereferenced `begin()` of an empty vector (UB). Fixed
+     mechanically at each site — `PathInsert` before `AddRoute` for fresh
+     entries, one `m_routingTable.Update (…)` after each mutated looked-up
+     copy (`RecvRequest`/`RecvReply`) — every site carries a
+     `// Vendoring fix (#296)` comment; no routing logic was changed.
+  3. `UpdateRouteToNeighbor` read an uninitialized `bool validPath` when the
+     neighbor entry had no matching path; now initialized to `false`.
+  4. `PathInsert` returned `&path` — the address of the function-local copy,
+     dead on return — so every caller that kept the pointer
+     (`RecvRequest`/`RecvReply`) wrote through a dangling stack address. GCC
+     proves it (`-Wreturn-local-addr`) and the matrix's ASan leg would report
+     stack-use-after-return. Now returns `&m_pathList.back ()`, the element
+     actually stored (`aomdv-rtable.cc`), which is what ns-2 AOMDV returned.
+  5. `RecvReply`'s same-sequence-number branch wrote
+     `if (forwardPath == toDst.PathLookupDisjoint (…))` where its own sibling
+     in `RecvRequest` — and ns-2 AOMDV — assigns. `forwardPath` is still
+     `NULL` at that point, so the branch was entered exactly when the lookup
+     found *nothing* and then dereferenced `NULL` (GCC proves it:
+     `-Wnonnull`), and did nothing at all when a disjoint path did exist.
+     Restored to the assignment form.
+  6. `SendRequest`'s fresh-entry branch never set the hop count. Stock aodv
+     passes `/*hop=*/ ttl` to the `RoutingTableEntry` ctor; the fork's AOMDV
+     ctor has no hop parameter, so `m_lastHopCount` kept its `INFINITY2`
+     default, the expanding-ring search read that back as "already at
+     NetDiameter", and `ScheduleRreqRetry` tripped stock's
+     `NS_ABORT_MSG_UNLESS (rt.GetRreqCnt () > 0)` on the *first* route
+     discovery. Now `SetLastHopCount (ttl)`, mirroring the existing-entry
+     branch alongside it.
+  7. Sockets were configured with `SetAttribute ("IpTtl", UintegerValue (1))`
+     (an ns-3.26-era artefact) where stock ns-3.36 aodv calls
+     `SetIpRecvTtl (true)` — 5 sites. With `IpTtl` set, `UdpSocketImpl` adds
+     its *own* `SocketIpTtlTag` to a packet that `SendRequest` had already
+     tagged, tripping "cannot add the same kind of tag twice". Restored to the
+     3.36 base's call, per the "keep the 3.36 side where the fork's difference
+     is not AOMDV semantics" rule above.
+  8. `PathFind ()` dereferenced `begin ()` unconditionally, so on a pathless
+     entry it returned `&*end ()` — UB, and in practice a null `Path*` that the
+     ~30 `PathFind ()->` call sites dereferenced. ns-2 AOMDV's `path_find ()`
+     returns `NULL` on an empty list; restored. The one site that legitimately
+     meets a pathless entry — `RecvRequest`'s RREP-loop drop, which looks up a
+     destination that may only have `SendRequest`'s pathless `IN_SEARCH`
+     placeholder — is now guarded (no path means no next hop, so there is no
+     loop to drop; stock aodv falls through there for the same reason).
+  9. `RecvRequest`'s fresh-reverse-route branch built the route in a local
+     `newEntry` and dropped it: `toOrigin`, which the rest of the function
+     reads (`SendReply`, the node-disjoint `SetFirstHop`), stayed
+     default-constructed and pathless. It now adopts the entry just stored and
+     re-points `reversePath` into `toOrigin`'s own path list — `reversePath`
+     pointed into `newEntry`, which dies at the end of that block. Same defect
+     class as items 2 and 4.
+- **Fork semantics kept as-is** (faithful port, not a rewrite): the RREP
+  forwarding path does not carry/decrement the `SocketIpTtlTag` (the fork
+  dropped stock's TTL bookkeeping there), node-disjoint path computation is the
+  compiled-in policy (`AOMDV_NODE_DISJOINT_PATHS`; the link-disjoint variant is
+  present but compiled out, as in the fork and AOMDV-UU), and the AOMDV bounds
+  (`AOMDV_MAX_PATHS 3`, `AOMDV_PRIM_ALT_PATH_LENGTH_DIFF 1`) are the fork's.
+- Wire format: RREQ grows a `firstHop` field (23→27 bytes), RREP grows
+  `requestID` + `firstHop` (19→27 bytes) — as in the fork; AOMDV RREQ/RREP are
+  therefore **not** interoperable with stock aodv's (they are different
+  protocols on the same UDP port 654).
+
+## Runtime status — the arm builds, it does not yet route multi-hop
+
+**This module is not ready to be measured.** Read this before scheduling the
+arm into a campaign.
+
+Verified locally (ns-3.48, `anthocnet-compare`, 25 nodes / 300 m / 4 flows /
+40 s / 5 m·s⁻¹, one run): the aomdv arm now *completes* a run — items 6–9 above
+were each found by running it, and each was a hard abort or segfault before the
+fix. But it delivers **PDR 0.0 %, with 86 % of drops attributed to "route"**
+(no route ever found), against **16 % PDR / 0.09 % route drops for stock `aodv`
+on the identical scenario**. On a trivial 5-node / 100 m field it does deliver
+(PDR 10 %, `hopsMean=1.00`), i.e. one-hop discovery works and **multi-hop
+discovery does not**.
+
+That remaining gap is protocol-level debugging of the fork, not port
+mechanics, and it is very likely the same root cause as items 2, 4 and 9: the
+fork's value-semantics translation of ns-2's *pointer-aliased* routing table
+means every `Path*` obtained from a `RoutingTableEntry` aliases whichever copy
+produced it, and a mutation is only durable if an `m_routingTable.Update ()`
+follows on the same copy. The sites fixed so far were the ones a run actually
+reached; the rest of the RREQ/RREP paths have not been audited for it. Until
+that audit happens, treat this arm as a build-matrix citizen only.
+
+- No benchmark numbers — measurement is phase 3 of the
+  [v1.5.0 campaign](../../docs/benchmarks/v1.5.0-campaign.md); acceptance is
+  directional agreement with Marina & Das 2001 (fewer route discoveries, lower
+  delay under mobility vs AODV), to be checked when the campaign measures it.
+- No attributes, traces or hooks beyond what the vendored delta needs; the
+  harness measures this arm exactly as it measures the stock baselines.
+- No regression/chain test port (only the id-cache unit test came along;
+  run it manually with `./test.py -s aomdv-routing-id-cache` on ns-3.42+ —
+  note CI's `--filter-module-examples-and-tests=anthocnet` deliberately skips
+  aomdv tests).

--- a/ns3/aomdv/helper/aomdv-helper.cc
+++ b/ns3/aomdv/helper/aomdv-helper.cc
@@ -1,0 +1,104 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Pavel Boyko <boyko@iitp.ru>, written after OlsrHelper by Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+#include "aomdv-helper.h"
+#include "ns3/aomdv-routing-protocol.h"
+#include "ns3/node-list.h"
+#include "ns3/names.h"
+#include "ns3/ptr.h"
+#include "ns3/ipv4-list-routing.h"
+
+namespace ns3
+{
+
+AomdvHelper::AomdvHelper() : 
+  Ipv4RoutingHelper ()
+{
+  m_agentFactory.SetTypeId ("ns3::aomdv::RoutingProtocol");
+}
+
+AomdvHelper* 
+AomdvHelper::Copy (void) const 
+{
+  return new AomdvHelper (*this); 
+}
+
+Ptr<Ipv4RoutingProtocol> 
+AomdvHelper::Create (Ptr<Node> node) const
+{
+  Ptr<aomdv::RoutingProtocol> agent = m_agentFactory.Create<aomdv::RoutingProtocol> ();
+  node->AggregateObject (agent);
+  return agent;
+}
+
+void 
+AomdvHelper::Set (std::string name, const AttributeValue &value)
+{
+  m_agentFactory.Set (name, value);
+}
+
+int64_t
+AomdvHelper::AssignStreams (NodeContainer c, int64_t stream)
+{
+  int64_t currentStream = stream;
+  Ptr<Node> node;
+  for (NodeContainer::Iterator i = c.Begin (); i != c.End (); ++i)
+    {
+      node = (*i);
+      Ptr<Ipv4> ipv4 = node->GetObject<Ipv4> ();
+      NS_ASSERT_MSG (ipv4, "Ipv4 not installed on node");
+      Ptr<Ipv4RoutingProtocol> proto = ipv4->GetRoutingProtocol ();
+      NS_ASSERT_MSG (proto, "Ipv4 routing not installed on node");
+      Ptr<aomdv::RoutingProtocol> aomdv = DynamicCast<aomdv::RoutingProtocol> (proto);
+      if (aomdv)
+        {
+          currentStream += aomdv->AssignStreams (currentStream);
+          continue;
+        }
+      // Aomdv may also be in a list
+      Ptr<Ipv4ListRouting> list = DynamicCast<Ipv4ListRouting> (proto);
+      if (list)
+        {
+          int16_t priority;
+          Ptr<Ipv4RoutingProtocol> listProto;
+          Ptr<aomdv::RoutingProtocol> listAomdv;
+          for (uint32_t i = 0; i < list->GetNRoutingProtocols (); i++)
+            {
+              listProto = list->GetRoutingProtocol (i, priority);
+              listAomdv = DynamicCast<aomdv::RoutingProtocol> (listProto);
+              if (listAomdv)
+                {
+                  currentStream += listAomdv->AssignStreams (currentStream);
+                  break;
+                }
+            }
+        }
+    }
+  return (currentStream - stream);
+}
+
+}

--- a/ns3/aomdv/helper/aomdv-helper.h
+++ b/ns3/aomdv/helper/aomdv-helper.h
@@ -1,0 +1,92 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Pavel Boyko <boyko@iitp.ru>, written after OlsrHelper by Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+
+#ifndef AOMDV_HELPER_H
+#define AOMDV_HELPER_H
+
+#include "ns3/object-factory.h"
+#include "ns3/node.h"
+#include "ns3/node-container.h"
+#include "ns3/ipv4-routing-helper.h"
+
+namespace ns3 {
+/**
+ * \ingroup aomdv
+ * \brief Helper class that adds AOMDV routing to nodes.
+ */
+class AomdvHelper : public Ipv4RoutingHelper
+{
+public:
+  AomdvHelper ();
+
+  /**
+   * \returns pointer to clone of this AomdvHelper
+   *
+   * \internal
+   * This method is mainly for internal use by the other helpers;
+   * clients are expected to free the dynamic memory allocated by this method
+   */
+  AomdvHelper* Copy (void) const;
+
+  /**
+   * \param node the node on which the routing protocol will run
+   * \returns a newly-created routing protocol
+   *
+   * This method will be called by ns3::InternetStackHelper::Install
+   *
+   * \todo support installing AOMDV on the subset of all available IP interfaces
+   */
+  virtual Ptr<Ipv4RoutingProtocol> Create (Ptr<Node> node) const;
+  /**
+   * \param name the name of the attribute to set
+   * \param value the value of the attribute to set.
+   *
+   * This method controls the attributes of ns3::aomdv::RoutingProtocol
+   */
+  void Set (std::string name, const AttributeValue &value);
+  /**
+   * Assign a fixed random variable stream number to the random variables
+   * used by this model.  Return the number of streams (possibly zero) that
+   * have been assigned.  The Install() method of the InternetStackHelper
+   * should have previously been called by the user.
+   *
+   * \param stream first stream index to use
+   * \param c NodeContainer of the set of nodes for which AOMDV
+   *          should be modified to use a fixed stream
+   * \return the number of stream indices assigned by this helper
+   */
+  int64_t AssignStreams (NodeContainer c, int64_t stream);
+
+private:
+  /** the factory to create AOMDV routing object */
+  ObjectFactory m_agentFactory;
+};
+
+}
+
+#endif /* AOMDV_HELPER_H */

--- a/ns3/aomdv/model/aomdv-dpd.cc
+++ b/ns3/aomdv/model/aomdv-dpd.cc
@@ -1,0 +1,56 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+
+#include "aomdv-dpd.h"
+
+namespace ns3 {
+namespace aomdv {
+
+bool
+DuplicatePacketDetection::IsDuplicate  (Ptr<const Packet> p, const Ipv4Header & header)
+{
+  return m_idCache.IsDuplicate (header.GetSource (), p->GetUid () );
+}
+void
+DuplicatePacketDetection::SetLifetime (Time lifetime)
+{
+  m_idCache.SetLifetime (lifetime);
+}
+
+Time
+DuplicatePacketDetection::GetLifetime () const
+{
+  return m_idCache.GetLifeTime ();
+}
+
+
+}
+}
+

--- a/ns3/aomdv/model/aomdv-dpd.h
+++ b/ns3/aomdv/model/aomdv-dpd.h
@@ -1,0 +1,84 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+
+#ifndef AOMDV_DPD_H
+#define AOMDV_DPD_H
+
+#include "aomdv-id-cache.h"
+#include "ns3/nstime.h"
+#include "ns3/packet.h"
+#include "ns3/ipv4-header.h"
+
+namespace ns3 {
+namespace aomdv {
+/**
+ * \ingroup aomdv
+ *
+ * \brief Helper class used to remember already seen packets and detect duplicates.
+ *
+ * Currently duplicate detection is based on unique packet ID given by Packet::GetUid ()
+ * This approach is known to be weak (ns3::Packet UID is an internal identifier and not intended for logical uniqueness in models) and should be changed.
+ */
+class DuplicatePacketDetection
+{
+public:
+  /**
+   * Constructor
+   * \param lifetime the lifetime for added entries
+   */
+  DuplicatePacketDetection (Time lifetime) : m_idCache (lifetime)
+  {
+  }
+  /**
+   * Check if the packet is a duplicate. If not, save information about this packet.
+   * \param p the packet to check
+   * \param header the IP header to check
+   * \returns true if duplicate
+   */
+  bool IsDuplicate (Ptr<const Packet> p, const Ipv4Header & header);
+  /**
+   * Set duplicate record lifetime
+   * \param lifetime the lifetime for duplicate records
+   */
+  void SetLifetime (Time lifetime);
+  /**
+   * Get duplicate record lifetime
+   * \returns the duplicate record lifetime
+   */
+  Time GetLifetime () const;
+private:
+  /// Impl
+  IdCache m_idCache;
+};
+
+}
+}
+
+#endif /* AOMDV_DPD_H */

--- a/ns3/aomdv/model/aomdv-id-cache.cc
+++ b/ns3/aomdv/model/aomdv-id-cache.cc
@@ -1,0 +1,140 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#include "aomdv-id-cache.h"
+#include <algorithm>
+
+namespace ns3 {
+namespace aomdv {
+bool
+IdCache::IsDuplicate (Ipv4Address addr, uint32_t id)
+{
+  Purge ();
+  for (std::vector<UniqueId>::const_iterator i = m_idCache.begin ();
+       i != m_idCache.end (); ++i)
+    {
+      if (i->m_context == addr && i->m_id == id)
+        {
+          return true;
+        }
+    }
+  struct UniqueId uniqueId =
+  {
+    addr, id, m_lifetime + Simulator::Now (), 0, {}, {}
+  };
+  m_idCache.push_back (uniqueId);
+  return false;
+}
+
+struct IdCache::UniqueId*
+IdCache::GetId (Ipv4Address addr, uint32_t id)
+{
+  Purge ();
+  for (std::vector<UniqueId>::iterator i = m_idCache.begin ();
+       i != m_idCache.end (); ++i)
+    {
+      if (i->m_context == addr && i->m_id == id)
+        {
+          UniqueId *uid=&(*i);
+          return uid;
+        }
+    }
+  return NULL;
+}
+
+void
+IdCache::InsertId (Ipv4Address addr, uint32_t id)
+{
+  struct UniqueId uniqueId =
+  { addr, id, m_lifetime + Simulator::Now (), 0 };
+  m_idCache.push_back (uniqueId);
+}
+
+void
+IdCache::Purge ()
+{
+  m_idCache.erase (remove_if (m_idCache.begin (), m_idCache.end (),
+                              IsExpired ()), m_idCache.end ());
+}
+
+uint32_t
+IdCache::GetSize ()
+{
+  Purge ();
+  return m_idCache.size ();
+}
+
+void
+IdCache::UniqueId::ReversePathInsert (Ipv4Address nextHop, Ipv4Address lastHop)
+{
+  m_reversePathList.push_back (AOMDVRoute (nextHop, lastHop));
+}
+
+bool 
+IdCache::UniqueId::ReversePathLookup (Ipv4Address nextHop, AOMDVRoute & rt, Ipv4Address lastHop)
+{
+  for (std::vector<AOMDVRoute>::iterator i = m_reversePathList.begin(); i != m_reversePathList.end(); ++i) 
+    {
+      if ( ( i->GetNextHop () == nextHop) && ( i->GetLastHop () == lastHop) )
+        {
+	  rt = *i;
+          return true;     
+        }
+    }
+    return false;
+}
+				
+void 
+IdCache::UniqueId::ForwardPathInsert (Ipv4Address nextHop, Ipv4Address lastHop)
+{
+  m_forwardPathList.push_back (AOMDVRoute (nextHop, lastHop));
+}
+
+bool
+IdCache::UniqueId::ForwardPathLookup (Ipv4Address nextHop, AOMDVRoute & rt, Ipv4Address lastHop)
+{
+  for (std::vector<AOMDVRoute>::iterator i = m_forwardPathList.begin(); i != m_forwardPathList.end(); ++i) 
+    {
+      if ( ( i->GetNextHop () == nextHop) && ( i->GetLastHop () == lastHop) )
+        {
+	  rt = *i;
+          return true;      
+        }
+    }
+  return false;
+}
+
+}
+}

--- a/ns3/aomdv/model/aomdv-id-cache.h
+++ b/ns3/aomdv/model/aomdv-id-cache.h
@@ -1,0 +1,167 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+
+#ifndef AOMDV_ID_CACHE_H
+#define AOMDV_ID_CACHE_H
+
+#include "ns3/ipv4-address.h"
+#include "ns3/simulator.h"
+#include <vector>
+
+namespace ns3 {
+namespace aomdv {
+
+/**
+ * \ingroup aomdv
+ * \brief Next-hop/last-hop pair describing one path of a multipath route
+ * (AOMDV addition).
+ */
+class AOMDVRoute 
+{
+public:
+  AOMDVRoute(Ipv4Address nextHop, Ipv4Address lastHop = 0) : m_nextHop (nextHop) , m_lastHop (lastHop) {}
+  void SetNextHop (Ipv4Address nextHop) { m_nextHop = nextHop; }
+  Ipv4Address GetNextHop () const { return m_nextHop; }
+  void SetLastHop (Ipv4Address lastHop) { m_lastHop = lastHop; }
+  Ipv4Address GetLastHop () const { return m_lastHop; }
+private:
+  Ipv4Address m_nextHop;
+  Ipv4Address m_lastHop;
+};
+
+/**
+ * \ingroup aomdv
+ *
+ * \brief Unique packets identification cache used for simple duplicate detection.
+ */
+class IdCache
+{
+public:
+  /**
+   * constructor
+   * \param lifetime the lifetime for added entries
+   */
+  IdCache (Time lifetime) : m_lifetime (lifetime)
+  {
+  }
+  /// Unique packet ID (AOMDV: extended with per-RREQ path bookkeeping)
+  struct UniqueId
+  {
+    /// ID is supposed to be unique in single address context (e.g. sender address)
+    Ipv4Address m_context;
+    /// The id
+    uint32_t m_id;
+    /// When record will expire
+    Time m_expire;
+    /// AOMDV: advertised-path counter for this RREQ generation
+    int count;
+    std::vector<AOMDVRoute> m_reversePathList;     ///< AOMDV: reverse paths used for forwarding replies
+    std::vector<AOMDVRoute> m_forwardPathList;     ///< AOMDV: forward paths advertised already
+    void ReversePathInsert (Ipv4Address nextHop, Ipv4Address lastHop = 0);
+    bool ReversePathLookup (Ipv4Address nextHop, AOMDVRoute & rt, Ipv4Address lastHop = 0);
+    void ForwardPathInsert (Ipv4Address nextHop, Ipv4Address lastHop = 0);
+    bool ForwardPathLookup (Ipv4Address nextHop, AOMDVRoute & rt, Ipv4Address lastHop = 0);
+  };
+
+  /**
+   * Add entry (addr, id) to the cache (AOMDV).
+   * \param addr the IP address
+   * \param id the cache entry ID
+   */
+  void InsertId (Ipv4Address addr, uint32_t id);
+  /**
+   * Look up the cache entry for (addr, id) (AOMDV).
+   * \param addr the IP address
+   * \param id the cache entry ID
+   * \returns the entry, or 0 if not present
+   */
+  struct UniqueId* GetId (Ipv4Address addr, uint32_t id);
+  /**
+   * Check that entry (addr, id) exists in cache. Add entry, if it doesn't exist.
+   * \param addr the IP address
+   * \param id the cache entry ID
+   * \returns true if the pair exists
+   */ 
+  bool IsDuplicate (Ipv4Address addr, uint32_t id);
+  /// Remove all expired entries
+  void Purge ();
+  /**
+   * \returns number of entries in cache
+   */
+  uint32_t GetSize ();
+  /**
+   * Set lifetime for future added entries.
+   * \param lifetime the lifetime for entries
+   */
+  void SetLifetime (Time lifetime)
+  {
+    m_lifetime = lifetime;
+  }
+  /**
+   * Return lifetime for existing entries in cache
+   * \returns thhe lifetime
+   */
+  Time GetLifeTime () const
+  {
+    return m_lifetime;
+  }
+private:
+  /**
+   * \brief IsExpired structure
+   */
+  struct IsExpired
+  {
+    /**
+     * \brief Check if the entry is expired
+     *
+     * \param u UniqueId entry
+     * \return true if expired, false otherwise
+     */
+    bool operator() (const struct UniqueId & u) const
+    {
+      return (u.m_expire < Simulator::Now ());
+    }
+  };
+  /// Already seen IDs
+  std::vector<UniqueId> m_idCache;
+  /// Default lifetime for ID records
+  Time m_lifetime;
+};
+
+}  // namespace aomdv
+}  // namespace ns3
+
+#endif /* AOMDV_ID_CACHE_H */

--- a/ns3/aomdv/model/aomdv-neighbor.cc
+++ b/ns3/aomdv/model/aomdv-neighbor.cc
@@ -1,0 +1,203 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+
+#include <algorithm>
+#include "ns3/log.h"
+#include "ns3/wifi-mac-header.h"
+#include "aomdv-neighbor.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("AomdvNeighbors");
+
+namespace aomdv {
+Neighbors::Neighbors (Time delay)
+  : m_ntimer (Timer::CANCEL_ON_DESTROY)
+{
+  m_ntimer.SetDelay (delay);
+  m_ntimer.SetFunction (&Neighbors::Purge, this);
+  m_txErrorCallback = MakeCallback (&Neighbors::ProcessTxError, this);
+}
+
+bool
+Neighbors::IsNeighbor (Ipv4Address addr)
+{
+  Purge ();
+  for (std::vector<Neighbor>::const_iterator i = m_nb.begin ();
+       i != m_nb.end (); ++i)
+    {
+      if (i->m_neighborAddress == addr)
+        {
+          return true;
+        }
+    }
+  return false;
+}
+
+Time
+Neighbors::GetExpireTime (Ipv4Address addr)
+{
+  Purge ();
+  for (std::vector<Neighbor>::const_iterator i = m_nb.begin (); i
+       != m_nb.end (); ++i)
+    {
+      if (i->m_neighborAddress == addr)
+        {
+          return (i->m_expireTime - Simulator::Now ());
+        }
+    }
+  return Seconds (0);
+}
+
+void
+Neighbors::Update (Ipv4Address addr, Time expire)
+{
+  for (std::vector<Neighbor>::iterator i = m_nb.begin (); i != m_nb.end (); ++i)
+    {
+      if (i->m_neighborAddress == addr)
+        {
+          i->m_expireTime
+            = std::max (expire + Simulator::Now (), i->m_expireTime);
+          if (i->m_hardwareAddress == Mac48Address ())
+            {
+              i->m_hardwareAddress = LookupMacAddress (i->m_neighborAddress);
+            }
+          return;
+        }
+    }
+
+  NS_LOG_LOGIC ("Open link to " << addr);
+  Neighbor neighbor (addr, LookupMacAddress (addr), expire + Simulator::Now ());
+  m_nb.push_back (neighbor);
+  Purge ();
+}
+
+/**
+ * \brief CloseNeighbor structure
+ */
+struct CloseNeighbor
+{
+  /**
+   * Check if the entry is expired
+   *
+   * \param nb Neighbors::Neighbor entry
+   * \return true if expired, false otherwise
+   */
+  bool operator() (const Neighbors::Neighbor & nb) const
+  {
+    return ((nb.m_expireTime < Simulator::Now ()) || nb.close);
+  }
+};
+
+void
+Neighbors::Purge ()
+{
+  if (m_nb.empty ())
+    {
+      return;
+    }
+
+  CloseNeighbor pred;
+  if (!m_handleLinkFailure.IsNull ())
+    {
+      for (std::vector<Neighbor>::iterator j = m_nb.begin (); j != m_nb.end (); ++j)
+        {
+          if (pred (*j))
+            {
+              NS_LOG_LOGIC ("Close link to " << j->m_neighborAddress);
+              m_handleLinkFailure (j->m_neighborAddress);
+            }
+        }
+    }
+  m_nb.erase (std::remove_if (m_nb.begin (), m_nb.end (), pred), m_nb.end ());
+  m_ntimer.Cancel ();
+  m_ntimer.Schedule ();
+}
+
+void
+Neighbors::ScheduleTimer ()
+{
+  m_ntimer.Cancel ();
+  m_ntimer.Schedule ();
+}
+
+void
+Neighbors::AddArpCache (Ptr<ArpCache> a)
+{
+  m_arp.push_back (a);
+}
+
+void
+Neighbors::DelArpCache (Ptr<ArpCache> a)
+{
+  m_arp.erase (std::remove (m_arp.begin (), m_arp.end (), a), m_arp.end ());
+}
+
+Mac48Address
+Neighbors::LookupMacAddress (Ipv4Address addr)
+{
+  Mac48Address hwaddr;
+  for (std::vector<Ptr<ArpCache> >::const_iterator i = m_arp.begin ();
+       i != m_arp.end (); ++i)
+    {
+      ArpCache::Entry * entry = (*i)->Lookup (addr);
+      if (entry != 0 && (entry->IsAlive () || entry->IsPermanent ()) && !entry->IsExpired ())
+        {
+          hwaddr = Mac48Address::ConvertFrom (entry->GetMacAddress ());
+          break;
+        }
+    }
+  return hwaddr;
+}
+
+void
+Neighbors::ProcessTxError (WifiMacHeader const & hdr)
+{
+  Mac48Address addr = hdr.GetAddr1 ();
+
+  for (std::vector<Neighbor>::iterator i = m_nb.begin (); i != m_nb.end (); ++i)
+    {
+      if (i->m_hardwareAddress == addr)
+        {
+          i->close = true;
+        }
+    }
+  Purge ();
+}
+
+}  // namespace aomdv
+}  // namespace ns3
+

--- a/ns3/aomdv/model/aomdv-neighbor.h
+++ b/ns3/aomdv/model/aomdv-neighbor.h
@@ -1,0 +1,187 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+
+#ifndef AOMDVNEIGHBOR_H
+#define AOMDVNEIGHBOR_H
+
+#include <vector>
+#include "ns3/simulator.h"
+#include "ns3/timer.h"
+#include "ns3/ipv4-address.h"
+#include "ns3/callback.h"
+#include "ns3/arp-cache.h"
+
+namespace ns3 {
+
+class WifiMacHeader;
+
+namespace aomdv {
+
+class RoutingProtocol;
+
+/**
+ * \ingroup aomdv
+ * \brief maintain list of active neighbors
+ */
+class Neighbors
+{
+public:
+  /**
+   * constructor
+   * \param delay the delay time for purging the list of neighbors
+   */
+  Neighbors (Time delay);
+  /// Neighbor description
+  struct Neighbor
+  {
+    /// Neighbor IPv4 address
+    Ipv4Address m_neighborAddress;
+    /// Neighbor MAC address
+    Mac48Address m_hardwareAddress;
+    /// Neighbor expire time
+    Time m_expireTime;
+    /// Neighbor close indicator
+    bool close;
+
+    /**
+     * \brief Neighbor structure constructor
+     *
+     * \param ip Ipv4Address entry
+     * \param mac Mac48Address entry
+     * \param t Time expire time
+     */
+    Neighbor (Ipv4Address ip, Mac48Address mac, Time t)
+      : m_neighborAddress (ip),
+        m_hardwareAddress (mac),
+        m_expireTime (t),
+        close (false)
+    {
+    }
+  };
+  /**
+   * Return expire time for neighbor node with address addr, if exists, else return 0.
+   * \param addr the IP address of the neighbor node
+   * \returns the expire time for the neighbor node
+   */
+  Time GetExpireTime (Ipv4Address addr);
+  /**
+   * Check that node with address addr is neighbor
+   * \param addr the IP address to check
+   * \returns true if the node with IP address is a neighbor
+   */
+  bool IsNeighbor (Ipv4Address addr);
+  /**
+   * Update expire time for entry with address addr, if it exists, else add new entry
+   * \param addr the IP address to check
+   * \param expire the expire time for the address
+   */
+  void Update (Ipv4Address addr, Time expire);
+  /// Remove all expired entries
+  void Purge ();
+  /// Schedule m_ntimer.
+  void ScheduleTimer ();
+  /// Remove all entries
+  void Clear ()
+  {
+    m_nb.clear ();
+  }
+
+  /**
+   * Add ARP cache to be used to allow layer 2 notifications processing
+   * \param a pointer to the ARP cache to add
+   */
+  void AddArpCache (Ptr<ArpCache> a);
+  /**
+   * Don't use given ARP cache any more (interface is down)
+   * \param a pointer to the ARP cache to delete
+   */
+  void DelArpCache (Ptr<ArpCache> a);
+  /**
+   * Get callback to ProcessTxError
+   * \returns the callback function
+   */
+  Callback<void, WifiMacHeader const &> GetTxErrorCallback () const
+  {
+    return m_txErrorCallback;
+  }
+
+  /**
+   * Set link failure callback
+   * \param cb the callback function
+   */
+  void SetCallback (Callback<void, Ipv4Address> cb)
+  {
+    m_handleLinkFailure = cb;
+  }
+  /**
+   * Get link failure callback
+   * \returns the link failure callback
+   */
+  Callback<void, Ipv4Address> GetCallback () const
+  {
+    return m_handleLinkFailure;
+  }
+
+private:
+  /// link failure callback
+  Callback<void, Ipv4Address> m_handleLinkFailure;
+  /// TX error callback
+  Callback<void, WifiMacHeader const &> m_txErrorCallback;
+  /// Timer for neighbor's list. Schedule Purge().
+  Timer m_ntimer;
+  /// vector of entries
+  std::vector<Neighbor> m_nb;
+  /// list of ARP cached to be used for layer 2 notifications processing
+  std::vector<Ptr<ArpCache> > m_arp;
+
+  /**
+   * Find MAC address by IP using list of ARP caches
+   * 
+   * \param addr the IP address to lookup
+   * \returns the MAC address for the IP address
+   */
+  Mac48Address LookupMacAddress (Ipv4Address addr);
+  /**
+   * Process layer 2 TX error notification
+   * \param hdr header of the packet
+   */
+  void ProcessTxError (WifiMacHeader const &hdr);
+};
+
+}  // namespace aomdv
+}  // namespace ns3
+
+#endif /* AOMDVNEIGHBOR_H */

--- a/ns3/aomdv/model/aomdv-packet.cc
+++ b/ns3/aomdv/model/aomdv-packet.cc
@@ -1,0 +1,704 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#include "aomdv-packet.h"
+#include "ns3/address-utils.h"
+#include "ns3/packet.h"
+
+namespace ns3 {
+namespace aomdv {
+
+NS_OBJECT_ENSURE_REGISTERED (TypeHeader);
+
+TypeHeader::TypeHeader (MessageType t)
+  : m_type (t),
+    m_valid (true)
+{
+}
+
+TypeId
+TypeHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::aomdv::TypeHeader")
+    .SetParent<Header> ()
+    .SetGroupName ("Aomdv")
+    .AddConstructor<TypeHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+TypeHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+TypeHeader::GetSerializedSize () const
+{
+  return 1;
+}
+
+void
+TypeHeader::Serialize (Buffer::Iterator i) const
+{
+  i.WriteU8 ((uint8_t) m_type);
+}
+
+uint32_t
+TypeHeader::Deserialize (Buffer::Iterator start)
+{
+  Buffer::Iterator i = start;
+  uint8_t type = i.ReadU8 ();
+  m_valid = true;
+  switch (type)
+    {
+    case AOMDVTYPE_RREQ:
+    case AOMDVTYPE_RREP:
+    case AOMDVTYPE_RERR:
+    case AOMDVTYPE_RREP_ACK:
+      {
+        m_type = (MessageType) type;
+        break;
+      }
+    default:
+      m_valid = false;
+    }
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+TypeHeader::Print (std::ostream &os) const
+{
+  switch (m_type)
+    {
+    case AOMDVTYPE_RREQ:
+      {
+        os << "RREQ";
+        break;
+      }
+    case AOMDVTYPE_RREP:
+      {
+        os << "RREP";
+        break;
+      }
+    case AOMDVTYPE_RERR:
+      {
+        os << "RERR";
+        break;
+      }
+    case AOMDVTYPE_RREP_ACK:
+      {
+        os << "RREP_ACK";
+        break;
+      }
+    default:
+      os << "UNKNOWN_TYPE";
+    }
+}
+
+bool
+TypeHeader::operator== (TypeHeader const & o) const
+{
+  return (m_type == o.m_type && m_valid == o.m_valid);
+}
+
+std::ostream &
+operator<< (std::ostream & os, TypeHeader const & h)
+{
+  h.Print (os);
+  return os;
+}
+
+//-----------------------------------------------------------------------------
+// RREQ
+//-----------------------------------------------------------------------------
+RreqHeader::RreqHeader (uint8_t flags, uint8_t reserved, uint8_t hopCount, uint32_t requestID, Ipv4Address dst,
+                        uint32_t dstSeqNo, Ipv4Address origin, uint32_t originSeqNo, Ipv4Address firstHop)
+  : m_flags (flags),
+    m_reserved (reserved),
+    m_hopCount (hopCount),
+    m_requestID (requestID),
+    m_dst (dst),
+    m_dstSeqNo (dstSeqNo),
+    m_origin (origin),
+    m_originSeqNo (originSeqNo),
+    m_firstHop (firstHop)
+{
+}
+
+NS_OBJECT_ENSURE_REGISTERED (RreqHeader);
+
+TypeId
+RreqHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::aomdv::RreqHeader")
+    .SetParent<Header> ()
+    .SetGroupName ("Aomdv")
+    .AddConstructor<RreqHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+RreqHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+RreqHeader::GetSerializedSize () const
+{
+  return 27;
+}
+
+void
+RreqHeader::Serialize (Buffer::Iterator i) const
+{
+  i.WriteU8 (m_flags);
+  i.WriteU8 (m_reserved);
+  i.WriteU8 (m_hopCount);
+  i.WriteHtonU32 (m_requestID);
+  WriteTo (i, m_dst);
+  i.WriteHtonU32 (m_dstSeqNo);
+  WriteTo (i, m_origin);
+  i.WriteHtonU32 (m_originSeqNo);
+  WriteTo (i, m_firstHop);
+}
+
+uint32_t
+RreqHeader::Deserialize (Buffer::Iterator start)
+{
+  Buffer::Iterator i = start;
+  m_flags = i.ReadU8 ();
+  m_reserved = i.ReadU8 ();
+  m_hopCount = i.ReadU8 ();
+  m_requestID = i.ReadNtohU32 ();
+  ReadFrom (i, m_dst);
+  m_dstSeqNo = i.ReadNtohU32 ();
+  ReadFrom (i, m_origin);
+  m_originSeqNo = i.ReadNtohU32 ();
+  ReadFrom (i, m_firstHop);
+
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+RreqHeader::Print (std::ostream &os) const
+{
+  os << "RREQ ID " << m_requestID << " destination: ipv4 " << m_dst
+     << " sequence number " << m_dstSeqNo << " source: ipv4 "
+     << m_origin << " sequence number " << m_originSeqNo << " first hop " << m_firstHop
+     << " flags:" << " Gratuitous RREP " << (*this).GetGratuitousRrep ()
+     << " Destination only " << (*this).GetDestinationOnly ()
+     << " Unknown sequence number " << (*this).GetUnknownSeqno ();
+}
+
+std::ostream &
+operator<< (std::ostream & os, RreqHeader const & h)
+{
+  h.Print (os);
+  return os;
+}
+
+void
+RreqHeader::SetGratuitousRrep (bool f)
+{
+  if (f)
+    {
+      m_flags |= (1 << 5);
+    }
+  else
+    {
+      m_flags &= ~(1 << 5);
+    }
+}
+
+bool
+RreqHeader::GetGratuitousRrep () const
+{
+  return (m_flags & (1 << 5));
+}
+
+void
+RreqHeader::SetDestinationOnly (bool f)
+{
+  if (f)
+    {
+      m_flags |= (1 << 4);
+    }
+  else
+    {
+      m_flags &= ~(1 << 4);
+    }
+}
+
+bool
+RreqHeader::GetDestinationOnly () const
+{
+  return (m_flags & (1 << 4));
+}
+
+void
+RreqHeader::SetUnknownSeqno (bool f)
+{
+  if (f)
+    {
+      m_flags |= (1 << 3);
+    }
+  else
+    {
+      m_flags &= ~(1 << 3);
+    }
+}
+
+bool
+RreqHeader::GetUnknownSeqno () const
+{
+  return (m_flags & (1 << 3));
+}
+
+bool
+RreqHeader::operator== (RreqHeader const & o) const
+{
+  return (m_flags == o.m_flags && m_reserved == o.m_reserved
+          && m_hopCount == o.m_hopCount && m_requestID == o.m_requestID
+          && m_dst == o.m_dst && m_dstSeqNo == o.m_dstSeqNo
+          && m_origin == o.m_origin && m_originSeqNo == o.m_originSeqNo
+          && m_firstHop == o.m_firstHop);
+}
+
+//-----------------------------------------------------------------------------
+// RREP
+//-----------------------------------------------------------------------------
+
+RrepHeader::RrepHeader (uint8_t prefixSize, uint8_t hopCount, Ipv4Address dst,
+                        uint32_t dstSeqNo, Ipv4Address origin, uint32_t requestID,
+                        Ipv4Address firstHop, Time lifeTime)
+  : m_flags (0),
+    m_prefixSize (prefixSize),
+    m_hopCount (hopCount),
+    m_dst (dst),
+    m_dstSeqNo (dstSeqNo),
+    m_origin (origin),
+    m_requestID (requestID),
+    m_firstHop (firstHop)
+{
+  m_lifeTime = uint32_t (lifeTime.GetMilliSeconds ());
+}
+
+NS_OBJECT_ENSURE_REGISTERED (RrepHeader);
+
+TypeId
+RrepHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::aomdv::RrepHeader")
+    .SetParent<Header> ()
+    .SetGroupName ("Aomdv")
+    .AddConstructor<RrepHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+RrepHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+RrepHeader::GetSerializedSize () const
+{
+  return 27;
+}
+
+void
+RrepHeader::Serialize (Buffer::Iterator i) const
+{
+  i.WriteU8 (m_flags);
+  i.WriteU8 (m_prefixSize);
+  i.WriteU8 (m_hopCount);
+  WriteTo (i, m_dst);
+  i.WriteHtonU32 (m_dstSeqNo);
+  WriteTo (i, m_origin);
+  i.WriteHtonU32 (m_requestID);
+  WriteTo (i, m_firstHop);
+  i.WriteHtonU32 (m_lifeTime);
+}
+
+uint32_t
+RrepHeader::Deserialize (Buffer::Iterator start)
+{
+  Buffer::Iterator i = start;
+
+  m_flags = i.ReadU8 ();
+  m_prefixSize = i.ReadU8 ();
+  m_hopCount = i.ReadU8 ();
+  ReadFrom (i, m_dst);
+  m_dstSeqNo = i.ReadNtohU32 ();
+  ReadFrom (i, m_origin);
+  m_requestID = i.ReadNtohU32 ();
+  ReadFrom (i, m_firstHop);
+  m_lifeTime = i.ReadNtohU32 ();
+
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+RrepHeader::Print (std::ostream &os) const
+{
+  os << "destination: ipv4 " << m_dst << " sequence number " << m_dstSeqNo << " Request ID " << m_requestID << " first hop " << m_firstHop;
+  if (m_prefixSize != 0)
+    {
+      os << " prefix size " << m_prefixSize;
+    }
+  os << " source ipv4 " << m_origin << " lifetime " << m_lifeTime
+     << " acknowledgment required flag " << (*this).GetAckRequired ();
+}
+
+void
+RrepHeader::SetLifeTime (Time t)
+{
+  m_lifeTime = t.GetMilliSeconds ();
+}
+
+Time
+RrepHeader::GetLifeTime () const
+{
+  Time t (MilliSeconds (m_lifeTime));
+  return t;
+}
+
+void
+RrepHeader::SetAckRequired (bool f)
+{
+  if (f)
+    {
+      m_flags |= (1 << 6);
+    }
+  else
+    {
+      m_flags &= ~(1 << 6);
+    }
+}
+
+bool
+RrepHeader::GetAckRequired () const
+{
+  return (m_flags & (1 << 6));
+}
+
+void
+RrepHeader::SetPrefixSize (uint8_t sz)
+{
+  m_prefixSize = sz;
+}
+
+uint8_t
+RrepHeader::GetPrefixSize () const
+{
+  return m_prefixSize;
+}
+
+bool
+RrepHeader::operator== (RrepHeader const & o) const
+{
+  return (m_flags == o.m_flags && m_prefixSize == o.m_prefixSize
+          && m_hopCount == o.m_hopCount && m_dst == o.m_dst && m_dstSeqNo == o.m_dstSeqNo
+          && m_origin == o.m_origin && m_requestID == o.m_requestID
+          && m_firstHop == o.m_firstHop && m_lifeTime == o.m_lifeTime);
+}
+
+void
+RrepHeader::SetHello (Ipv4Address origin, uint32_t srcSeqNo, Time lifetime)
+{
+  m_flags = 0;
+  m_prefixSize = 0;
+  m_hopCount = 0;
+  m_dst = origin;
+  m_dstSeqNo = srcSeqNo;
+  m_origin = origin;
+  m_requestID = 0;
+  //m_firstHop =  
+  m_lifeTime = lifetime.GetMilliSeconds ();
+}
+
+std::ostream &
+operator<< (std::ostream & os, RrepHeader const & h)
+{
+  h.Print (os);
+  return os;
+}
+
+//-----------------------------------------------------------------------------
+// RREP-ACK
+//-----------------------------------------------------------------------------
+
+RrepAckHeader::RrepAckHeader ()
+  : m_reserved (0)
+{
+}
+
+NS_OBJECT_ENSURE_REGISTERED (RrepAckHeader);
+
+TypeId
+RrepAckHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::aomdv::RrepAckHeader")
+    .SetParent<Header> ()
+    .SetGroupName ("Aomdv")
+    .AddConstructor<RrepAckHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+RrepAckHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+RrepAckHeader::GetSerializedSize () const
+{
+  return 1;
+}
+
+void
+RrepAckHeader::Serialize (Buffer::Iterator i ) const
+{
+  i.WriteU8 (m_reserved);
+}
+
+uint32_t
+RrepAckHeader::Deserialize (Buffer::Iterator start )
+{
+  Buffer::Iterator i = start;
+  m_reserved = i.ReadU8 ();
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+RrepAckHeader::Print (std::ostream &os ) const
+{
+}
+
+bool
+RrepAckHeader::operator== (RrepAckHeader const & o ) const
+{
+  return m_reserved == o.m_reserved;
+}
+
+std::ostream &
+operator<< (std::ostream & os, RrepAckHeader const & h )
+{
+  h.Print (os);
+  return os;
+}
+
+//-----------------------------------------------------------------------------
+// RERR
+//-----------------------------------------------------------------------------
+RerrHeader::RerrHeader ()
+  : m_flag (0),
+    m_reserved (0)
+{
+}
+
+NS_OBJECT_ENSURE_REGISTERED (RerrHeader);
+
+TypeId
+RerrHeader::GetTypeId ()
+{
+  static TypeId tid = TypeId ("ns3::aomdv::RerrHeader")
+    .SetParent<Header> ()
+    .SetGroupName ("Aomdv")
+    .AddConstructor<RerrHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+RerrHeader::GetInstanceTypeId () const
+{
+  return GetTypeId ();
+}
+
+uint32_t
+RerrHeader::GetSerializedSize () const
+{
+  return (3 + 8 * GetDestCount ());
+}
+
+void
+RerrHeader::Serialize (Buffer::Iterator i ) const
+{
+  i.WriteU8 (m_flag);
+  i.WriteU8 (m_reserved);
+  i.WriteU8 (GetDestCount ());
+  std::map<Ipv4Address, uint32_t>::const_iterator j;
+  for (j = m_unreachableDstSeqNo.begin (); j != m_unreachableDstSeqNo.end (); ++j)
+    {
+      WriteTo (i, (*j).first);
+      i.WriteHtonU32 ((*j).second);
+    }
+}
+
+uint32_t
+RerrHeader::Deserialize (Buffer::Iterator start )
+{
+  Buffer::Iterator i = start;
+  m_flag = i.ReadU8 ();
+  m_reserved = i.ReadU8 ();
+  uint8_t dest = i.ReadU8 ();
+  m_unreachableDstSeqNo.clear ();
+  Ipv4Address address;
+  uint32_t seqNo;
+  for (uint8_t k = 0; k < dest; ++k)
+    {
+      ReadFrom (i, address);
+      seqNo = i.ReadNtohU32 ();
+      m_unreachableDstSeqNo.insert (std::make_pair (address, seqNo));
+    }
+
+  uint32_t dist = i.GetDistanceFrom (start);
+  NS_ASSERT (dist == GetSerializedSize ());
+  return dist;
+}
+
+void
+RerrHeader::Print (std::ostream &os ) const
+{
+  os << "Unreachable destination (ipv4 address, seq. number):";
+  std::map<Ipv4Address, uint32_t>::const_iterator j;
+  for (j = m_unreachableDstSeqNo.begin (); j != m_unreachableDstSeqNo.end (); ++j)
+    {
+      os << (*j).first << ", " << (*j).second;
+    }
+  os << "No delete flag " << (*this).GetNoDelete ();
+}
+
+void
+RerrHeader::SetNoDelete (bool f )
+{
+  if (f)
+    {
+      m_flag |= (1 << 0);
+    }
+  else
+    {
+      m_flag &= ~(1 << 0);
+    }
+}
+
+bool
+RerrHeader::GetNoDelete () const
+{
+  return (m_flag & (1 << 0));
+}
+
+bool
+RerrHeader::AddUnDestination (Ipv4Address dst, uint32_t seqNo )
+{
+  if (m_unreachableDstSeqNo.find (dst) != m_unreachableDstSeqNo.end ())
+    {
+      return true;
+    }
+
+  NS_ASSERT (GetDestCount () < 255); // can't support more than 255 destinations in single RERR
+  m_unreachableDstSeqNo.insert (std::make_pair (dst, seqNo));
+  return true;
+}
+
+bool
+RerrHeader::RemoveUnDestination (std::pair<Ipv4Address, uint32_t> & un )
+{
+  if (m_unreachableDstSeqNo.empty ())
+    {
+      return false;
+    }
+  std::map<Ipv4Address, uint32_t>::iterator i = m_unreachableDstSeqNo.begin ();
+  un = *i;
+  m_unreachableDstSeqNo.erase (i);
+  return true;
+}
+
+void
+RerrHeader::Clear ()
+{
+  m_unreachableDstSeqNo.clear ();
+  m_flag = 0;
+  m_reserved = 0;
+}
+
+bool
+RerrHeader::operator== (RerrHeader const & o ) const
+{
+  if (m_flag != o.m_flag || m_reserved != o.m_reserved || GetDestCount () != o.GetDestCount ())
+    {
+      return false;
+    }
+
+  std::map<Ipv4Address, uint32_t>::const_iterator j = m_unreachableDstSeqNo.begin ();
+  std::map<Ipv4Address, uint32_t>::const_iterator k = o.m_unreachableDstSeqNo.begin ();
+  for (uint8_t i = 0; i < GetDestCount (); ++i)
+    {
+      if ((j->first != k->first) || (j->second != k->second))
+        {
+          return false;
+        }
+
+      j++;
+      k++;
+    }
+  return true;
+}
+
+std::ostream &
+operator<< (std::ostream & os, RerrHeader const & h )
+{
+  h.Print (os);
+  return os;
+}
+}
+}

--- a/ns3/aomdv/model/aomdv-packet.h
+++ b/ns3/aomdv/model/aomdv-packet.h
@@ -1,0 +1,700 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#ifndef AOMDVPACKET_H
+#define AOMDVPACKET_H
+
+#include <iostream>
+#include "ns3/header.h"
+#include "ns3/enum.h"
+#include "ns3/ipv4-address.h"
+#include <map>
+#include "ns3/nstime.h"
+
+namespace ns3 {
+namespace aomdv {
+
+/**
+* \ingroup aomdv
+* \brief MessageType enumeration
+*/
+enum MessageType
+{
+  AOMDVTYPE_RREQ  = 1,   //!< AOMDVTYPE_RREQ
+  AOMDVTYPE_RREP  = 2,   //!< AOMDVTYPE_RREP
+  AOMDVTYPE_RERR  = 3,   //!< AOMDVTYPE_RERR
+  AOMDVTYPE_RREP_ACK = 4 //!< AOMDVTYPE_RREP_ACK
+};
+
+/**
+* \ingroup aomdv
+* \brief AOMDV types
+*/
+class TypeHeader : public Header
+{
+public:
+  /**
+   * constructor
+   * \param t the AOMDV RREQ type
+   */
+  TypeHeader (MessageType t = AOMDVTYPE_RREQ);
+
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator start) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+  //\}
+
+  /**
+   * \returns the type
+   */
+  MessageType Get () const
+  {
+    return m_type;
+  }
+  /**
+   * Check that type if valid
+   * \returns true if the type is valid
+   */
+  bool IsValid () const
+  {
+    return m_valid;
+  }
+  /**
+   * \brief Comparison operator
+   * \param o header to compare
+   * \return true if the headers are equal
+   */
+  bool operator== (TypeHeader const & o) const;
+private:
+  MessageType m_type; ///< type of the message
+  bool m_valid; ///< Indicates if the message is valid
+};
+
+/**
+  * \brief Stream output operator
+  * \param os output stream
+  * \return updated stream
+  */
+std::ostream & operator<< (std::ostream & os, TypeHeader const & h);
+
+/**
+* \ingroup aomdv
+* \brief   Route Request (RREQ) Message Format
+  \verbatim
+  0                   1                   2                   3
+  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |     Type      |J|R|G|D|U|   Reserved          |   Hop Count   |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                            RREQ ID                            |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                    Destination IP Address                     |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                  Destination Sequence Number                  |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                    Originator IP Address                      |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                  Originator Sequence Number                   |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  \endverbatim
+*/
+class RreqHeader : public Header
+{
+public:
+  /**
+   * constructor
+   *
+   * \param flags the message flags (0)
+   * \param reserved the reserved bits (0)
+   * \param hopCount the hop count
+   * \param requestID the request ID
+   * \param dst the destination IP address
+   * \param dstSeqNo the destination sequence number
+   * \param origin the origin IP address
+   * \param originSeqNo the origin sequence number
+   */
+   RreqHeader (uint8_t flags = 0, uint8_t reserved = 0, uint8_t hopCount = 0,
+              uint32_t requestID = 0, Ipv4Address dst = Ipv4Address (),
+              uint32_t dstSeqNo = 0, Ipv4Address origin = Ipv4Address (),
+              uint32_t originSeqNo = 0, Ipv4Address firstHop = Ipv4Address());
+
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator start) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+  //\}
+
+  // Fields
+  /**
+   * \brief Set the hop count
+   * \param count the hop count
+   */
+  void SetHopCount (uint8_t count)
+  {
+    m_hopCount = count;
+  }
+  /**
+   * \brief Get the hop count
+   * \return the hop count
+   */
+  uint8_t GetHopCount () const
+  {
+    return m_hopCount;
+  }
+  /**
+   * \brief Set the request ID
+   * \param id the request ID
+   */
+  void SetId (uint32_t id)
+  {
+    m_requestID = id;
+  }
+  /**
+   * \brief Get the request ID
+   * \return the request ID
+   */
+  uint32_t GetId () const
+  {
+    return m_requestID;
+  }
+  /**
+   * \brief Set the destination address
+   * \param a the destination address
+   */
+  void SetDst (Ipv4Address a)
+  {
+    m_dst = a;
+  }
+  /**
+   * \brief Get the destination address
+   * \return the destination address
+   */
+  Ipv4Address GetDst () const
+  {
+    return m_dst;
+  }
+  /**
+   * \brief Set the destination sequence number
+   * \param s the destination sequence number
+   */
+  void SetDstSeqno (uint32_t s)
+  {
+    m_dstSeqNo = s;
+  }
+  /**
+   * \brief Get the destination sequence number
+   * \return the destination sequence number
+   */
+  uint32_t GetDstSeqno () const
+  {
+    return m_dstSeqNo;
+  }
+  /**
+   * \brief Set the origin address
+   * \param a the origin address
+   */
+  void SetOrigin (Ipv4Address a)
+  {
+    m_origin = a;
+  }
+  /**
+   * \brief Get the origin address
+   * \return the origin address
+   */
+  Ipv4Address GetOrigin () const
+  {
+    return m_origin;
+  }
+  /**
+   * \brief Set the origin sequence number
+   * \param s the origin sequence number
+   */
+  void SetOriginSeqno (uint32_t s)
+  {
+    m_originSeqNo = s;
+  }
+  /**
+   * \brief Get the origin sequence number
+   * \return the origin sequence number
+   */
+  uint32_t GetOriginSeqno () const
+  {
+    return m_originSeqNo;
+  }
+  /**
+   * \brief Set the first hop taken from the RREQ originator (AOMDV)
+   * \param a the first-hop address
+   */
+  void SetFirstHop (Ipv4Address a)
+  {
+    m_firstHop = a;
+  }
+  /**
+   * \brief Get the first hop taken from the RREQ originator (AOMDV)
+   * \return the first-hop address
+   */
+  Ipv4Address GetFirstHop () const
+  {
+    return m_firstHop;
+  }
+
+  // Flags
+  /**
+   * \brief Set the gratuitous RREP flag
+   * \param f the gratuitous RREP flag
+   */
+  void SetGratuitousRrep (bool f);
+  /**
+   * \brief Get the gratuitous RREP flag
+   * \return the gratuitous RREP flag
+   */
+  bool GetGratuitousRrep () const;
+  /**
+   * \brief Set the Destination only flag
+   * \param f the Destination only flag
+   */
+  void SetDestinationOnly (bool f);
+  /**
+   * \brief Get the Destination only flag
+   * \return the Destination only flag
+   */
+  bool GetDestinationOnly () const;
+  /**
+   * \brief Set the unknown sequence number flag
+   * \param f the unknown sequence number flag
+   */
+  void SetUnknownSeqno (bool f);
+  /**
+   * \brief Get the unknown sequence number flag
+   * \return the unknown sequence number flag
+   */
+  bool GetUnknownSeqno () const;
+  //\}
+
+  /**
+   * \brief Comparison operator
+   * \param o RREQ header to compare
+   * \return true if the RREQ headers are equal
+   */
+  bool operator== (RreqHeader const & o) const;
+private:
+  uint8_t        m_flags;          ///< |J|R|G|D|U| bit flags, see RFC
+  uint8_t        m_reserved;       ///< Not used (must be 0)
+  uint8_t        m_hopCount;       ///< Hop Count
+  uint32_t       m_requestID;      ///< RREQ ID
+  Ipv4Address    m_dst;            ///< Destination IP Address
+  uint32_t       m_dstSeqNo;       ///< Destination Sequence Number
+  Ipv4Address    m_origin;         ///< Originator IP Address
+  uint32_t       m_originSeqNo;    ///< Source Sequence Number
+  Ipv4Address    m_firstHop;
+};
+
+/**
+  * \brief Stream output operator
+  * \param os output stream
+  * \return updated stream
+  */
+std::ostream & operator<< (std::ostream & os, RreqHeader const &);
+
+/**
+* \ingroup aomdv
+* \brief Route Reply (RREP) Message Format
+  \verbatim
+  0                   1                   2                   3
+  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |     Type      |R|A|    Reserved     |Prefix Sz|   Hop Count   |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                     Destination IP address                    |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                  Destination Sequence Number                  |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                    Originator IP address                      |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |                           Lifetime                            |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  \endverbatim
+*/
+class RrepHeader : public Header
+{
+public:
+  /**
+   * constructor
+   *
+   * \param prefixSize the prefix size (0)
+   * \param hopCount the hop count (0)
+   * \param dst the destination IP address
+   * \param dstSeqNo the destination sequence number
+   * \param origin the origin IP address
+   * \param lifetime the lifetime
+   */
+  RrepHeader (uint8_t prefixSize = 0, uint8_t hopCount = 0, Ipv4Address dst =
+                Ipv4Address (), uint32_t dstSeqNo = 0, Ipv4Address origin =
+                Ipv4Address (), uint32_t requestID = 0,  Ipv4Address firstHop =
+                Ipv4Address (), Time lifetime = MilliSeconds (0));
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator start) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+  //\}
+
+  // Fields
+  /**
+   * \brief Set the hop count
+   * \param count the hop count
+   */
+  void SetHopCount (uint8_t count)
+  {
+    m_hopCount = count;
+  }
+  /**
+   * \brief Get the hop count
+   * \return the hop count
+   */
+  uint8_t GetHopCount () const
+  {
+    return m_hopCount;
+  }
+  /**
+   * \brief Set the destination address
+   * \param a the destination address
+   */
+  void SetDst (Ipv4Address a)
+  {
+    m_dst = a;
+  }
+  /**
+   * \brief Get the destination address
+   * \return the destination address
+   */
+  Ipv4Address GetDst () const
+  {
+    return m_dst;
+  }
+  /**
+   * \brief Set the destination sequence number
+   * \param s the destination sequence number
+   */
+  void SetDstSeqno (uint32_t s)
+  {
+    m_dstSeqNo = s;
+  }
+  /**
+   * \brief Get the destination sequence number
+   * \return the destination sequence number
+   */
+  uint32_t GetDstSeqno () const
+  {
+    return m_dstSeqNo;
+  }
+  /**
+   * \brief Set the origin address
+   * \param a the origin address
+   */
+  void SetOrigin (Ipv4Address a)
+  {
+    m_origin = a;
+  }
+  /**
+   * \brief Get the origin address
+   * \return the origin address
+   */
+  Ipv4Address GetOrigin () const
+  {
+    return m_origin;
+  }
+  /**
+   * \brief Set the RREQ ID this RREP answers (AOMDV)
+   * \param s the request ID
+   */
+  void SetRequestID (uint32_t s)
+  {
+    m_requestID = s;
+  }
+  /**
+   * \brief Get the RREQ ID this RREP answers (AOMDV)
+   * \return the request ID
+   */
+  uint32_t GetRequestID () const
+  {
+    return m_requestID;
+  }
+  /**
+   * \brief Set the first hop taken from the RREQ originator (AOMDV)
+   * \param a the first-hop address
+   */
+  void SetFirstHop (Ipv4Address a)
+  {
+    m_firstHop = a;
+  }
+  /**
+   * \brief Get the first hop taken from the RREQ originator (AOMDV)
+   * \return the first-hop address
+   */
+  Ipv4Address GetFirstHop () const
+  {
+    return m_firstHop;
+  }
+  /**
+   * \brief Set the lifetime
+   * \param t the lifetime
+   */
+  void SetLifeTime (Time t);
+  /**
+   * \brief Get the lifetime
+   * \return the lifetime
+   */
+  Time GetLifeTime () const;
+  //\}
+
+  // Flags
+  /**
+   * \brief Set the ack required flag
+   * \param f the ack required flag
+   */
+  void SetAckRequired (bool f);
+  /**
+   * \brief get the ack required flag
+   * \return the ack required flag
+   */
+  bool GetAckRequired () const;
+  /**
+   * \brief Set the prefix size
+   * \param sz the prefix size
+   */
+  void SetPrefixSize (uint8_t sz);
+  /**
+   * \brief Set the pefix size
+   * \return the prefix size
+   */
+  uint8_t GetPrefixSize () const;
+  //\}
+
+  /**
+   * Configure RREP to be a Hello message
+   *
+   * \param src the source IP address
+   * \param srcSeqNo the source sequence number
+   * \param lifetime the lifetime of the message
+   */
+  void SetHello (Ipv4Address src, uint32_t srcSeqNo, Time lifetime);
+
+  /**
+   * \brief Comparison operator
+   * \param o RREP header to compare
+   * \return true if the RREP headers are equal
+   */
+  bool operator== (RrepHeader const & o) const;
+private:
+  uint8_t       m_flags;                  ///< A - acknowledgment required flag
+  uint8_t       m_prefixSize;         ///< Prefix Size
+  uint8_t       m_hopCount;         ///< Hop Count
+  Ipv4Address   m_dst;              ///< Destination IP Address
+  uint32_t      m_dstSeqNo;         ///< Destination Sequence Number
+  Ipv4Address   m_origin;           ///< Source IP Address
+  uint32_t      m_requestID;
+  Ipv4Address   m_firstHop;
+  uint32_t      m_lifeTime;         ///< Lifetime (in milliseconds)
+};
+
+/**
+  * \brief Stream output operator
+  * \param os output stream
+  * \return updated stream
+  */
+std::ostream & operator<< (std::ostream & os, RrepHeader const &);
+
+/**
+* \ingroup aomdv
+* \brief Route Reply Acknowledgment (RREP-ACK) Message Format
+  \verbatim
+  0                   1
+  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |     Type      |   Reserved    |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  \endverbatim
+*/
+class RrepAckHeader : public Header
+{
+public:
+  /// constructor
+  RrepAckHeader ();
+
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator start) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+  //\}
+
+  /**
+   * \brief Comparison operator
+   * \param o RREP header to compare
+   * \return true if the RREQ headers are equal
+   */
+  bool operator== (RrepAckHeader const & o) const;
+private:
+  uint8_t       m_reserved; ///< Not used (must be 0)
+};
+
+/**
+  * \brief Stream output operator
+  * \param os output stream
+  * \return updated stream
+  */
+std::ostream & operator<< (std::ostream & os, RrepAckHeader const &);
+
+
+/**
+* \ingroup aomdv
+* \brief Route Error (RERR) Message Format
+  \verbatim
+  0                   1                   2                   3
+  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |     Type      |N|          Reserved           |   DestCount   |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |            Unreachable Destination IP Address (1)             |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |         Unreachable Destination Sequence Number (1)           |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+  |  Additional Unreachable Destination IP Addresses (if needed)  |
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  |Additional Unreachable Destination Sequence Numbers (if needed)|
+  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  \endverbatim
+*/
+class RerrHeader : public Header
+{
+public:
+  /// constructor
+  RerrHeader ();
+
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId ();
+  TypeId GetInstanceTypeId () const;
+  uint32_t GetSerializedSize () const;
+  void Serialize (Buffer::Iterator i) const;
+  uint32_t Deserialize (Buffer::Iterator start);
+  void Print (std::ostream &os) const;
+
+  // No delete flag
+  /**
+   * \brief Set the no delete flag
+   * \param f the no delete flag
+   */
+  void SetNoDelete (bool f);
+  /**
+   * \brief Get the no delete flag
+   * \return the no delete flag
+   */
+  bool GetNoDelete () const;
+
+  /**
+   * \brief Add unreachable node address and its sequence number in RERR header
+   * \param dst unreachable IPv4 address
+   * \param seqNo unreachable sequence number
+   * \return false if we already added maximum possible number of unreachable destinations
+   */
+  bool AddUnDestination (Ipv4Address dst, uint32_t seqNo);
+  /**
+   * \brief Delete pair (address + sequence number) from REER header, if the number of unreachable destinations > 0
+   * \param un unreachable pair (address + sequence number)
+   * \return true on success
+   */
+  bool RemoveUnDestination (std::pair<Ipv4Address, uint32_t> & un);
+  /// Clear header
+  void Clear ();
+  /**
+   * \returns number of unreachable destinations in RERR message
+   */
+  uint8_t GetDestCount () const
+  {
+    return (uint8_t)m_unreachableDstSeqNo.size ();
+  }
+
+  /**
+   * \brief Comparison operator
+   * \param o RERR header to compare
+   * \return true if the RERR headers are equal
+   */
+  bool operator== (RerrHeader const & o) const;
+private:
+  uint8_t m_flag;            ///< No delete flag
+  uint8_t m_reserved;        ///< Not used (must be 0)
+
+  /// List of Unreachable destination: IP addresses and sequence numbers
+  std::map<Ipv4Address, uint32_t> m_unreachableDstSeqNo;
+};
+
+/**
+  * \brief Stream output operator
+  * \param os output stream
+  * \return updated stream
+  */
+std::ostream & operator<< (std::ostream & os, RerrHeader const &);
+
+}  // namespace aomdv
+}  // namespace ns3
+
+#endif /* AOMDVPACKET_H */

--- a/ns3/aomdv/model/aomdv-routing-protocol.cc
+++ b/ns3/aomdv/model/aomdv-routing-protocol.cc
@@ -1,0 +1,2412 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#define NS_LOG_APPEND_CONTEXT                                   \
+  if (m_ipv4) { std::clog << "[node " << m_ipv4->GetObject<Node> ()->GetId () << "] "; }
+
+#include "aomdv-routing-protocol.h"
+#include "ns3/log.h"
+#include "ns3/boolean.h"
+#include "ns3/random-variable-stream.h"
+#include "ns3/inet-socket-address.h"
+#include "ns3/trace-source-accessor.h"
+#include "ns3/udp-socket-factory.h"
+#include "ns3/udp-l4-protocol.h"
+#include "ns3/udp-header.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/adhoc-wifi-mac.h"
+// WifiMacQueueItem was renamed to WifiMpdu (header wifi-mac-queue-item.h ->
+// wifi-mpdu.h) in ns-3.37; AOMDV_NS3_WIFI_QUEUE_ITEM is set by CMakeLists for
+// ns-3 <= 3.36 (same pattern as the anthocnet module).
+#ifdef AOMDV_NS3_WIFI_QUEUE_ITEM
+#include "ns3/wifi-mac-queue-item.h"
+#else
+#include "ns3/wifi-mpdu.h"
+#endif
+#include "ns3/string.h"
+#include "ns3/pointer.h"
+#include <algorithm>
+#include <limits>
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("AomdvRoutingProtocol");
+
+namespace aomdv {
+NS_OBJECT_ENSURE_REGISTERED (RoutingProtocol);
+
+/// UDP Port for AOMDV control traffic
+const uint32_t RoutingProtocol::AOMDV_PORT = 654;
+
+/**
+* \ingroup aomdv
+* \brief Tag used by AOMDV implementation
+*/
+class DeferredRouteOutputTag : public Tag
+{
+
+public:
+  /**
+   * \brief Constructor
+   * \param o the output interface
+   */
+  DeferredRouteOutputTag (int32_t o = -1) : Tag (),
+                                            m_oif (o)
+  {
+  }
+
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId ()
+  {
+    static TypeId tid = TypeId ("ns3::aomdv::DeferredRouteOutputTag")
+      .SetParent<Tag> ()
+      .SetGroupName ("Aomdv")
+      .AddConstructor<DeferredRouteOutputTag> ()
+    ;
+    return tid;
+  }
+
+  TypeId  GetInstanceTypeId () const
+  {
+    return GetTypeId ();
+  }
+
+  /**
+   * \brief Get the output interface
+   * \return the output interface
+   */
+  int32_t GetInterface () const
+  {
+    return m_oif;
+  }
+
+  /**
+   * \brief Set the output interface
+   * \param oif the output interface
+   */
+  void SetInterface (int32_t oif)
+  {
+    m_oif = oif;
+  }
+
+  uint32_t GetSerializedSize () const
+  {
+    return sizeof(int32_t);
+  }
+
+  void  Serialize (TagBuffer i) const
+  {
+    i.WriteU32 (m_oif);
+  }
+
+  void  Deserialize (TagBuffer i)
+  {
+    m_oif = i.ReadU32 ();
+  }
+
+  void  Print (std::ostream &os) const
+  {
+    os << "DeferredRouteOutputTag: output interface = " << m_oif;
+  }
+
+private:
+  /// Positive if output device is fixed in RouteOutput
+  int32_t m_oif;
+};
+
+NS_OBJECT_ENSURE_REGISTERED (DeferredRouteOutputTag);
+
+
+//-----------------------------------------------------------------------------
+RoutingProtocol::RoutingProtocol ()
+  : m_rreqRetries (2),
+    m_ttlStart (1),
+    m_ttlIncrement (2),
+    m_ttlThreshold (7),
+    m_timeoutBuffer (2),
+    m_rreqRateLimit (10),
+    m_rerrRateLimit (10),
+    m_activeRouteTimeout (Seconds (3)),
+    m_netDiameter (35),
+    m_nodeTraversalTime (MilliSeconds (40)),
+    m_netTraversalTime (Time ((2 * m_netDiameter) * m_nodeTraversalTime)),
+    m_pathDiscoveryTime ( Time (2 * m_netTraversalTime)),
+    m_myRouteTimeout (Time (2 * std::max (m_pathDiscoveryTime, m_activeRouteTimeout))),
+    m_helloInterval (Seconds (1)),
+    m_allowedHelloLoss (2),
+    m_deletePeriod (Time (5 * std::max (m_activeRouteTimeout, m_helloInterval))),
+    m_nextHopWait (m_nodeTraversalTime + MilliSeconds (10)),
+    m_blackListTimeout (Time (m_rreqRetries * m_netTraversalTime)),
+    m_maxQueueLen (64),
+    m_maxQueueTime (Seconds (30)),
+    m_destinationOnly (false),
+    m_gratuitousReply (true),
+    m_enableHello (false),
+    m_routingTable (m_deletePeriod),
+    m_queue (m_maxQueueLen, m_maxQueueTime),
+    m_requestId (0),
+    m_seqNo (0),
+    m_rreqIdCache (m_pathDiscoveryTime),
+    m_dpd (m_pathDiscoveryTime),
+    m_nb (m_helloInterval),
+    m_rreqCount (0),
+    m_rerrCount (0),
+    m_htimer (Timer::CANCEL_ON_DESTROY),
+    m_rreqRateLimitTimer (Timer::CANCEL_ON_DESTROY),
+    m_rerrRateLimitTimer (Timer::CANCEL_ON_DESTROY),
+    m_lastBcastTime (Seconds (0))
+{
+  m_nb.SetCallback (MakeCallback (&RoutingProtocol::SendRerrWhenBreaksLinkToNextHop, this));
+}
+
+TypeId
+RoutingProtocol::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::aomdv::RoutingProtocol")
+    .SetParent<Ipv4RoutingProtocol> ()
+    .SetGroupName ("Aomdv")
+    .AddConstructor<RoutingProtocol> ()
+    .AddAttribute ("HelloInterval", "HELLO messages emission interval.",
+                   TimeValue (Seconds (1)),
+                   MakeTimeAccessor (&RoutingProtocol::m_helloInterval),
+                   MakeTimeChecker ())
+    .AddAttribute ("RreqRetries", "Maximum number of retransmissions of RREQ to discover a route",
+                   UintegerValue (2),
+                   MakeUintegerAccessor (&RoutingProtocol::m_rreqRetries),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("RreqRateLimit", "Maximum number of RREQ per second.",
+                   UintegerValue (10),
+                   MakeUintegerAccessor (&RoutingProtocol::m_rreqRateLimit),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("RerrRateLimit", "Maximum number of RERR per second.",
+                   UintegerValue (10),
+                   MakeUintegerAccessor (&RoutingProtocol::m_rerrRateLimit),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("NodeTraversalTime", "Conservative estimate of the average one hop traversal time for packets and should include "
+                   "queuing delays, interrupt processing times and transfer times.",
+                   TimeValue (MilliSeconds (40)),
+                   MakeTimeAccessor (&RoutingProtocol::m_nodeTraversalTime),
+                   MakeTimeChecker ())
+    .AddAttribute ("NextHopWait", "Period of our waiting for the neighbour's RREP_ACK = 10 ms + NodeTraversalTime",
+                   TimeValue (MilliSeconds (50)),
+                   MakeTimeAccessor (&RoutingProtocol::m_nextHopWait),
+                   MakeTimeChecker ())
+    .AddAttribute ("ActiveRouteTimeout", "Period of time during which the route is considered to be valid",
+                   TimeValue (Seconds (3)),
+                   MakeTimeAccessor (&RoutingProtocol::m_activeRouteTimeout),
+                   MakeTimeChecker ())
+    .AddAttribute ("MyRouteTimeout", "Value of lifetime field in RREP generating by this node = 2 * max(ActiveRouteTimeout, PathDiscoveryTime)",
+                   TimeValue (Seconds (11.2)),
+                   MakeTimeAccessor (&RoutingProtocol::m_myRouteTimeout),
+                   MakeTimeChecker ())
+    .AddAttribute ("BlackListTimeout", "Time for which the node is put into the blacklist = RreqRetries * NetTraversalTime",
+                   TimeValue (Seconds (5.6)),
+                   MakeTimeAccessor (&RoutingProtocol::m_blackListTimeout),
+                   MakeTimeChecker ())
+    .AddAttribute ("DeletePeriod", "DeletePeriod is intended to provide an upper bound on the time for which an upstream node A "
+                   "can have a neighbor B as an active next hop for destination D, while B has invalidated the route to D."
+                   " = 5 * max (HelloInterval, ActiveRouteTimeout)",
+                   TimeValue (Seconds (15)),
+                   MakeTimeAccessor (&RoutingProtocol::m_deletePeriod),
+                   MakeTimeChecker ())
+    .AddAttribute ("NetDiameter", "Net diameter measures the maximum possible number of hops between two nodes in the network",
+                   UintegerValue (35),
+                   MakeUintegerAccessor (&RoutingProtocol::m_netDiameter),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("NetTraversalTime", "Estimate of the average net traversal time = 2 * NodeTraversalTime * NetDiameter",
+                   TimeValue (Seconds (2.8)),
+                   MakeTimeAccessor (&RoutingProtocol::m_netTraversalTime),
+                   MakeTimeChecker ())
+    .AddAttribute ("PathDiscoveryTime", "Estimate of maximum time needed to find route in network = 2 * NetTraversalTime",
+                   TimeValue (Seconds (5.6)),
+                   MakeTimeAccessor (&RoutingProtocol::m_pathDiscoveryTime),
+                   MakeTimeChecker ())
+    .AddAttribute ("MaxQueueLen", "Maximum number of packets that we allow a routing protocol to buffer.",
+                   UintegerValue (64),
+                   MakeUintegerAccessor (&RoutingProtocol::SetMaxQueueLen,
+                                         &RoutingProtocol::GetMaxQueueLen),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("MaxQueueTime", "Maximum time packets can be queued (in seconds)",
+                   TimeValue (Seconds (30)),
+                   MakeTimeAccessor (&RoutingProtocol::SetMaxQueueTime,
+                                     &RoutingProtocol::GetMaxQueueTime),
+                   MakeTimeChecker ())
+    .AddAttribute ("AllowedHelloLoss", "Number of hello messages which may be loss for valid link.",
+                   UintegerValue (2),
+                   MakeUintegerAccessor (&RoutingProtocol::m_allowedHelloLoss),
+                   MakeUintegerChecker<uint16_t> ())
+    .AddAttribute ("GratuitousReply", "Indicates whether a gratuitous RREP should be unicast to the node originated route discovery.",
+                   BooleanValue (true),
+                   MakeBooleanAccessor (&RoutingProtocol::SetGratuitousReplyFlag,
+                                        &RoutingProtocol::GetGratuitousReplyFlag),
+                   MakeBooleanChecker ())
+    .AddAttribute ("DestinationOnly", "Indicates only the destination may respond to this RREQ.",
+                   BooleanValue (false),
+                   MakeBooleanAccessor (&RoutingProtocol::SetDestinationOnlyFlag,
+                                        &RoutingProtocol::GetDestinationOnlyFlag),
+                   MakeBooleanChecker ())
+    .AddAttribute ("EnableHello", "Indicates whether a hello messages enable.",
+                   BooleanValue (true),
+                   MakeBooleanAccessor (&RoutingProtocol::SetHelloEnable,
+                                        &RoutingProtocol::GetHelloEnable),
+                   MakeBooleanChecker ())
+    .AddAttribute ("EnableBroadcast", "Indicates whether a broadcast data packets forwarding enable.",
+                   BooleanValue (true),
+                   MakeBooleanAccessor (&RoutingProtocol::SetBroadcastEnable,
+                                        &RoutingProtocol::GetBroadcastEnable),
+                   MakeBooleanChecker ())
+    .AddAttribute ("UniformRv",
+                   "Access to the underlying UniformRandomVariable",
+                   StringValue ("ns3::UniformRandomVariable"),
+                   MakePointerAccessor (&RoutingProtocol::m_uniformRandomVariable),
+                   MakePointerChecker<UniformRandomVariable> ())
+  ;
+  return tid;
+}
+
+void
+RoutingProtocol::SetMaxQueueLen (uint32_t len)
+{
+  m_maxQueueLen = len;
+  m_queue.SetMaxQueueLen (len);
+}
+void
+RoutingProtocol::SetMaxQueueTime (Time t)
+{
+  m_maxQueueTime = t;
+  m_queue.SetQueueTimeout (t);
+}
+
+RoutingProtocol::~RoutingProtocol ()
+{
+}
+
+void
+RoutingProtocol::DoDispose ()
+{
+  m_ipv4 = 0;
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::iterator iter =
+         m_socketAddresses.begin (); iter != m_socketAddresses.end (); iter++)
+    {
+      iter->first->Close ();
+    }
+  m_socketAddresses.clear ();
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::iterator iter =
+         m_socketSubnetBroadcastAddresses.begin (); iter != m_socketSubnetBroadcastAddresses.end (); iter++)
+    {
+      iter->first->Close ();
+    }
+  m_socketSubnetBroadcastAddresses.clear ();
+  Ipv4RoutingProtocol::DoDispose ();
+}
+
+void
+RoutingProtocol::PrintRoutingTable (Ptr<OutputStreamWrapper> stream, Time::Unit unit) const
+{
+  *stream->GetStream () << "Node: " << m_ipv4->GetObject<Node> ()->GetId ()
+                        << "; Time: " << Now ().As (unit)
+                        << ", Local time: " << m_ipv4->GetObject<Node> ()->GetLocalTime ().As (unit)
+                        << ", AOMDV Routing table" << std::endl;
+
+  m_routingTable.Print (stream, unit);
+  *stream->GetStream () << std::endl;
+}
+
+int64_t
+RoutingProtocol::AssignStreams (int64_t stream)
+{
+  NS_LOG_FUNCTION (this << stream);
+  m_uniformRandomVariable->SetStream (stream);
+  return 1;
+}
+
+void
+RoutingProtocol::Start ()
+{
+  NS_LOG_FUNCTION (this);
+  if (m_enableHello)
+    {
+      m_nb.ScheduleTimer ();
+    }
+  m_rreqRateLimitTimer.SetFunction (&RoutingProtocol::RreqRateLimitTimerExpire,
+                                    this);
+  m_rreqRateLimitTimer.Schedule (Seconds (1));
+
+  m_rerrRateLimitTimer.SetFunction (&RoutingProtocol::RerrRateLimitTimerExpire,
+                                    this);
+  m_rerrRateLimitTimer.Schedule (Seconds (1));
+
+}
+
+Ptr<Ipv4Route>
+RoutingProtocol::RouteOutput (Ptr<Packet> p, const Ipv4Header &header,
+                              Ptr<NetDevice> oif, Socket::SocketErrno &sockerr)
+{
+  NS_LOG_FUNCTION (this << header << (oif ? oif->GetIfIndex () : 0));
+  if (!p)
+    {
+      NS_LOG_DEBUG ("Packet is == 0");
+      return LoopbackRoute (header, oif); // later
+    }
+  if (m_socketAddresses.empty ())
+    {
+      sockerr = Socket::ERROR_NOROUTETOHOST;
+      NS_LOG_LOGIC ("No aomdv interfaces");
+      Ptr<Ipv4Route> route;
+      return route;
+    }
+  sockerr = Socket::ERROR_NOTERROR;
+  Ptr<Ipv4Route> route;
+  Ipv4Address dst = header.GetDestination ();
+  RoutingTableEntry rt;
+  if (m_routingTable.LookupValidRoute (dst, rt))
+    {
+      RoutingTableEntry::Path *path = rt.PathFind ();
+      route = path->GetRoute ();
+      NS_ASSERT (route);
+      NS_LOG_DEBUG ("Exist route to " << route->GetDestination () << " from interface " << route->GetSource ());
+      if (oif && route->GetOutputDevice () != oif)
+        {
+          NS_LOG_DEBUG ("Output device doesn't match. Dropped.");
+          sockerr = Socket::ERROR_NOROUTETOHOST;
+          return Ptr<Ipv4Route> ();
+        }
+      UpdateRouteLifeTime (dst, m_activeRouteTimeout);
+      UpdatePathsLifeTime (route->GetGateway (), m_activeRouteTimeout);
+      path->SetExpire (std::max (m_activeRouteTimeout, path->GetExpire ()));
+      return route;
+    }
+
+  // Valid route not found, in this case we return loopback.
+  // Actual route request will be deferred until packet will be fully formed,
+  // routed to loopback, received from loopback and passed to RouteInput (see below)
+  uint32_t iif = (oif ? m_ipv4->GetInterfaceForDevice (oif) : -1);
+  DeferredRouteOutputTag tag (iif);
+  NS_LOG_DEBUG ("Valid Route not found");
+  if (!p->PeekPacketTag (tag))
+    {
+      p->AddPacketTag (tag);
+    }
+  return LoopbackRoute (header, oif);
+}
+
+void
+RoutingProtocol::DeferredRouteOutput (Ptr<const Packet> p, const Ipv4Header & header,
+                                      UnicastForwardCallback ucb, ErrorCallback ecb)
+{
+  NS_LOG_FUNCTION (this << p << header);
+  NS_ASSERT (p && p != Ptr<Packet> ());
+
+  QueueEntry newEntry (p, header, ucb, ecb);
+  bool result = m_queue.Enqueue (newEntry);
+  if (result)
+    {
+      NS_LOG_LOGIC ("Add packet " << p->GetUid () << " to queue. Protocol " << (uint16_t) header.GetProtocol ());
+      RoutingTableEntry rt;
+      bool result = m_routingTable.LookupRoute (header.GetDestination (), rt);
+      if (!result || ((rt.GetFlag () != IN_SEARCH) && result))
+        {
+          NS_LOG_LOGIC ("Send new RREQ for outbound packet to " << header.GetDestination ());
+          SendRequest (header.GetDestination ());
+        }
+    }
+}
+
+bool
+RoutingProtocol::RouteInput (Ptr<const Packet> p, const Ipv4Header &header,
+                             Ptr<const NetDevice> idev, AOMDV_RI_CB (UnicastForwardCallback) ucb,
+                             AOMDV_RI_CB (MulticastForwardCallback) mcb, AOMDV_RI_CB (LocalDeliverCallback) lcb,
+                             AOMDV_RI_CB (ErrorCallback) ecb)
+{
+  NS_LOG_FUNCTION (this << p->GetUid () << header.GetDestination () << idev->GetAddress ());
+  if (m_socketAddresses.empty ())
+    {
+      NS_LOG_LOGIC ("No aomdv interfaces");
+      return false;
+    }
+  NS_ASSERT (m_ipv4);
+  NS_ASSERT (p);
+  // Check if input device supports IP
+  NS_ASSERT (m_ipv4->GetInterfaceForDevice (idev) >= 0);
+  int32_t iif = m_ipv4->GetInterfaceForDevice (idev);
+
+  Ipv4Address dst = header.GetDestination ();
+  Ipv4Address origin = header.GetSource ();
+
+  // Deferred route request
+  if (idev == m_lo)
+    {
+      DeferredRouteOutputTag tag;
+      if (p->PeekPacketTag (tag))
+        {
+          DeferredRouteOutput (p, header, ucb, ecb);
+          return true;
+        }
+    }
+
+  // Duplicate of own packet
+  if (IsMyOwnAddress (origin))
+    {
+      return true;
+    }
+
+  // AOMDV is not a multicast routing protocol
+  if (dst.IsMulticast ())
+    {
+      return false;
+    }
+
+  // Broadcast local delivery/forwarding
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+         m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ipv4InterfaceAddress iface = j->second;
+      if (m_ipv4->GetInterfaceForAddress (iface.GetLocal ()) == iif)
+        {
+          if (dst == iface.GetBroadcast () || dst.IsBroadcast ())
+            {
+              if (m_dpd.IsDuplicate (p, header))
+                {
+                  NS_LOG_DEBUG ("Duplicated packet " << p->GetUid () << " from " << origin << ". Drop.");
+                  return true;
+                }
+              UpdatePathsLifeTime (origin, m_activeRouteTimeout);
+              Ptr<Packet> packet = p->Copy ();
+              if (lcb.IsNull () == false)
+                {
+                  NS_LOG_LOGIC ("Broadcast local delivery to " << iface.GetLocal ());
+                  lcb (p, header, iif);
+                  // Fall through to additional processing
+                }
+              else
+                {
+                  NS_LOG_ERROR ("Unable to deliver packet locally due to null callback " << p->GetUid () << " from " << origin);
+                  ecb (p, header, Socket::ERROR_NOROUTETOHOST);
+                }
+              if (!m_enableBroadcast)
+                {
+                  return true;
+                }
+              if (header.GetProtocol () == UdpL4Protocol::PROT_NUMBER)
+                {
+                  UdpHeader udpHeader;
+                  p->PeekHeader (udpHeader);
+                  if (udpHeader.GetDestinationPort () == AOMDV_PORT)
+                    {
+                      // AOMDV packets sent in broadcast are already managed
+                      return true;
+                    }
+                }
+              if (header.GetTtl () > 1)
+                {
+                  NS_LOG_LOGIC ("Forward broadcast. TTL " << (uint16_t) header.GetTtl ());
+                  RoutingTableEntry toBroadcast;
+                  if (m_routingTable.LookupRoute (dst, toBroadcast))
+                    {
+                      RoutingTableEntry::Path *path = toBroadcast.PathFind ();
+                      Ptr<Ipv4Route> route = path->GetRoute ();
+                      ucb (route, packet, header);
+                    }
+                  else
+                    {
+                      NS_LOG_DEBUG ("No route to forward broadcast. Drop packet " << p->GetUid ());
+                    }
+                }
+              else
+                {
+                  NS_LOG_DEBUG ("TTL exceeded. Drop packet " << p->GetUid ());
+                }
+              return true;
+            }
+        }
+    }
+
+  // Unicast local delivery
+  if (m_ipv4->IsDestinationAddress (dst, iif))
+    {
+      UpdatePathsLifeTime (origin, m_activeRouteTimeout);
+      RoutingTableEntry toOrigin;
+      if (m_routingTable.LookupValidRoute (origin, toOrigin))
+        {
+          UpdatePathsLifeTime (toOrigin.PathFind ()->GetNextHop (), m_activeRouteTimeout);
+          m_nb.Update (toOrigin.PathFind ()->GetNextHop (), m_activeRouteTimeout);
+        }
+      if (lcb.IsNull () == false)
+        {
+          NS_LOG_LOGIC ("Unicast local delivery to " << dst);
+          lcb (p, header, iif);
+        }
+      else
+        {
+          NS_LOG_ERROR ("Unable to deliver packet locally due to null callback " << p->GetUid () << " from " << origin);
+          ecb (p, header, Socket::ERROR_NOROUTETOHOST);
+        }
+      return true;
+    }
+
+  // Forwarding
+  return Forwarding (p, header, ucb, ecb);
+}
+
+bool
+RoutingProtocol::Forwarding (Ptr<const Packet> p, const Ipv4Header & header,
+                             UnicastForwardCallback ucb, ErrorCallback ecb)
+{
+  NS_LOG_FUNCTION (this);
+  Ipv4Address dst = header.GetDestination ();
+  Ipv4Address origin = header.GetSource ();
+  m_routingTable.Purge ();
+  RoutingTableEntry toDst;
+  if (m_routingTable.LookupRoute (dst, toDst))
+    {
+      if (toDst.GetFlag () == VALID)
+        {
+          RoutingTableEntry::Path *path = toDst.PathFind ();
+          Ptr<Ipv4Route> route = path->GetRoute ();
+          NS_LOG_LOGIC (route->GetSource ()<<" forwarding to " << dst << " from " << origin << " packet " << p->GetUid ());
+
+          /*
+           *  Each time a route is used to forward a data packet, its Active Route
+           *  Lifetime field of the source, destination and the next hop on the
+           *  path to the destination is updated to be no less than the current
+           *  time plus ActiveRouteTimeout.
+           */
+          UpdatePathsLifeTime (origin, m_activeRouteTimeout);
+          UpdateRouteLifeTime (dst, m_activeRouteTimeout);
+          path->SetExpire (std::max (m_activeRouteTimeout, path->GetExpire ()));
+          UpdatePathsLifeTime (route->GetGateway (), m_activeRouteTimeout);
+          /*
+           *  Since the route between each originator and destination pair is expected to be symmetric, the
+           *  Active Route Lifetime for the previous hop, along the reverse path back to the IP source, is also updated
+           *  to be no less than the current time plus ActiveRouteTimeout
+           */
+          RoutingTableEntry toOrigin;
+          m_routingTable.LookupRoute (origin, toOrigin);
+          UpdatePathsLifeTime (toOrigin.PathFind ()->GetNextHop (), m_activeRouteTimeout);
+
+          m_nb.Update (route->GetGateway (), m_activeRouteTimeout);
+          m_nb.Update (toOrigin.PathFind ()->GetNextHop (), m_activeRouteTimeout);
+
+          ucb (route, p, header);
+          return true;
+        }
+      else
+        {
+          if (toDst.GetValidSeqNo ())
+            {
+              SendRerrWhenNoRouteToForward (dst, toDst.GetSeqNo (), origin);
+              NS_LOG_DEBUG ("Drop packet " << p->GetUid () << " because no route to forward it.");
+              return false;
+            }
+        }
+    }
+  NS_LOG_LOGIC ("route not found to " << dst << ". Send RERR message.");
+  NS_LOG_DEBUG ("Drop packet " << p->GetUid () << " because no route to forward it.");
+  SendRerrWhenNoRouteToForward (dst, 0, origin);
+  return false;
+}
+
+void
+RoutingProtocol::SetIpv4 (Ptr<Ipv4> ipv4)
+{
+  NS_ASSERT (ipv4);
+  NS_ASSERT (!m_ipv4);
+
+  m_ipv4 = ipv4;
+
+  // Create lo route. It is asserted that the only one interface up for now is loopback
+  NS_ASSERT (m_ipv4->GetNInterfaces () == 1 && m_ipv4->GetAddress (0, 0).GetLocal () == Ipv4Address ("127.0.0.1"));
+  m_lo = m_ipv4->GetNetDevice (0);
+  NS_ASSERT (m_lo);
+  // Remember lo route
+  RoutingTableEntry rt (/*dst=*/ Ipv4Address::GetLoopback (), /*validSeqNo=*/ true, /*seqno=*/ 0, 
+                              /*lifeTime=*/ Simulator::GetMaximumSimulationTime ());
+  // Vendoring fix (#296): insert the path before handing the entry to the
+  // table — AddRoute stores a copy, so the fork's insert-after-AddRoute left
+  // every table entry pathless. See ns3/aomdv/README.md.
+  rt.PathInsert (/*device=*/ m_lo, /*nextHop=*/ Ipv4Address::GetLoopback (), /*hop=*/ 1, 
+                 /*expireTime=*/ Simulator::GetMaximumSimulationTime (), 
+                 /*lastHop=*/ Ipv4Address::GetLoopback (), 
+                 /*iface=*/ Ipv4InterfaceAddress (Ipv4Address::GetLoopback (), Ipv4Mask ("255.0.0.0")));
+  m_routingTable.AddRoute (rt);
+
+  Simulator::ScheduleNow (&RoutingProtocol::Start, this);
+}
+
+void
+RoutingProtocol::NotifyInterfaceUp (uint32_t i)
+{
+  NS_LOG_FUNCTION (this << m_ipv4->GetAddress (i, 0).GetLocal ());
+  Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+  if (l3->GetNAddresses (i) > 1)
+    {
+      NS_LOG_WARN ("AOMDV does not work with more then one address per each interface.");
+    }
+  Ipv4InterfaceAddress iface = l3->GetAddress (i, 0);
+  if (iface.GetLocal () == Ipv4Address ("127.0.0.1"))
+    {
+      return;
+    }
+
+  // Create a socket to listen only on this interface
+  Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
+                                             UdpSocketFactory::GetTypeId ());
+  NS_ASSERT (socket);
+  socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvAomdv, this));
+  socket->BindToNetDevice (l3->GetNetDevice (i));
+  socket->Bind (InetSocketAddress (iface.GetLocal (), AOMDV_PORT));
+  socket->SetAllowBroadcast (true);
+  socket->SetIpRecvTtl (true);
+  m_socketAddresses.insert (std::make_pair (socket, iface));
+
+  // create also a subnet broadcast socket
+  socket = Socket::CreateSocket (GetObject<Node> (),
+                                 UdpSocketFactory::GetTypeId ());
+  NS_ASSERT (socket);
+  socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvAomdv, this));
+  socket->BindToNetDevice (l3->GetNetDevice (i));
+  socket->Bind (InetSocketAddress (iface.GetBroadcast (), AOMDV_PORT));
+  socket->SetAllowBroadcast (true);
+  socket->SetIpRecvTtl (true);
+  m_socketSubnetBroadcastAddresses.insert (std::make_pair (socket, iface));
+
+  // Add local broadcast record to the routing table
+  Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (iface.GetLocal ()));
+  RoutingTableEntry rt (/*dst=*/ iface.GetBroadcast (), /*validSeqNo=*/ true, /*seqno=*/ 0, 
+                              /*lifeTime=*/ Simulator::GetMaximumSimulationTime ());
+  // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+  rt.PathInsert (/*device=*/ dev, /*nextHop=*/ iface.GetBroadcast (), /*hop=*/ 1, 
+                 /*expireTime=*/ Simulator::GetMaximumSimulationTime (), 
+                 /*lastHop=*/ iface.GetBroadcast (), 
+                 /*iface=*/ iface);
+  m_routingTable.AddRoute (rt);
+
+  if (l3->GetInterface (i)->GetArpCache ())
+    {
+      m_nb.AddArpCache (l3->GetInterface (i)->GetArpCache ());
+    }
+
+  // Allow neighbor manager use this interface for layer 2 feedback if possible
+  Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
+  if (!wifi)
+    {
+      return;
+    }
+  Ptr<WifiMac> mac = wifi->GetMac ();
+  if (!mac)
+    {
+      return;
+    }
+
+  mac->TraceConnectWithoutContext ("DroppedMpdu", MakeCallback (&RoutingProtocol::NotifyTxError, this));
+}
+
+void
+RoutingProtocol::NotifyTxError (WifiMacDropReason reason, Ptr<const AOMDV_WIFI_MPDU> mpdu)
+{
+  m_nb.GetTxErrorCallback ()(mpdu->GetHeader ());
+}
+
+void
+RoutingProtocol::NotifyInterfaceDown (uint32_t i)
+{
+  NS_LOG_FUNCTION (this << m_ipv4->GetAddress (i, 0).GetLocal ());
+
+  // Disable layer 2 link state monitoring (if possible)
+  Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+  Ptr<NetDevice> dev = l3->GetNetDevice (i);
+  Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
+  if (wifi)
+    {
+      Ptr<WifiMac> mac = wifi->GetMac ()->GetObject<AdhocWifiMac> ();
+      if (mac)
+        {
+          mac->TraceDisconnectWithoutContext ("DroppedMpdu",
+                                              MakeCallback (&RoutingProtocol::NotifyTxError, this));
+          m_nb.DelArpCache (l3->GetInterface (i)->GetArpCache ());
+        }
+    }
+
+  // Close socket
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (m_ipv4->GetAddress (i, 0));
+  NS_ASSERT (socket);
+  socket->Close ();
+  m_socketAddresses.erase (socket);
+
+  // Close socket
+  socket = FindSubnetBroadcastSocketWithInterfaceAddress (m_ipv4->GetAddress (i, 0));
+  NS_ASSERT (socket);
+  socket->Close ();
+  m_socketSubnetBroadcastAddresses.erase (socket);
+
+  if (m_socketAddresses.empty ())
+    {
+      NS_LOG_LOGIC ("No aomdv interfaces");
+      m_htimer.Cancel ();
+      m_nb.Clear ();
+      m_routingTable.Clear ();
+      return;
+    }
+  m_routingTable.DeleteAllRoutesFromInterface (m_ipv4->GetAddress (i, 0));
+}
+
+void
+RoutingProtocol::NotifyAddAddress (uint32_t i, Ipv4InterfaceAddress address)
+{
+  NS_LOG_FUNCTION (this << " interface " << i << " address " << address);
+  Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+  if (!l3->IsUp (i))
+    {
+      return;
+    }
+  if (l3->GetNAddresses (i) == 1)
+    {
+      Ipv4InterfaceAddress iface = l3->GetAddress (i, 0);
+      Ptr<Socket> socket = FindSocketWithInterfaceAddress (iface);
+      if (!socket)
+        {
+          if (iface.GetLocal () == Ipv4Address ("127.0.0.1"))
+            {
+              return;
+            }
+          // Create a socket to listen only on this interface
+          Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
+                                                     UdpSocketFactory::GetTypeId ());
+          NS_ASSERT (socket);
+          socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvAomdv,this));
+          socket->BindToNetDevice (l3->GetNetDevice (i));
+          socket->Bind (InetSocketAddress (iface.GetLocal (), AOMDV_PORT));
+          socket->SetAllowBroadcast (true);
+          m_socketAddresses.insert (std::make_pair (socket, iface));
+
+          // create also a subnet directed broadcast socket
+          socket = Socket::CreateSocket (GetObject<Node> (),
+                                         UdpSocketFactory::GetTypeId ());
+          NS_ASSERT (socket);
+          socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvAomdv, this));
+          socket->BindToNetDevice (l3->GetNetDevice (i));
+          socket->Bind (InetSocketAddress (iface.GetBroadcast (), AOMDV_PORT));
+          socket->SetAllowBroadcast (true);
+          socket->SetIpRecvTtl (true);
+          m_socketSubnetBroadcastAddresses.insert (std::make_pair (socket, iface));
+
+          // Add local broadcast record to the routing table
+          Ptr<NetDevice> dev = m_ipv4->GetNetDevice (
+              m_ipv4->GetInterfaceForAddress (iface.GetLocal ()));
+          RoutingTableEntry rt (/*dst=*/ iface.GetBroadcast (), /*validSeqNo=*/ true, /*seqno=*/ 0, 
+                              /*lifeTime=*/ Simulator::GetMaximumSimulationTime ());
+          // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+          rt.PathInsert (/*device=*/ dev, /*nextHop=*/ iface.GetBroadcast (), /*hop=*/ 1, 
+                         /*expireTime=*/ Simulator::GetMaximumSimulationTime (), 
+                         /*lastHop=*/ iface.GetBroadcast (), 
+                         /*iface=*/ iface);
+          m_routingTable.AddRoute (rt);
+        }
+    }
+  else
+    {
+      NS_LOG_LOGIC ("AOMDV does not work with more then one address per each interface. Ignore added address");
+    }
+}
+
+void
+RoutingProtocol::NotifyRemoveAddress (uint32_t i, Ipv4InterfaceAddress address)
+{
+  NS_LOG_FUNCTION (this);
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (address);
+  if (socket)
+    {
+      m_routingTable.DeleteAllRoutesFromInterface (address);
+      socket->Close ();
+      m_socketAddresses.erase (socket);
+
+      Ptr<Socket> unicastSocket = FindSubnetBroadcastSocketWithInterfaceAddress (address);
+      if (unicastSocket)
+        {
+          unicastSocket->Close ();
+          m_socketAddresses.erase (unicastSocket);
+        }
+
+      Ptr<Ipv4L3Protocol> l3 = m_ipv4->GetObject<Ipv4L3Protocol> ();
+      if (l3->GetNAddresses (i))
+        {
+          Ipv4InterfaceAddress iface = l3->GetAddress (i, 0);
+          // Create a socket to listen only on this interface
+          Ptr<Socket> socket = Socket::CreateSocket (GetObject<Node> (),
+                                                     UdpSocketFactory::GetTypeId ());
+          NS_ASSERT (socket);
+          socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvAomdv, this));
+          // Bind to any IP address so that broadcasts can be received
+          socket->BindToNetDevice (l3->GetNetDevice (i));
+          socket->Bind (InetSocketAddress (iface.GetLocal (), AOMDV_PORT));
+          socket->SetAllowBroadcast (true);
+          socket->SetIpRecvTtl (true);
+          m_socketAddresses.insert (std::make_pair (socket, iface));
+
+          // create also a unicast socket
+          socket = Socket::CreateSocket (GetObject<Node> (),
+                                         UdpSocketFactory::GetTypeId ());
+          NS_ASSERT (socket);
+          socket->SetRecvCallback (MakeCallback (&RoutingProtocol::RecvAomdv, this));
+          socket->BindToNetDevice (l3->GetNetDevice (i));
+          socket->Bind (InetSocketAddress (iface.GetBroadcast (), AOMDV_PORT));
+          socket->SetAllowBroadcast (true);
+          socket->SetIpRecvTtl (true);
+          m_socketSubnetBroadcastAddresses.insert (std::make_pair (socket, iface));
+
+          // Add local broadcast record to the routing table
+          Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (iface.GetLocal ()));
+          RoutingTableEntry rt (/*dst=*/ iface.GetBroadcast (), /*validSeqNo=*/ true, /*seqno=*/ 0, 
+                              /*lifeTime=*/ Simulator::GetMaximumSimulationTime ());
+          // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+          rt.PathInsert (/*device=*/ dev, /*nextHop=*/ iface.GetBroadcast (), /*hop=*/ 1, 
+                         /*expireTime=*/ Simulator::GetMaximumSimulationTime (), 
+                         /*lastHop=*/ iface.GetBroadcast (), 
+                         /*iface=*/ iface);
+          m_routingTable.AddRoute (rt);
+        }
+      if (m_socketAddresses.empty ())
+        {
+          NS_LOG_LOGIC ("No aomdv interfaces");
+          m_htimer.Cancel ();
+          m_nb.Clear ();
+          m_routingTable.Clear ();
+          return;
+        }
+    }
+  else
+    {
+      NS_LOG_LOGIC ("Remove address not participating in AOMDV operation");
+    }
+}
+
+bool
+RoutingProtocol::IsMyOwnAddress (Ipv4Address src)
+{
+  NS_LOG_FUNCTION (this << src);
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+         m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ipv4InterfaceAddress iface = j->second;
+      if (src == iface.GetLocal ())
+        {
+          return true;
+        }
+    }
+  return false;
+}
+
+Ptr<Ipv4Route>
+RoutingProtocol::LoopbackRoute (const Ipv4Header & hdr, Ptr<NetDevice> oif) const
+{
+  NS_LOG_FUNCTION (this << hdr);
+  NS_ASSERT (m_lo);
+  Ptr<Ipv4Route> rt = Create<Ipv4Route> ();
+  rt->SetDestination (hdr.GetDestination ());
+  //
+  // Source address selection here is tricky.  The loopback route is
+  // returned when AOMDV does not have a route; this causes the packet
+  // to be looped back and handled (cached) in RouteInput() method
+  // while a route is found. However, connection-oriented protocols
+  // like TCP need to create an endpoint four-tuple (src, src port,
+  // dst, dst port) and create a pseudo-header for checksumming.  So,
+  // AOMDV needs to guess correctly what the eventual source address
+  // will be.
+  //
+  // For single interface, single address nodes, this is not a problem.
+  // When there are possibly multiple outgoing interfaces, the policy
+  // implemented here is to pick the first available AOMDV interface.
+  // If RouteOutput() caller specified an outgoing interface, that
+  // further constrains the selection of source address
+  //
+  std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j = m_socketAddresses.begin ();
+  if (oif)
+    {
+      // Iterate to find an address on the oif device
+      for (j = m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+        {
+          Ipv4Address addr = j->second.GetLocal ();
+          int32_t interface = m_ipv4->GetInterfaceForAddress (addr);
+          if (oif == m_ipv4->GetNetDevice (static_cast<uint32_t> (interface)))
+            {
+              rt->SetSource (addr);
+              break;
+            }
+        }
+    }
+  else
+    {
+      rt->SetSource (j->second.GetLocal ());
+    }
+  NS_ASSERT_MSG (rt->GetSource () != Ipv4Address (), "Valid AOMDV source address not found");
+  rt->SetGateway (Ipv4Address ("127.0.0.1"));
+  rt->SetOutputDevice (m_lo);
+  return rt;
+}
+
+void
+RoutingProtocol::SendRequest (Ipv4Address dst)
+{
+  NS_LOG_FUNCTION ( this << dst);
+  // A node SHOULD NOT originate more than RREQ_RATELIMIT RREQ messages per second.
+  if (m_rreqCount == m_rreqRateLimit)
+    {
+      Simulator::Schedule (m_rreqRateLimitTimer.GetDelayLeft () + MicroSeconds (100),
+                           &RoutingProtocol::SendRequest, this, dst);
+      return;
+    }
+  else
+    {
+      m_rreqCount++;
+    }
+  // Create RREQ header
+  RreqHeader rreqHeader;
+  rreqHeader.SetDst (dst);
+
+  RoutingTableEntry rt;
+  // Using the Hop field in Routing Table to manage the expanding ring search
+  uint16_t ttl = m_ttlStart;
+  if (m_routingTable.LookupRoute (dst, rt))
+    {
+      if (rt.GetFlag () != IN_SEARCH)
+        {
+          ttl = std::min<uint16_t> (rt.GetLastHopCount () + m_ttlIncrement, m_netDiameter);
+        }
+      else
+        {
+          ttl = rt.GetLastHopCount () + m_ttlIncrement;
+          if (ttl > m_ttlThreshold)
+            {
+              ttl = m_netDiameter;
+            }
+        }
+      if (ttl == m_netDiameter)
+        {
+          rt.IncrementRreqCnt ();
+        }
+      if (rt.GetValidSeqNo ())
+        {
+          rreqHeader.SetDstSeqno (rt.GetSeqNo ());
+        }
+      else
+        {
+          rreqHeader.SetUnknownSeqno (true);
+        }
+      rt.SetLastHopCount (ttl);
+      rt.SetFlag (IN_SEARCH);
+      rt.SetLifeTime (m_pathDiscoveryTime);
+      m_routingTable.Update (rt);
+    }
+  else
+    {
+      rreqHeader.SetUnknownSeqno (true);
+      Ptr<NetDevice> dev = 0;
+      RoutingTableEntry newEntry (/*dst=*/ dst, /*validSeqNo=*/ false, /*seqno=*/ 0, /*lifeTime=*/ m_pathDiscoveryTime);
+      // Vendoring fix (#296): stock aodv passes /*hop=*/ ttl to this ctor; the
+      // fork's AOMDV ctor has no hop parameter, so m_lastHopCount stayed at
+      // its INFINITY2 default and the expanding-ring search read it back as
+      // "already at NetDiameter" — ScheduleRreqRetry then took the backoff
+      // branch and tripped stock's NS_ABORT_MSG_UNLESS (GetRreqCnt () > 0) on
+      // the very first route discovery. Mirrors the SetLastHopCount (ttl) the
+      // existing-entry branch above already does.
+      newEntry.SetLastHopCount (ttl);
+      // Check if TtlStart == NetDiameter
+      if (ttl == m_netDiameter)
+        {
+          newEntry.IncrementRreqCnt ();
+        }
+      newEntry.SetFlag (IN_SEARCH);
+      m_routingTable.AddRoute (newEntry);
+    }
+  if (m_gratuitousReply)
+    {
+      rreqHeader.SetGratuitousRrep (true);
+    }
+  if (m_destinationOnly)
+    {
+      rreqHeader.SetDestinationOnly (true);
+    }
+
+  m_seqNo++;
+  rreqHeader.SetOriginSeqno (m_seqNo);
+  m_requestId++;
+  rreqHeader.SetId (m_requestId);
+  rreqHeader.SetHopCount (0);
+
+  // Send RREQ as subnet directed broadcast from each interface used by aomdv
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+         m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ptr<Socket> socket = j->first;
+      Ipv4InterfaceAddress iface = j->second;
+
+      rreqHeader.SetOrigin (iface.GetLocal ());
+      m_rreqIdCache.IsDuplicate (iface.GetLocal (), m_requestId);
+
+      Ptr<Packet> packet = Create<Packet> ();
+      SocketIpTtlTag tag;
+      tag.SetTtl (ttl);
+      packet->AddPacketTag (tag);
+      packet->AddHeader (rreqHeader);
+      TypeHeader tHeader (AOMDVTYPE_RREQ);
+      packet->AddHeader (tHeader);
+      // Send to all-hosts broadcast if on /32 addr, subnet-directed otherwise
+      Ipv4Address destination;
+      if (iface.GetMask () == Ipv4Mask::GetOnes ())
+        {
+          destination = Ipv4Address ("255.255.255.255");
+        }
+      else
+        {
+          destination = iface.GetBroadcast ();
+        }
+      NS_LOG_DEBUG ("Send RREQ with id " << rreqHeader.GetId () << " to socket");
+      m_lastBcastTime = Simulator::Now ();
+      Simulator::Schedule (Time (MilliSeconds (m_uniformRandomVariable->GetInteger (0, 10))), &RoutingProtocol::SendTo, this, socket, packet, destination);
+    }
+  ScheduleRreqRetry (dst);
+}
+
+void
+RoutingProtocol::SendTo (Ptr<Socket> socket, Ptr<Packet> packet, Ipv4Address destination)
+{
+  socket->SendTo (packet, 0, InetSocketAddress (destination, AOMDV_PORT));
+
+}
+void
+RoutingProtocol::ScheduleRreqRetry (Ipv4Address dst)
+{
+  NS_LOG_FUNCTION (this << dst);
+  if (m_addressReqTimer.find (dst) == m_addressReqTimer.end ())
+    {
+      Timer timer (Timer::CANCEL_ON_DESTROY);
+      m_addressReqTimer[dst] = timer;
+    }
+  m_addressReqTimer[dst].SetFunction (&RoutingProtocol::RouteRequestTimerExpire, this);
+  m_addressReqTimer[dst].Cancel ();
+  m_addressReqTimer[dst].SetArguments (dst);
+  RoutingTableEntry rt;
+  m_routingTable.LookupRoute (dst, rt);
+  Time retry;
+  if (rt.GetLastHopCount () < m_netDiameter)
+    {
+      retry = 2 * m_nodeTraversalTime * (rt.GetLastHopCount () + m_timeoutBuffer);
+    }
+  else
+    {
+      NS_ABORT_MSG_UNLESS (rt.GetRreqCnt () > 0, "Unexpected value for GetRreqCount ()");
+      uint16_t backoffFactor = rt.GetRreqCnt () - 1;
+      NS_LOG_LOGIC ("Applying binary exponential backoff factor " << backoffFactor);
+      retry = m_netTraversalTime * (1 << backoffFactor);
+    }
+  m_addressReqTimer[dst].Schedule (retry);
+  NS_LOG_LOGIC ("Scheduled RREQ retry in " << retry.As (Time::S));
+}
+
+void
+RoutingProtocol::RecvAomdv (Ptr<Socket> socket)
+{
+  NS_LOG_FUNCTION (this << socket);
+  Address sourceAddress;
+  Ptr<Packet> packet = socket->RecvFrom (sourceAddress);
+  InetSocketAddress inetSourceAddr = InetSocketAddress::ConvertFrom (sourceAddress);
+  Ipv4Address sender = inetSourceAddr.GetIpv4 ();
+  Ipv4Address receiver;
+
+  if (m_socketAddresses.find (socket) != m_socketAddresses.end ())
+    {
+      receiver = m_socketAddresses[socket].GetLocal ();
+    }
+  else if (m_socketSubnetBroadcastAddresses.find (socket) != m_socketSubnetBroadcastAddresses.end ())
+    {
+      receiver = m_socketSubnetBroadcastAddresses[socket].GetLocal ();
+    }
+  else
+    {
+      NS_ASSERT_MSG (false, "Received a packet from an unknown socket");
+    }
+  NS_LOG_DEBUG ("AOMDV node " << this << " received a AOMDV packet from " << sender << " to " << receiver);
+
+  UpdateRouteToNeighbor (sender, receiver);
+  TypeHeader tHeader (AOMDVTYPE_RREQ);
+  packet->RemoveHeader (tHeader);
+  if (!tHeader.IsValid ())
+    {
+      NS_LOG_DEBUG ("AOMDV message " << packet->GetUid () << " with unknown type received: " << tHeader.Get () << ". Drop");
+      return; // drop
+    }
+  switch (tHeader.Get ())
+    {
+    case AOMDVTYPE_RREQ:
+      {
+        RecvRequest (packet, receiver, sender);
+        break;
+      }
+    case AOMDVTYPE_RREP:
+      {
+        RecvReply (packet, receiver, sender);
+        break;
+      }
+    case AOMDVTYPE_RERR:
+      {
+        RecvError (packet, sender);
+        break;
+      }
+    case AOMDVTYPE_RREP_ACK:
+      {
+        RecvReplyAck (sender);
+        break;
+      }
+    }
+}
+
+bool
+RoutingProtocol::UpdateRouteLifeTime (Ipv4Address addr, Time lifetime)
+{
+  NS_LOG_FUNCTION (this << addr << lifetime);
+  RoutingTableEntry rt;
+  if (m_routingTable.LookupRoute (addr, rt))
+    {
+      if (rt.GetFlag () == VALID)
+        {
+          NS_LOG_DEBUG ("Updating VALID route");
+          rt.SetRreqCnt (0);
+          rt.SetLifeTime (std::max (lifetime, rt.GetLifeTime ()));
+          m_routingTable.Update (rt);
+          return true;
+        }
+    }
+  return false;
+}
+
+bool
+RoutingProtocol::UpdatePathsLifeTime (Ipv4Address addr, Time lifetime)
+{
+  NS_LOG_FUNCTION (this << addr << lifetime);
+  RoutingTableEntry rt;
+  if (m_routingTable.LookupRoute (addr, rt))
+    {
+      if (rt.GetFlag () == VALID)
+        {
+          NS_LOG_DEBUG ("Updating VALID route");
+          rt.SetRreqCnt (0);
+          rt.SetLifeTime (std::max (lifetime, rt.GetLifeTime ()));
+          m_routingTable.Update (rt);
+          std::vector<RoutingTableEntry::Path> paths;
+          rt.GetPaths (paths);
+          for (std::vector<RoutingTableEntry::Path>::iterator i = paths.begin (); i!= paths.end (); ++i)
+            {
+               i->SetExpire (std::max (lifetime, i->GetExpire ()));
+            }
+          return true;
+        }
+    }
+  return false;
+}
+
+void
+RoutingProtocol::UpdateRouteToNeighbor (Ipv4Address sender, Ipv4Address receiver)
+{
+  NS_LOG_FUNCTION (this << "sender " << sender << " receiver " << receiver);
+  RoutingTableEntry toNeighbor;
+  if (!m_routingTable.LookupRoute (sender, toNeighbor))
+    {
+      Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver));
+      RoutingTableEntry newEntry (/*dst=*/ sender, /*validSeqNo=*/ false, /*seqno=*/ 0, 
+                                  /*lifeTime=*/ m_activeRouteTimeout);
+      // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+      newEntry.PathInsert (/*device=*/ dev, /*nextHop=*/ sender, /*hop=*/ 1, 
+                           /*expireTime=*/ m_activeRouteTimeout, 
+                           /*lastHop=*/ sender, 
+                           /*iface=*/ m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+      m_routingTable.AddRoute (newEntry);
+    }
+  else
+    {
+      Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver));
+      std::vector<RoutingTableEntry::Path> paths;
+      // Vendoring fix (#296): the fork read this uninitialized when the
+      // neighbor entry had no matching path.
+      bool validPath = false;
+      toNeighbor.GetPaths (paths);
+      for (std::vector<RoutingTableEntry::Path>::const_iterator i = paths.begin (); i!= paths.end (); ++i)
+        {
+          if ((i->GetHopCount () == 1) && (i->GetOutputDevice () == dev))
+            {
+              validPath = true;
+            }
+        }
+      if (toNeighbor.GetValidSeqNo () && validPath)
+        {
+          toNeighbor.SetLifeTime (std::max (m_activeRouteTimeout, toNeighbor.GetLifeTime ()));
+        }
+      else
+        {
+          RoutingTableEntry newEntry (/*dst=*/ sender, /*validSeqNo=*/ false, /*seqno=*/ 0, 
+                                      /*lifeTime=*/ std::max (m_activeRouteTimeout, toNeighbor.GetLifeTime ()));
+          // Vendoring fix (#296): path before Update (see SetIpv4 note).
+          newEntry.PathInsert (/*device=*/ dev, /*nextHop=*/ sender, /*hop=*/ 1, 
+                               /*expireTime=*/ std::max (m_activeRouteTimeout, toNeighbor.GetLifeTime ()), 
+                               /*lastHop=*/ sender, 
+                               /*iface=*/ m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+          m_routingTable.Update (newEntry);
+        }
+    }
+
+}
+
+void
+RoutingProtocol::RecvRequest (Ptr<Packet> p, Ipv4Address receiver, Ipv4Address src)
+{
+  NS_LOG_FUNCTION (this);
+  bool killRequestPropagation = false;
+  RreqHeader rreqHeader;
+  p->RemoveHeader (rreqHeader);
+  IdCache::UniqueId* b = NULL;
+  RoutingTableEntry::Path* reversePath = NULL;
+  RoutingTableEntry::Path* erp = NULL;
+
+  // A node ignores all RREQs received from any node in its blacklist
+  RoutingTableEntry toPrev;
+  if (m_routingTable.LookupRoute (src, toPrev))
+    {
+      if (toPrev.IsUnidirectional ())
+        {
+          NS_LOG_DEBUG ("Ignoring RREQ from node in blacklist");
+          return;
+        }
+    }
+
+  uint32_t id = rreqHeader.GetId ();
+  Ipv4Address origin = rreqHeader.GetOrigin ();
+
+  /*
+   *  Node checks to determine whether it has received a RREQ with the same Originator IP Address and RREQ ID.
+   *  If such a RREQ has been received, the node silently discards the newly received RREQ.
+   */
+  if ((b = m_rreqIdCache.GetId (origin, id)) == NULL)
+    {
+      m_rreqIdCache.InsertId (origin, id);
+      b = m_rreqIdCache.GetId (origin, id);
+    }
+  else
+    {
+      killRequestPropagation = true;
+    }
+  
+   if (rreqHeader.GetHopCount () == 0) 
+    {
+      rreqHeader.SetFirstHop (receiver);
+      //rq->rq_first_hop = index;
+    }
+  // Increment RREQ hop count
+  uint8_t hop = rreqHeader.GetHopCount () + 1;
+  //rreqHeader.SetHopCount (hop);
+
+  /*
+   *  When the reverse route is created or updated, the following actions on the route are also carried out:
+   *  1. the Originator Sequence Number from the RREQ is compared to the corresponding destination sequence number
+   *     in the route table entry and copied if greater than the existing value there
+   *  2. the valid sequence number field is set to true;
+   *  3. the next hop in the routing table becomes the node from which the  RREQ was received
+   *  4. the hop count is copied from the Hop Count in the RREQ message;
+   *  5. the Lifetime is set to be the maximum of (ExistingLifetime, MinimalLifetime), where
+   *     MinimalLifetime = current time + 2*NetTraversalTime - 2*HopCount*NodeTraversalTime
+   */
+  RoutingTableEntry toOrigin;
+  Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver));
+  if (!m_routingTable.LookupRoute (origin, toOrigin))
+    {
+      RoutingTableEntry newEntry (/*dst=*/ origin, /*validSeno=*/ true, /*seqNo=*/ rreqHeader.GetOriginSeqno (),
+                                  /*timeLife=*/ Time ((2 * m_netTraversalTime - 2 * hop * m_nodeTraversalTime)));
+      // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+      reversePath = newEntry.PathInsert (dev, src, rreqHeader.GetHopCount ()+1, 
+                           Time ((2 * m_netTraversalTime - 2 * hop * m_nodeTraversalTime)), 
+                           rreqHeader.GetFirstHop (), 
+                           m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+      m_routingTable.AddRoute (newEntry);
+      // Vendoring fix (#296): the fork built the reverse route in newEntry and
+      // dropped it — toOrigin, which the rest of RecvRequest reads (SendReply,
+      // the SetFirstHop below), stayed default-constructed and pathless, so
+      // PathFind () was NULL there. Adopt the entry just stored, and re-point
+      // reversePath into toOrigin's own path list: it pointed into newEntry,
+      // which dies at the end of this block. Same defect class as the
+      // insert-into-a-copy sites above; see ns3/aomdv/README.md.
+      toOrigin = newEntry;
+      reversePath = toOrigin.PathFind ();
+    }
+  else
+    {
+      if (toOrigin.GetValidSeqNo ())
+        {
+          if (int32_t (rreqHeader.GetOriginSeqno ()) - int32_t (toOrigin.GetSeqNo ()) > 0)
+            {
+              toOrigin.SetSeqNo (rreqHeader.GetOriginSeqno ());
+              toOrigin.SetAdvertisedHopCount (INFINITY2);
+              toOrigin.PathAllDelete ();
+              toOrigin.SetFlag (VALID);
+              Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver));
+              reversePath = toOrigin.PathInsert (dev, src, rreqHeader.GetHopCount ()+1, 
+                                                 Time ((2 * m_netTraversalTime - 2 * hop * m_nodeTraversalTime)), 
+                                                 rreqHeader.GetFirstHop (), 
+                                                 m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+              toOrigin.SetLastHopCount (toOrigin.PathGetMaxHopCount ());           
+            }
+        }
+      else if ((int32_t (rreqHeader.GetOriginSeqno ()) == int32_t (toOrigin.GetSeqNo ())) &&
+				 (toOrigin.GetAdvertisedHopCount () > rreqHeader.GetHopCount ()))
+        {
+          if(toOrigin.GetFlag () == VALID)
+            {
+              if ((reversePath = toOrigin.PathLookupDisjoint(src, rreqHeader.GetFirstHop ()))) 
+                {
+		  if (reversePath->GetHopCount () == (rreqHeader.GetHopCount ()+1))
+                    {
+	              reversePath->SetExpire (std::max(reversePath->GetExpire (), Time ((2 * m_netTraversalTime - 2 * hop *                  
+                                                                                         m_nodeTraversalTime))));
+                    }
+		}
+              else if (toOrigin.PathNewDisjoint(src, rreqHeader.GetFirstHop ()))
+                {
+                  if ( (toOrigin.GetNumberofPaths () < AOMDV_MAX_PATHS) &&
+		       (((rreqHeader.GetHopCount ()+1) - toOrigin.PathGetMinHopCount ()) <= AOMDV_PRIM_ALT_PATH_LENGTH_DIFF))
+                    {
+                      reversePath = toOrigin.PathInsert (dev, src, rreqHeader.GetHopCount ()+1, 
+                                                         Time ((2 * m_netTraversalTime - 2 * hop * m_nodeTraversalTime)), 
+                                                         rreqHeader.GetFirstHop (), 
+                                                         m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+                      toOrigin.SetLastHopCount (toOrigin.PathGetMaxHopCount ());
+                    }
+                  if (((rreqHeader.GetHopCount ()+1) - toOrigin.PathGetMinHopCount ()) > AOMDV_PRIM_ALT_PATH_LENGTH_DIFF) 
+                    {
+		      return;
+	            }
+                }
+              else if ( (IsMyOwnAddress (rreqHeader.GetDst ())) && 
+			(((erp = toOrigin.PathLookupLastHop (rreqHeader.GetFirstHop ())) == NULL) ||
+			((rreqHeader.GetHopCount ()+1) > erp->GetHopCount ())))  
+                {
+			return;
+		}
+            }
+          else
+            {
+              return;
+            } 
+        }
+      // Vendoring fix (#296): persist the reverse-path changes made on this
+      // looked-up copy — the fork mutated the copy and dropped it, so the
+      // table never learned any reverse path. See ns3/aomdv/README.md.
+      m_routingTable.Update (toOrigin);
+    }
+
+  RoutingTableEntry toNeighbor;
+  if (!m_routingTable.LookupRoute (src, toNeighbor))
+    {
+      NS_LOG_DEBUG ("Neighbor:" << src << " not found in routing table. Creating an entry");
+      Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver));
+      RoutingTableEntry newEntry (/*dst=*/ src, /*validSeno=*/ false, /*seqNo=*/ rreqHeader.GetOriginSeqno (),
+                                  /*timeLife=*/ m_activeRouteTimeout);
+      // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+      newEntry.PathInsert (dev, src, 1, 
+                           m_activeRouteTimeout, src, 
+                           m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+      m_routingTable.AddRoute (newEntry);
+    }
+  else
+    {
+      toNeighbor.SetLifeTime (m_activeRouteTimeout);
+      toNeighbor.SetValidSeqNo (false);
+      toNeighbor.SetSeqNo (rreqHeader.GetOriginSeqno ());
+      toNeighbor.SetFlag (VALID);
+      RoutingTableEntry::Path *p = toNeighbor.PathLookup (src);
+      p->SetOutputDevice (m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver)));
+      p->SetInterface (m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+      p->SetHopCount (1);
+      p->SetNextHop (src);
+      m_routingTable.Update (toNeighbor);
+    }
+  m_nb.Update (src, Time (m_allowedHelloLoss * m_helloInterval));
+
+  NS_LOG_LOGIC (receiver << " receive RREQ with hop count " << static_cast<uint32_t> (rreqHeader.GetHopCount ())
+                         << " ID " << rreqHeader.GetId ()
+                         << " to destination " << rreqHeader.GetDst ());
+
+  //  A node generates a RREP if either:
+  //  (i)  it is itself the destination,
+  if (IsMyOwnAddress (rreqHeader.GetDst ()))
+    {
+      m_routingTable.LookupRoute (origin, toOrigin);
+      NS_LOG_DEBUG ("Send reply since I am the destination");
+      SendReply (rreqHeader, toOrigin, src);
+      return;
+    }
+  
+  /*
+   * (ii) or it has an active route to the destination, the destination sequence number in the node's existing route table entry for the destination
+   *      is valid and greater than or equal to the Destination Sequence Number of the RREQ, and the "destination only" flag is NOT set.
+   */
+  RoutingTableEntry toDst;
+  Ipv4Address dst = rreqHeader.GetDst ();
+  if (m_routingTable.LookupRoute (dst, toDst))
+    {
+      /*
+       * Drop RREQ, This node RREP will make a loop.
+       */
+      // Vendoring fix (#296): PathFind () is NULL on a pathless entry — and
+      // SendRequest adds exactly such an entry (the IN_SEARCH placeholder) for
+      // a destination we are still looking for, which is precisely the entry a
+      // RREQ for that destination finds here. No path means no next hop, so
+      // there is no RREP loop to drop; fall through as stock aodv does (its
+      // entry always carries a next hop, so the comparison is simply false).
+      RoutingTableEntry::Path *dstPath = toDst.PathFind ();
+      if (dstPath && dstPath->GetNextHop () == src)
+        {
+          NS_LOG_DEBUG ("Drop RREQ from " << src << ", dest next hop " << dstPath->GetNextHop ());
+          return;
+        }
+      /*
+       * The Destination Sequence number for the requested destination is set to the maximum of the corresponding value
+       * received in the RREQ message, and the destination sequence value currently maintained by the node for the requested destination.
+       * However, the forwarding node MUST NOT modify its maintained value for the destination sequence number, even if the value
+       * received in the incoming RREQ is larger than the value currently maintained by the forwarding node.
+       */
+      if ((rreqHeader.GetUnknownSeqno () || (int32_t (toDst.GetSeqNo ()) - int32_t (rreqHeader.GetDstSeqno ()) >= 0))
+          && toDst.GetValidSeqNo () )
+        {
+          if (!rreqHeader.GetDestinationOnly () && toDst.GetFlag () == VALID)
+            {
+              if (reversePath)
+                {
+                  #ifdef AOMDV_NODE_DISJOINT_PATHS
+                  if (b->count == 0)
+                    {
+                      b->count = 1;
+                      if (toDst.GetAdvertisedHopCount () == INFINITY2)
+                        {
+                          toDst.SetAdvertisedHopCount (toDst.PathGetMaxHopCount ());
+                        }
+                      RoutingTableEntry::Path *forwardPath = toDst.PathFind ();
+                      toDst.SetError (true);
+                      SendReplyByIntermediateNode (toDst, toOrigin, rreqHeader.GetGratuitousRrep (),forwardPath->GetExpire (), 
+                                                   forwardPath->GetLastHop (),rreqHeader.GetId ());
+                      return;
+                    }
+                  #endif
+                  #ifdef AOMDV_LINK_DISJOINT_PATHS
+                  RoutingTableEntry::Path *forwardPath = NULL;
+                  RoutingTableEntry::Path *firstPath = toDst.PathFind (); // Get first path for RREQ destination
+			/* Make sure we don't answer with the same forward path twice in response 
+				to a certain RREQ (received more than once). E.g. "middle node" 
+				in "double diamond". */
+                  std::vector<Path> paths;
+                  toDst.GetPaths (paths);
+                  AOMDVRoute rt;
+                  for (std::vector<Path>::const_iterator i = paths.begin (); i!= paths.end (); ++i)
+                    {
+                      if (!(b->ForwardPathLookup (i->m_nextHop, & rt, i->m_lastHop)))
+                        {
+                          forwardPath = i;
+                          break;
+                        }
+                    }
+                  /* If an unused forward path is found and we have not answered
+				along this reverse path (for this RREQ) - send a RREP back. */
+                  if (forwardPath && !(b->ReversePathLookup (reversePath->m_nextHop, & rt, reversePath->m_lastHop)))
+                    {
+                      /* Mark the reverse and forward path as used (for this RREQ). */
+				// Cache the broadcast ID
+                      b->ReversePathInsert (reversePath->m_nextHop,reversePath->m_lastHop);
+                      b->ForwardPathInsert (forwardPath->m_nextHop, forwardPath->m_lastHop);
+                      if (toDst.GetAdvertisedHopCount () == INFINITY2)
+                        {
+                          toDst.SetAdvertisedHopCount (toDst.PathGetMaxHopCount ());
+                        }
+                      toDst.SetError (true);
+                      SendReplyByIntermediateNode (toDst, toOrigin, rreqHeader.GetGratuitousRrep (), forwardPath->GetExpire (), 
+                                                   forwardPath->GetLastHop (), rreqHeader.GetId ());
+                      return;
+		    }
+                  #endif // AOMDV_LINK_DISJOINT_PATHS
+                }
+            }
+          rreqHeader.SetDstSeqno (toDst.GetSeqNo ());
+          rreqHeader.SetUnknownSeqno (false);
+        }
+    }   
+  if (killRequestPropagation)
+    {
+      return;
+    }
+  else
+    {
+      if (toOrigin.GetAdvertisedHopCount () == INFINITY2)
+        {
+          toOrigin.SetAdvertisedHopCount ( toOrigin.PathGetMaxHopCount ());
+        }
+      rreqHeader.SetHopCount (toOrigin.GetAdvertisedHopCount ());
+      #ifdef AOMDV_NODE_DISJOINT_PATHS
+      rreqHeader.SetFirstHop ((toOrigin.PathFind ())->GetLastHop ());
+      #endif // AOMDV_NODE_DISJOINT_PATHS
+      for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+           m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+        {
+          Ptr<Socket> socket = j->first;
+          Ipv4InterfaceAddress iface = j->second;
+          Ptr<Packet> packet = Create<Packet> ();
+          packet->AddHeader (rreqHeader);
+          TypeHeader tHeader (AOMDVTYPE_RREQ);
+          packet->AddHeader (tHeader);
+          // Send to all-hosts broadcast if on /32 addr, subnet-directed otherwise
+          Ipv4Address destination;
+          if (iface.GetMask () == Ipv4Mask::GetOnes ())
+            {
+              destination = Ipv4Address ("255.255.255.255");
+            }
+          else
+            { 
+              destination = iface.GetBroadcast ();
+            }
+          m_lastBcastTime = Simulator::Now ();
+          Simulator::Schedule (Time (MilliSeconds (m_uniformRandomVariable->GetInteger (0, 10))), 
+                               &RoutingProtocol::SendTo, this, socket, packet, destination); 
+        }
+    }
+}
+
+void
+RoutingProtocol::SendReply (RreqHeader const & rreqHeader, RoutingTableEntry & toOrigin,
+                            Ipv4Address firstHop)
+{
+  NS_LOG_FUNCTION (this << toOrigin.GetDestination ());
+  /*
+   * Destination node MUST increment its own sequence number by one if the sequence number in the RREQ packet is equal to that
+   * incremented value. Otherwise, the destination does not change its sequence number before generating the  RREP message.
+   */
+  if (!rreqHeader.GetUnknownSeqno () && (rreqHeader.GetDstSeqno () == m_seqNo + 1))
+    {
+      m_seqNo++;
+    }
+  RrepHeader rrepHeader ( /*prefixSize=*/ 0, /*hops=*/ 0, /*dst=*/ rreqHeader.GetDst (),
+                          /*dstSeqNo=*/ m_seqNo, /*origin=*/ toOrigin.GetDestination (), 
+                          /*requestId=*/ rreqHeader.GetId (), /*firstHop=*/firstHop,
+                          /*lifeTime=*/ m_myRouteTimeout);
+  Ptr<Packet> packet = Create<Packet> ();
+  packet->AddHeader (rrepHeader);
+  TypeHeader tHeader (AOMDVTYPE_RREP);
+  packet->AddHeader (tHeader);
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (toOrigin.PathFind ()->GetInterface ());
+  NS_ASSERT (socket);
+  socket->SendTo (packet, 0, InetSocketAddress (toOrigin.PathFind ()->GetNextHop (), AOMDV_PORT));
+}
+
+void
+RoutingProtocol::SendReplyByIntermediateNode (RoutingTableEntry & toDst, RoutingTableEntry & toOrigin,
+                                              bool gratRep, Time expire, 
+                                              Ipv4Address firstHop, uint32_t requestId)
+{
+  NS_LOG_FUNCTION (this);
+  RrepHeader rrepHeader (/*prefix size=*/ 0, /*hops=*/ toDst.PathFind ()->GetHopCount (), /*dst=*/ toDst.GetDestination (), 
+                         /*dst seqno=*/ toDst.GetSeqNo (), /*origin=*/ toOrigin.GetDestination (),
+                         /*requestId=*/requestId, /*firstHop=*/ firstHop, /*lifetime=*/ toDst.GetLifeTime ());
+
+  /* If the node we received a RREQ for is a neighbor we are
+   * probably facing a unidirectional link... Better request a RREP-ack
+   */
+  if (toDst.PathFind ()->GetHopCount () == 1)
+    {
+      rrepHeader.SetAckRequired (true);
+      RoutingTableEntry toNextHop;
+      m_routingTable.LookupRoute (toOrigin.PathFind ()->GetNextHop (), toNextHop);
+      toNextHop.m_ackTimer.SetFunction (&RoutingProtocol::AckTimerExpire, this);
+      toNextHop.m_ackTimer.SetArguments (toNextHop.GetDestination (), m_blackListTimeout);
+      toNextHop.m_ackTimer.SetDelay (m_nextHopWait);
+    }
+  toDst.InsertPrecursor (toOrigin.PathFind ()->GetNextHop ());
+  toOrigin.InsertPrecursor (toDst.PathFind ()->GetNextHop ());
+  m_routingTable.Update (toDst);
+  m_routingTable.Update (toOrigin);
+
+  Ptr<Packet> packet = Create<Packet> ();
+  packet->AddHeader (rrepHeader);
+  TypeHeader tHeader (AOMDVTYPE_RREP);
+  packet->AddHeader (tHeader);
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (toOrigin.PathFind ()->GetInterface ());
+  NS_ASSERT (socket);
+  socket->SendTo (packet, 0, InetSocketAddress (toOrigin.PathFind ()->GetNextHop (), AOMDV_PORT));
+
+  // Generating gratuitous RREPs
+  if (gratRep)
+    {
+      RrepHeader gratRepHeader (/*prefix size=*/ 0, /*hops=*/ toOrigin.PathFind ()->GetHopCount (), /*dst=*/ toOrigin.GetDestination (),
+                                /*dst seqno=*/ toOrigin.GetSeqNo (), /*origin=*/ toDst.GetDestination (), /*requestId=*/
+                                requestId, /*firstHop=*/ firstHop, /*lifetime=*/ toOrigin.GetLifeTime ());
+      Ptr<Packet> packetToDst = Create<Packet> ();
+      packetToDst->AddHeader (gratRepHeader);
+      TypeHeader type (AOMDVTYPE_RREP);
+      packetToDst->AddHeader (type);
+      Ptr<Socket> socket = FindSocketWithInterfaceAddress (toDst.PathFind ()->GetInterface ());
+      NS_ASSERT (socket);
+      NS_LOG_LOGIC ("Send gratuitous RREP " << packet->GetUid ());
+      socket->SendTo (packetToDst, 0, InetSocketAddress (toDst.PathFind ()->GetNextHop (), AOMDV_PORT));
+    }
+}
+
+void
+RoutingProtocol::SendReplyAck (Ipv4Address neighbor)
+{
+  NS_LOG_FUNCTION (this << " to " << neighbor);
+  RrepAckHeader h;
+  TypeHeader typeHeader (AOMDVTYPE_RREP_ACK);
+  Ptr<Packet> packet = Create<Packet> ();
+  packet->AddHeader (h);
+  packet->AddHeader (typeHeader);
+  RoutingTableEntry toNeighbor;
+  m_routingTable.LookupRoute (neighbor, toNeighbor);
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (toNeighbor.PathFind ()->GetInterface ());
+  NS_ASSERT (socket);
+  socket->SendTo (packet, 0, InetSocketAddress (neighbor, AOMDV_PORT));
+}
+
+void
+RoutingProtocol::RecvReply (Ptr<Packet> p, Ipv4Address receiver, Ipv4Address sender)
+{
+  NS_LOG_FUNCTION (this << " src " << sender);
+  RrepHeader rrepHeader;
+  p->RemoveHeader (rrepHeader);
+  IdCache::UniqueId* b = NULL;
+  RoutingTableEntry::Path* forwardPath = NULL;
+  Ipv4Address dst = rrepHeader.GetDst ();
+  NS_LOG_LOGIC ("RREP destination " << dst << " RREP origin " << rrepHeader.GetOrigin ());
+
+  if (IsMyOwnAddress (dst))
+    {
+      return;
+    }
+
+  uint8_t hop = rrepHeader.GetHopCount () + 1;
+  //rrepHeader.SetHopCount (hop);
+
+  // If RREP is Hello message
+  if (dst == rrepHeader.GetOrigin ())
+    {
+      ProcessHello (rrepHeader, receiver);
+      return;
+    }
+
+  /*
+   * If the route table entry to the destination is created or updated, then the following actions occur:
+   * -  the route is marked as active,
+   * -  the destination sequence number is marked as valid,
+   * -  the next hop in the route entry is assigned to be the node from which the RREP is received,
+   *    which is indicated by the source IP address field in the IP header,
+   * -  the hop count is set to the value of the hop count from RREP message + 1
+   * -  the expiry time is set to the current time plus the value of the Lifetime in the RREP message,
+   * -  and the destination sequence number is the Destination Sequence Number in the RREP message.
+   */
+  Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver));
+  //RoutingTableEntry newEntry (/*device=*/ dev, /*dst=*/ dst, /*validSeqNo=*/ true, /*seqno=*/ rrepHeader.GetDstSeqno (),
+  //                                        /*iface=*/ m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0),/*hop=*/ hop,
+  //                                        /*nextHop=*/ sender, /*lifeTime=*/ rrepHeader.GetLifeTime ());
+
+  RoutingTableEntry newEntry (/*dst=*/ dst, /*validSeqNo=*/ true, /*seqno=*/ rrepHeader.GetDstSeqno (), 
+                              /*lifeTime=*/ rrepHeader.GetLifeTime ());
+  RoutingTableEntry toDst;
+  if (m_routingTable.LookupRoute (dst, toDst))
+    {
+      /*
+       * The existing entry is updated only in the following circumstances:
+       * (i) the sequence number in the routing table is marked as invalid in route table entry.
+       */
+      // if (!toDst.GetValidSeqNo ())
+      //   {
+      //     m_routingTable.Update (newEntry);
+      //   }
+      // (ii)the Destination Sequence Number in the RREP is greater than the node's copy of the destination sequence number
+      // and the known value is valid,
+      if ((int32_t (rrepHeader.GetDstSeqno ()) - int32_t (toDst.GetSeqNo ())) > 0)
+        {
+          toDst.SetSeqNo (rrepHeader.GetDstSeqno ());
+          toDst.SetAdvertisedHopCount (INFINITY2);
+          toDst.PathAllDelete ();
+          toDst.SetFlag (VALID);
+          /* Insert forward path to RREQ destination. */
+          forwardPath = toDst.PathInsert (dev, rrepHeader.GetOrigin (), hop, 
+                                          Simulator::Now() + rrepHeader.GetLifeTime (), rrepHeader.GetFirstHop (),
+                                          m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+	  // CHANGE
+          toDst.SetLastHopCount (toDst.PathGetMaxHopCount ());
+        }
+
+      /* If the sequence number in the RREP is the same as for route entry but 
+      with a smaller hop count - try to insert new forward path to (RREQ) dest. */
+      // (iii) the sequence numbers are the same, but the route is marked as inactive.
+      else if ((rrepHeader.GetDstSeqno () == toDst.GetSeqNo ()) && (toDst.GetFlag () == VALID)
+               && (toDst.GetAdvertisedHopCount () > rrepHeader.GetHopCount ()))
+        {
+          // Vendoring fix (#296): the fork wrote '==' where its own sibling in
+          // RecvRequest (and ns-2 AOMDV) assigns — forwardPath is still NULL
+          // here, so the branch was taken exactly when the lookup found
+          // nothing and then dereferenced NULL (GCC proves it: -Wnonnull),
+          // and did nothing at all when a disjoint path did exist.
+          if ((forwardPath = toDst.PathLookupDisjoint (rrepHeader.GetOrigin (),rrepHeader.GetFirstHop ())))
+            {
+              if (forwardPath->GetHopCount () == hop)
+                {
+                  forwardPath->SetExpire (std::max (forwardPath->GetExpire (), Simulator::Now() + rrepHeader.GetLifeTime ()));
+                }
+            }
+          else if ((toDst.PathNewDisjoint (rrepHeader.GetOrigin (),rrepHeader.GetFirstHop ()))
+                    && (toDst.GetNumberofPaths () < AOMDV_MAX_PATHS) 
+                    && (hop - toDst.PathGetMinHopCount () <= AOMDV_PRIM_ALT_PATH_LENGTH_DIFF))
+            {
+              /* Insert forward path to RREQ destination. */
+              forwardPath = toDst.PathInsert (dev, rrepHeader.GetOrigin (), hop, 
+                                              Simulator::Now() + rrepHeader.GetLifeTime (), 
+                                              rrepHeader.GetFirstHop (),
+                                              m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+	      // CHANGE
+              toDst.SetLastHopCount (toDst.PathGetMaxHopCount ());
+            }
+          else
+            {
+              return;
+            }
+       
+        }
+      else          
+        {
+          return;
+        }
+      // Vendoring fix (#296): persist the forward-path changes made on this
+      // looked-up copy (see the RecvRequest note).
+      m_routingTable.Update (toDst);
+    }
+  else
+    {
+      // The forward route for this destination is created if it does not already exist.
+      NS_LOG_LOGIC ("add new route");
+      // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+      forwardPath = newEntry.PathInsert (dev, sender, hop, 
+                           Time ((2 * m_netTraversalTime - 2 * hop * m_nodeTraversalTime)), 
+                           rrepHeader.GetFirstHop (), 
+                           m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+      m_routingTable.AddRoute (newEntry);
+    }
+  // Acknowledge receipt of the RREP by sending a RREP-ACK message back
+  if (rrepHeader.GetAckRequired ())
+    {
+      SendReplyAck (sender);
+      rrepHeader.SetAckRequired (false);
+    }
+  NS_LOG_LOGIC ("receiver " << receiver << " origin " << rrepHeader.GetOrigin ());
+  if (IsMyOwnAddress (rrepHeader.GetOrigin ()))
+    {
+      if (toDst.GetFlag () == IN_SEARCH)
+        {
+          m_routingTable.Update (newEntry);
+          m_addressReqTimer[dst].Cancel ();
+          m_addressReqTimer.erase (dst);
+        }
+      m_routingTable.LookupRoute (dst, toDst);
+      SendPacketFromQueue (dst, toDst.PathFind()->GetRoute ());
+      return;
+    }
+
+  RoutingTableEntry toOrigin;
+  uint32_t id = rrepHeader.GetRequestID ();
+  b = m_rreqIdCache.GetId (dst, id);
+  #ifdef AOMDV_NODE_DISJOINT_PATHS
+  if (!m_routingTable.LookupRoute (rrepHeader.GetOrigin (), toOrigin) || (toOrigin.GetFlag () != VALID)
+      || (b == NULL) || (b->count))
+    {
+      return; // Impossible! drop.
+    }
+
+  b->count = 1;
+  RoutingTableEntry::Path *reversePath = toOrigin.PathFind ();
+
+  if (toDst.GetAdvertisedHopCount () == INFINITY2)
+    {
+      toDst.SetAdvertisedHopCount (toDst.PathGetMaxHopCount ());
+    }
+  rrepHeader.SetHopCount (toDst.GetAdvertisedHopCount ());
+  rrepHeader.SetFirstHop (toDst.PathFind ()->GetLastHop ());
+  reversePath->SetExpire (Simulator::Now() + m_activeRouteTimeout);
+  toDst.SetError (true);
+  #endif // AOMDV_NODE_DISJOINT_PATHS
+
+  #ifdef AOMDV_LINK_DISJOINT_PATHS
+  /* Drop the RREP packet if we do not have a path back to the source, 
+      or the route is marked as down, or if we never received the original RREQ. */
+  if (!m_routingTable.LookupRoute (rrepHeader.GetOrigin (), toOrigin) || (toOrigin.GetFlag () != VALID)
+      || (b == NULL))
+    {
+      return; // Impossible! drop.
+    }
+  /* Make sure we don't answer along the same path twice in response 
+      to a certain RREQ. Try to find an unused (reverse) path to forward the RREP. */
+  RoutingTableEntry::Path* reversePath = NULL;
+  RoutingTableEntry::Path *firstPath = toDst.PathFind (); // Get first path for RREQ destination
+  /* Make sure we don't answer with the same forward path twice in response 
+  to a certain RREQ (received more than once). E.g. "middle node" in "double diamond". */
+  std::vector<Path> paths;
+  toDst.GetPaths (paths);
+  AOMDVRoute rt;
+  for (std::vector<Path>::const_iterator i = paths.begin (); i!= paths.end (); ++i)
+    {
+      if (!(b->ReversePathLookup (i->GetNextHop (), & rt, i->GetLastHop ())))
+        {
+          reversePath = i;
+          break;
+        }
+    }
+
+  /* If an unused reverse path is found and the forward path (for 
+     this RREP) has not already been replied - forward the RREP. */
+  if (reversePath && b->ForwardPathLookup (forwardPath->GetNextHop (), &rt, forwardPath->GetLastHop () == NULL)
+    {
+      if(forwardPath->GetNextHop () == rrepHeader.GetOrigin () && forwardPath->GetLastHop () == rrepHeader.GetFirstHop ())
+        {
+          b->ReversePathInsert (reversePath->GetNextHop (), reversePath->GetLastHop ());
+          b->ForwardPathInsert (forwardPath->GetNextHop (), forwardPath->GetLastHop ());
+          // route advertisement
+          if (toDst.GetAdvertisedHopCount () == INFINITY2)
+            {
+              toDst.SetAdvertisedHopCount (toDst.PathGetMaxHopCount ());
+            }
+          rrepHeader.SetHopCount (toDst.GetAdvertisedHopCount);
+          reversePath->SetExpire (Simulator::Now() + m_activeRouteTimeout);  
+          // CHANGE
+          toDst.SetError (true);
+	}
+    }
+  else
+    {
+      return;
+    }
+  #endif // AOMDV_LINK_DISJOINT_PATHS
+
+  Ptr<Packet> packet = Create<Packet> ();
+  packet->AddHeader (rrepHeader);
+  TypeHeader tHeader (AOMDVTYPE_RREP);
+  packet->AddHeader (tHeader);
+  Ptr<Socket> socket = FindSocketWithInterfaceAddress (toOrigin.PathFind ()->GetInterface ());
+  NS_ASSERT (socket);
+  socket->SendTo (packet, 0, InetSocketAddress (toOrigin.PathFind ()->GetNextHop (), AOMDV_PORT));
+}
+
+void
+RoutingProtocol::RecvReplyAck (Ipv4Address neighbor)
+{
+  NS_LOG_FUNCTION (this);
+  RoutingTableEntry rt;
+  if (m_routingTable.LookupRoute (neighbor, rt))
+    {
+      rt.m_ackTimer.Cancel ();
+      rt.SetFlag (VALID);
+      m_routingTable.Update (rt);
+    }
+}
+
+void
+RoutingProtocol::ProcessHello (RrepHeader const & rrepHeader, Ipv4Address receiver )
+{
+  NS_LOG_FUNCTION (this << "from " << rrepHeader.GetDst ());
+  /*
+   *  Whenever a node receives a Hello message from a neighbor, the node
+   * SHOULD make sure that it has an active route to the neighbor, and
+   * create one if necessary.
+   */
+  RoutingTableEntry toNeighbor;
+  if (!m_routingTable.LookupRoute (rrepHeader.GetDst (), toNeighbor))
+    {
+      Ptr<NetDevice> dev = m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver));
+      RoutingTableEntry newEntry (/*dst=*/ rrepHeader.GetDst (), /*validSeqNo=*/ true, /*seqno=*/ rrepHeader.GetDstSeqno (), 
+                              /*lifeTime=*/ rrepHeader.GetLifeTime ());
+      // Vendoring fix (#296): path before AddRoute (see SetIpv4 note).
+      newEntry.PathInsert (/*device=*/ dev, /*nextHop=*/ rrepHeader.GetDst (), /*hop=*/ 1, 
+                           /*expireTime=*/ rrepHeader.GetLifeTime (), 
+                           /*lastHop=*/ rrepHeader.GetFirstHop (), 
+                           /*iface=*/ m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+      m_routingTable.AddRoute (newEntry);
+
+    }
+  else
+    {
+      RoutingTableEntry::Path *neighborPath = toNeighbor.PathFind ();
+      toNeighbor.SetLifeTime (std::max (Time (m_allowedHelloLoss * m_helloInterval), toNeighbor.GetLifeTime ()));
+      toNeighbor.SetSeqNo (rrepHeader.GetDstSeqno ());
+      toNeighbor.SetValidSeqNo (true);
+      toNeighbor.SetFlag (VALID);
+      neighborPath->SetOutputDevice (m_ipv4->GetNetDevice (m_ipv4->GetInterfaceForAddress (receiver)));
+      neighborPath->SetInterface (m_ipv4->GetAddress (m_ipv4->GetInterfaceForAddress (receiver), 0));
+      neighborPath->SetHopCount (1);
+      neighborPath->SetNextHop (rrepHeader.GetDst ());
+      neighborPath->SetExpire (std::max (Time (m_allowedHelloLoss * m_helloInterval), toNeighbor.GetLifeTime ()));
+      m_routingTable.Update (toNeighbor);
+    }
+  if (m_enableHello)
+    {
+      m_nb.Update (rrepHeader.GetDst (), Time (m_allowedHelloLoss * m_helloInterval));
+    }
+}
+
+void
+RoutingProtocol::RecvError (Ptr<Packet> p, Ipv4Address src )
+{
+  NS_LOG_FUNCTION (this << " from " << src);
+  RerrHeader rerrHeader;
+  p->RemoveHeader (rerrHeader);
+  std::map<Ipv4Address, uint32_t> dstWithNextHopSrc;
+  std::map<Ipv4Address, uint32_t> unreachable;
+  m_routingTable.GetListOfDestinationWithNextHop (src, dstWithNextHopSrc);
+  std::pair<Ipv4Address, uint32_t> un;
+  while (rerrHeader.RemoveUnDestination (un))
+    {
+      for (std::map<Ipv4Address, uint32_t>::const_iterator i =
+             dstWithNextHopSrc.begin (); i != dstWithNextHopSrc.end (); ++i)
+        {
+          if (i->first == un.first)
+            {
+              unreachable.insert (un);
+            }
+        }
+    }
+
+  std::vector<Ipv4Address> precursors;
+  for (std::map<Ipv4Address, uint32_t>::const_iterator i = unreachable.begin ();
+       i != unreachable.end (); )
+    {
+      if (!rerrHeader.AddUnDestination (i->first, i->second))
+        {
+          TypeHeader typeHeader (AOMDVTYPE_RERR);
+          Ptr<Packet> packet = Create<Packet> ();
+          packet->AddHeader (rerrHeader);
+          packet->AddHeader (typeHeader);
+          SendRerrMessage (packet, precursors);
+          rerrHeader.Clear ();
+        }
+      else
+        {
+          RoutingTableEntry toDst;
+          m_routingTable.LookupRoute (i->first, toDst);
+          toDst.GetPrecursors (precursors);
+          ++i;
+        }
+    }
+  if (rerrHeader.GetDestCount () != 0)
+    {
+      TypeHeader typeHeader (AOMDVTYPE_RERR);
+      Ptr<Packet> packet = Create<Packet> ();
+      packet->AddHeader (rerrHeader);
+      packet->AddHeader (typeHeader);
+      SendRerrMessage (packet, precursors);
+    }
+  m_routingTable.InvalidateRoutesWithDst (unreachable);
+}
+
+void
+RoutingProtocol::RouteRequestTimerExpire (Ipv4Address dst)
+{
+  NS_LOG_LOGIC (this);
+  RoutingTableEntry toDst;
+  if (m_routingTable.LookupValidRoute (dst, toDst))
+    {
+      SendPacketFromQueue (dst, toDst.PathFind ()->GetRoute ());
+      NS_LOG_LOGIC ("route to " << dst << " found");
+      return;
+    }
+  /*
+   *  If a route discovery has been attempted RreqRetries times at the maximum TTL without
+   *  receiving any RREP, all data packets destined for the corresponding destination SHOULD be
+   *  dropped from the buffer and a Destination Unreachable message SHOULD be delivered to the application.
+   */
+  if (toDst.GetRreqCnt () == m_rreqRetries)
+    {
+      NS_LOG_LOGIC ("route discovery to " << dst << " has been attempted RreqRetries (" << m_rreqRetries << ") times");
+      m_addressReqTimer.erase (dst);
+      m_routingTable.DeleteRoute (dst);
+      NS_LOG_DEBUG ("Route not found. Drop all packets with dst " << dst);
+      m_queue.DropPacketWithDst (dst);
+      return;
+    }
+
+  if (toDst.GetFlag () == IN_SEARCH)
+    {
+      NS_LOG_LOGIC ("Resend RREQ to " << dst << " ttl " << m_netDiameter);
+      SendRequest (dst);
+    }
+  else
+    {
+      NS_LOG_DEBUG ("Route down. Stop search. Drop packet with destination " << dst);
+      m_addressReqTimer.erase (dst);
+      m_routingTable.DeleteRoute (dst);
+      m_queue.DropPacketWithDst (dst);
+    }
+}
+
+void
+RoutingProtocol::HelloTimerExpire ()
+{
+  NS_LOG_FUNCTION (this);
+  Time offset = Time (Seconds (0));
+  if (m_lastBcastTime > Time (Seconds (0)))
+    {
+      offset = Simulator::Now () - m_lastBcastTime;
+      NS_LOG_DEBUG ("Hello deferred due to last bcast at:" << m_lastBcastTime);
+    }
+  else
+    {
+      SendHello ();
+    }
+  m_htimer.Cancel ();
+  Time diff = m_helloInterval - offset;
+  m_htimer.Schedule (std::max (Time (Seconds (0)), diff));
+  m_lastBcastTime = Time (Seconds (0));
+}
+
+void
+RoutingProtocol::RreqRateLimitTimerExpire ()
+{
+  NS_LOG_FUNCTION (this);
+  m_rreqCount = 0;
+  m_rreqRateLimitTimer.Schedule (Seconds (1));
+}
+
+void
+RoutingProtocol::RerrRateLimitTimerExpire ()
+{
+  NS_LOG_FUNCTION (this);
+  m_rerrCount = 0;
+  m_rerrRateLimitTimer.Schedule (Seconds (1));
+}
+
+void
+RoutingProtocol::AckTimerExpire (Ipv4Address neighbor, Time blacklistTimeout)
+{
+  NS_LOG_FUNCTION (this);
+  m_routingTable.MarkLinkAsUnidirectional (neighbor, blacklistTimeout);
+}
+
+void
+RoutingProtocol::SendHello ()
+{
+  NS_LOG_FUNCTION (this);
+  /* Broadcast a RREP with TTL = 1 with the RREP message fields set as follows:
+   *   Destination IP Address         The node's IP address.
+   *   Destination Sequence Number    The node's latest sequence number.
+   *   Hop Count                      0
+   *   Lifetime                       AllowedHelloLoss * HelloInterval
+   */
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j = m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ptr<Socket> socket = j->first;
+      Ipv4InterfaceAddress iface = j->second;
+      RrepHeader helloHeader (/*prefix size=*/ 0, /*hops=*/ 1, /*dst=*/ iface.GetLocal (), /*dst seqno=*/ m_seqNo,
+                              /*origin=*/ iface.GetLocal (), /*requestId=*/ 0, /*firstHop=*/ Ipv4Address (),
+                              /*lifetime=*/ Time (m_allowedHelloLoss * m_helloInterval));
+      Ptr<Packet> packet = Create<Packet> ();
+      packet->AddHeader (helloHeader);
+      TypeHeader tHeader (AOMDVTYPE_RREP);
+      packet->AddHeader (tHeader);
+      // Send to all-hosts broadcast if on /32 addr, subnet-directed otherwise
+      Ipv4Address destination;
+      if (iface.GetMask () == Ipv4Mask::GetOnes ())
+        {
+          destination = Ipv4Address ("255.255.255.255");
+        }
+      else
+        {
+          destination = iface.GetBroadcast ();
+        }
+      Time jitter = Time (MilliSeconds (m_uniformRandomVariable->GetInteger (0, 10)));
+      Simulator::Schedule (jitter, &RoutingProtocol::SendTo, this, socket, packet, destination);
+    }
+}
+
+void
+RoutingProtocol::SendPacketFromQueue (Ipv4Address dst, Ptr<Ipv4Route> route)
+{
+  NS_LOG_FUNCTION (this);
+  QueueEntry queueEntry;
+  while (m_queue.Dequeue (dst, queueEntry))
+    {
+      DeferredRouteOutputTag tag;
+      Ptr<Packet> p = ConstCast<Packet> (queueEntry.GetPacket ());
+      if (p->RemovePacketTag (tag)
+          && tag.GetInterface () != -1
+          && tag.GetInterface () != m_ipv4->GetInterfaceForDevice (route->GetOutputDevice ()))
+        {
+          NS_LOG_DEBUG ("Output device doesn't match. Dropped.");
+          return;
+        }
+      UnicastForwardCallback ucb = queueEntry.GetUnicastForwardCallback ();
+      Ipv4Header header = queueEntry.GetIpv4Header ();
+      header.SetSource (route->GetSource ());
+      header.SetTtl (header.GetTtl () + 1); // compensate extra TTL decrement by fake loopback routing
+      ucb (route, p, header);
+    }
+}
+
+void
+RoutingProtocol::SendRerrWhenBreaksLinkToNextHop (Ipv4Address nextHop)
+{
+  NS_LOG_FUNCTION (this << nextHop);
+  RerrHeader rerrHeader;
+  std::vector<Ipv4Address> precursors;
+  std::map<Ipv4Address, uint32_t> unreachable;
+
+  RoutingTableEntry toNextHop;
+  if (!m_routingTable.LookupRoute (nextHop, toNextHop))
+    {
+      return;
+    }
+  toNextHop.GetPrecursors (precursors);
+  rerrHeader.AddUnDestination (nextHop, toNextHop.GetSeqNo ());
+  m_routingTable.GetListOfDestinationWithNextHop (nextHop, unreachable);
+  for (std::map<Ipv4Address, uint32_t>::const_iterator i = unreachable.begin (); i
+       != unreachable.end (); )
+    {
+      if (!rerrHeader.AddUnDestination (i->first, i->second))
+        {
+          NS_LOG_LOGIC ("Send RERR message with maximum size.");
+          TypeHeader typeHeader (AOMDVTYPE_RERR);
+          Ptr<Packet> packet = Create<Packet> ();
+          packet->AddHeader (rerrHeader);
+          packet->AddHeader (typeHeader);
+          SendRerrMessage (packet, precursors);
+          rerrHeader.Clear ();
+        }
+      else
+        {
+          RoutingTableEntry toDst;
+          m_routingTable.LookupRoute (i->first, toDst);
+          toDst.GetPrecursors (precursors);
+          ++i;
+        }
+    }
+  if (rerrHeader.GetDestCount () != 0)
+    {
+      TypeHeader typeHeader (AOMDVTYPE_RERR);
+      Ptr<Packet> packet = Create<Packet> ();
+      packet->AddHeader (rerrHeader);
+      packet->AddHeader (typeHeader);
+      SendRerrMessage (packet, precursors);
+    }
+  unreachable.insert (std::make_pair (nextHop, toNextHop.GetSeqNo ()));
+  m_routingTable.InvalidateRoutesWithDst (unreachable);
+}
+
+void
+RoutingProtocol::SendRerrWhenNoRouteToForward (Ipv4Address dst,
+                                               uint32_t dstSeqNo, Ipv4Address origin)
+{
+  NS_LOG_FUNCTION (this);
+  // A node SHOULD NOT originate more than RERR_RATELIMIT RERR messages per second.
+  if (m_rerrCount == m_rerrRateLimit)
+    {
+      // Just make sure that the RerrRateLimit timer is running and will expire
+      NS_ASSERT (m_rerrRateLimitTimer.IsRunning ());
+      // discard the packet and return
+      NS_LOG_LOGIC ("RerrRateLimit reached at " << Simulator::Now ().As (Time::S) << " with timer delay left "
+                                                << m_rerrRateLimitTimer.GetDelayLeft ().As (Time::S)
+                                                << "; suppressing RERR");
+      return;
+    }
+  RerrHeader rerrHeader;
+  rerrHeader.AddUnDestination (dst, dstSeqNo);
+  RoutingTableEntry toOrigin;
+  Ptr<Packet> packet = Create<Packet> ();
+  packet->AddHeader (rerrHeader);
+  packet->AddHeader (TypeHeader (AOMDVTYPE_RERR));
+  if (m_routingTable.LookupValidRoute (origin, toOrigin))
+    {
+      Ptr<Socket> socket = FindSocketWithInterfaceAddress (
+          toOrigin.PathFind()->GetInterface ());
+      NS_ASSERT (socket);
+      NS_LOG_LOGIC ("Unicast RERR to the source of the data transmission");
+      socket->SendTo (packet, 0, InetSocketAddress (toOrigin.PathFind()->GetNextHop (), AOMDV_PORT));
+    }
+  else
+    {
+      for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator i =
+             m_socketAddresses.begin (); i != m_socketAddresses.end (); ++i)
+        {
+          Ptr<Socket> socket = i->first;
+          Ipv4InterfaceAddress iface = i->second;
+          NS_ASSERT (socket);
+          NS_LOG_LOGIC ("Broadcast RERR message from interface " << iface.GetLocal ());
+          // Send to all-hosts broadcast if on /32 addr, subnet-directed otherwise
+          Ipv4Address destination;
+          if (iface.GetMask () == Ipv4Mask::GetOnes ())
+            {
+              destination = Ipv4Address ("255.255.255.255");
+            }
+          else
+            {
+              destination = iface.GetBroadcast ();
+            }
+          socket->SendTo (packet->Copy (), 0, InetSocketAddress (destination, AOMDV_PORT));
+        }
+    }
+}
+
+void
+RoutingProtocol::SendRerrMessage (Ptr<Packet> packet, std::vector<Ipv4Address> precursors)
+{
+  NS_LOG_FUNCTION (this);
+
+  if (precursors.empty ())
+    {
+      NS_LOG_LOGIC ("No precursors");
+      return;
+    }
+  // A node SHOULD NOT originate more than RERR_RATELIMIT RERR messages per second.
+  if (m_rerrCount == m_rerrRateLimit)
+    {
+      // Just make sure that the RerrRateLimit timer is running and will expire
+      NS_ASSERT (m_rerrRateLimitTimer.IsRunning ());
+      // discard the packet and return
+      NS_LOG_LOGIC ("RerrRateLimit reached at " << Simulator::Now ().As (Time::S) << " with timer delay left "
+                                                << m_rerrRateLimitTimer.GetDelayLeft ().As (Time::S)
+                                                << "; suppressing RERR");
+      return;
+    }
+  // If there is only one precursor, RERR SHOULD be unicast toward that precursor
+  if (precursors.size () == 1)
+    {
+      RoutingTableEntry toPrecursor;
+      if (m_routingTable.LookupValidRoute (precursors.front (), toPrecursor))
+        {
+          Ptr<Socket> socket = FindSocketWithInterfaceAddress (toPrecursor.PathFind ()->GetInterface ());
+          NS_ASSERT (socket);
+          NS_LOG_LOGIC ("one precursor => unicast RERR to " << toPrecursor.GetDestination () << " from " << 
+                         toPrecursor.PathFind ()->GetInterface ().GetLocal ());
+          Simulator::Schedule (Time (MilliSeconds (m_uniformRandomVariable->GetInteger (0, 10))), &RoutingProtocol::SendTo, this, socket, packet, precursors.front ());
+          m_rerrCount++;
+        }
+      return;
+    }
+
+  //  Should only transmit RERR on those interfaces which have precursor nodes for the broken route
+  std::vector<Ipv4InterfaceAddress> ifaces;
+  RoutingTableEntry toPrecursor;
+  for (std::vector<Ipv4Address>::const_iterator i = precursors.begin (); i != precursors.end (); ++i)
+    {
+      if (m_routingTable.LookupValidRoute (*i, toPrecursor) && 
+          std::find (ifaces.begin (), ifaces.end (), toPrecursor.PathFind ()->GetInterface ()) == ifaces.end ())
+        {
+          ifaces.push_back (toPrecursor.PathFind ()->GetInterface ());
+        }
+    }
+
+  for (std::vector<Ipv4InterfaceAddress>::const_iterator i = ifaces.begin (); i != ifaces.end (); ++i)
+    {
+      Ptr<Socket> socket = FindSocketWithInterfaceAddress (*i);
+      NS_ASSERT (socket);
+      NS_LOG_LOGIC ("Broadcast RERR message from interface " << i->GetLocal ());
+      // std::cout << "Broadcast RERR message from interface " << i->GetLocal () << std::endl;
+      // Send to all-hosts broadcast if on /32 addr, subnet-directed otherwise
+      Ptr<Packet> p = packet->Copy ();
+      Ipv4Address destination;
+      if (i->GetMask () == Ipv4Mask::GetOnes ())
+        {
+          destination = Ipv4Address ("255.255.255.255");
+        }
+      else
+        {
+          destination = i->GetBroadcast ();
+        }
+      Simulator::Schedule (Time (MilliSeconds (m_uniformRandomVariable->GetInteger (0, 10))), &RoutingProtocol::SendTo, this, socket, p, destination);
+    }
+}
+
+Ptr<Socket>
+RoutingProtocol::FindSocketWithInterfaceAddress (Ipv4InterfaceAddress addr ) const
+{
+  NS_LOG_FUNCTION (this << addr);
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+         m_socketAddresses.begin (); j != m_socketAddresses.end (); ++j)
+    {
+      Ptr<Socket> socket = j->first;
+      Ipv4InterfaceAddress iface = j->second;
+      if (iface == addr)
+        {
+          return socket;
+        }
+    }
+  Ptr<Socket> socket;
+  return socket;
+}
+
+Ptr<Socket>
+RoutingProtocol::FindSubnetBroadcastSocketWithInterfaceAddress (Ipv4InterfaceAddress addr ) const
+{
+  NS_LOG_FUNCTION (this << addr);
+  for (std::map<Ptr<Socket>, Ipv4InterfaceAddress>::const_iterator j =
+         m_socketSubnetBroadcastAddresses.begin (); j != m_socketSubnetBroadcastAddresses.end (); ++j)
+    {
+      Ptr<Socket> socket = j->first;
+      Ipv4InterfaceAddress iface = j->second;
+      if (iface == addr)
+        {
+          return socket;
+        }
+    }
+  Ptr<Socket> socket;
+  return socket;
+}
+
+void
+RoutingProtocol::DoInitialize (void)
+{
+  NS_LOG_FUNCTION (this);
+  uint32_t startTime;
+  if (m_enableHello)
+    {
+      m_htimer.SetFunction (&RoutingProtocol::HelloTimerExpire, this);
+      startTime = m_uniformRandomVariable->GetInteger (0, 100);
+      NS_LOG_DEBUG ("Starting at time " << startTime << "ms");
+      m_htimer.Schedule (MilliSeconds (startTime));
+    }
+  Ipv4RoutingProtocol::DoInitialize ();
+}
+
+} //namespace aomdv
+} //namespace ns3

--- a/ns3/aomdv/model/aomdv-routing-protocol.h
+++ b/ns3/aomdv/model/aomdv-routing-protocol.h
@@ -1,0 +1,526 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#ifndef AOMDVROUTINGPROTOCOL_H
+#define AOMDVROUTINGPROTOCOL_H
+
+#include "aomdv-rtable.h"
+#include "aomdv-rqueue.h"
+#include "aomdv-packet.h"
+#include "aomdv-neighbor.h"
+#include "aomdv-dpd.h"
+#include "ns3/node.h"
+#include "ns3/random-variable-stream.h"
+#include "ns3/output-stream-wrapper.h"
+#include "ns3/ipv4-routing-protocol.h"
+#include "ns3/ipv4-interface.h"
+#include "ns3/ipv4-l3-protocol.h"
+#include <map>
+
+// ns-3 changed Ipv4RoutingProtocol::RouteInput's forwarding-callback parameters
+// from by-value (<= ns-3.36) to const-reference (ns-3.37+). The override must
+// match exactly or the class stays abstract. AOMDV_NS3_ROUTEINPUT_BYVALUE is
+// defined by the module's CMakeLists for ns-3 <= 3.36 (same pattern as the
+// anthocnet module's ANTHOCNET_NS3_ROUTEINPUT_BYVALUE) — but that definition is
+// directory-scoped, so translation units OUTSIDE contrib/aomdv that include
+// this header (e.g. contrib/anthocnet's anthocnet-compare example) never see
+// it. Fall back to probing for a header that appeared in the same release:
+// aomdv links wifi, so ns3/wifi-mpdu.h is present exactly on ns-3.37+.
+#if defined(AOMDV_NS3_ROUTEINPUT_BYVALUE) || !__has_include("ns3/wifi-mpdu.h")
+#define AOMDV_RI_CB(T) T
+#else
+#define AOMDV_RI_CB(T) const T&
+#endif
+
+// AOMDV compile-time policy (Marina & Das / AOMDV-UU lineage, kept as in the
+// vendored port): node-disjoint path computation, packet salvaging, and the
+// path-count / path-length-difference bounds.
+#define AOMDV_PACKET_SALVAGING
+#define AOMDV_MAX_SALVAGE_COUNT  10
+//#define AOMDV_LINK_DISJOINT_PATHS
+#define AOMDV_NODE_DISJOINT_PATHS
+#define AOMDV_NODE_TRAVERSAL_TIME     0.03             // 30 ms
+#define AOMDV_LOCAL_REPAIR_WAIT_TIME  0.15 //sec
+#define AOMDV_MAX_PATHS 3
+#define AOMDV_PRIM_ALT_PATH_LENGTH_DIFF 1
+
+namespace ns3 {
+
+// ns-3 renamed WifiMacQueueItem -> WifiMpdu (and wifi-mac-queue-item.h ->
+// wifi-mpdu.h) in ns-3.37; the WifiMac "DroppedMpdu" trace carries this type.
+// AOMDV_NS3_WIFI_QUEUE_ITEM is defined by the module's CMakeLists for
+// ns-3 <= 3.36 (same pattern as the anthocnet module's
+// ANTHOCNET_NS3_WIFI_QUEUE_ITEM); like the RouteInput gate above it is
+// directory-scoped, so out-of-module includers fall back to probing for the
+// modern header itself.
+#if defined(AOMDV_NS3_WIFI_QUEUE_ITEM) || !__has_include("ns3/wifi-mpdu.h")
+class WifiMacQueueItem;
+#define AOMDV_WIFI_MPDU WifiMacQueueItem
+#else
+class WifiMpdu;
+#define AOMDV_WIFI_MPDU WifiMpdu
+#endif
+enum WifiMacDropReason : uint8_t;  // opaque enum declaration
+
+namespace aomdv {
+/**
+ * \ingroup aomdv
+ *
+ * \brief AOMDV routing protocol
+ */
+class RoutingProtocol : public Ipv4RoutingProtocol
+{
+public:
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId (void);
+  static const uint32_t AOMDV_PORT;
+
+  /// constructor
+  RoutingProtocol ();
+  virtual ~RoutingProtocol ();
+  virtual void DoDispose ();
+
+  // Inherited from Ipv4RoutingProtocol
+  Ptr<Ipv4Route> RouteOutput (Ptr<Packet> p, const Ipv4Header &header, Ptr<NetDevice> oif, Socket::SocketErrno &sockerr);
+  bool RouteInput (Ptr<const Packet> p, const Ipv4Header &header, Ptr<const NetDevice> idev,
+                   AOMDV_RI_CB (UnicastForwardCallback) ucb, AOMDV_RI_CB (MulticastForwardCallback) mcb,
+                   AOMDV_RI_CB (LocalDeliverCallback) lcb, AOMDV_RI_CB (ErrorCallback) ecb);
+  virtual void NotifyInterfaceUp (uint32_t interface);
+  virtual void NotifyInterfaceDown (uint32_t interface);
+  virtual void NotifyAddAddress (uint32_t interface, Ipv4InterfaceAddress address);
+  virtual void NotifyRemoveAddress (uint32_t interface, Ipv4InterfaceAddress address);
+  virtual void SetIpv4 (Ptr<Ipv4> ipv4);
+  virtual void PrintRoutingTable (Ptr<OutputStreamWrapper> stream, Time::Unit unit = Time::S) const;
+
+  // Handle protocol parameters
+  /**
+   * Get maximum queue time
+   * \returns the maximum queue time
+   */
+  Time GetMaxQueueTime () const
+  {
+    return m_maxQueueTime;
+  }
+  /**
+   * Set the maximum queue time
+   * \param t the maximum queue time
+   */
+  void SetMaxQueueTime (Time t);
+  /**
+   * Get the maximum queue length
+   * \returns the maximum queue length
+   */
+  uint32_t GetMaxQueueLen () const
+  {
+    return m_maxQueueLen;
+  }
+  /**
+   * Set the maximum queue length
+   * \param len the maximum queue length
+   */
+  void SetMaxQueueLen (uint32_t len);
+  /**
+   * Get destination only flag
+   * \returns the destination only flag
+   */
+  bool GetDestinationOnlyFlag () const
+  {
+    return m_destinationOnly;
+  }
+  /**
+   * Set destination only flag
+   * \param f the destination only flag
+   */
+  void SetDestinationOnlyFlag (bool f)
+  {
+    m_destinationOnly = f;
+  }
+  /**
+   * Get gratuitous reply flag
+   * \returns the gratuitous reply flag
+   */
+  bool GetGratuitousReplyFlag () const
+  {
+    return m_gratuitousReply;
+  }
+  /**
+   * Set gratuitous reply flag
+   * \param f the gratuitous reply flag
+   */
+  void SetGratuitousReplyFlag (bool f)
+  {
+    m_gratuitousReply = f;
+  }
+  /**
+   * Set hello enable
+   * \param f the hello enable flag
+   */
+  void SetHelloEnable (bool f)
+  {
+    m_enableHello = f;
+  }
+  /**
+   * Get hello enable flag
+   * \returns the enable hello flag
+   */
+  bool GetHelloEnable () const
+  {
+    return m_enableHello;
+  }
+  /**
+   * Set broadcast enable flag
+   * \param f enable broadcast flag
+   */
+  void SetBroadcastEnable (bool f)
+  {
+    m_enableBroadcast = f;
+  }
+  /**
+   * Get broadcast enable flag
+   * \returns the broadcast enable flag
+   */
+  bool GetBroadcastEnable () const
+  {
+    return m_enableBroadcast;
+  }
+
+  /**
+   * Assign a fixed random variable stream number to the random variables
+   * used by this model.  Return the number of streams (possibly zero) that
+   * have been assigned.
+   *
+   * \param stream first stream index to use
+   * \return the number of stream indices assigned by this model
+   */
+  int64_t AssignStreams (int64_t stream);
+
+protected:
+  virtual void DoInitialize (void);
+private:
+  /**
+   * Notify that an MPDU was dropped.
+   *
+   * \param reason the reason why the MPDU was dropped
+   * \param mpdu the dropped MPDU
+   */
+  void NotifyTxError (WifiMacDropReason reason, Ptr<const AOMDV_WIFI_MPDU> mpdu);
+
+  // Protocol parameters.
+  uint32_t m_rreqRetries;             ///< Maximum number of retransmissions of RREQ with TTL = NetDiameter to discover a route
+  uint16_t m_ttlStart;                ///< Initial TTL value for RREQ.
+  uint16_t m_ttlIncrement;            ///< TTL increment for each attempt using the expanding ring search for RREQ dissemination.
+  uint16_t m_ttlThreshold;            ///< Maximum TTL value for expanding ring search, TTL = NetDiameter is used beyond this value.
+  uint16_t m_timeoutBuffer;           ///< Provide a buffer for the timeout.
+  uint16_t m_rreqRateLimit;           ///< Maximum number of RREQ per second.
+  uint16_t m_rerrRateLimit;           ///< Maximum number of REER per second.
+  Time m_activeRouteTimeout;          ///< Period of time during which the route is considered to be valid.
+  uint32_t m_netDiameter;             ///< Net diameter measures the maximum possible number of hops between two nodes in the network
+  /**
+   *  NodeTraversalTime is a conservative estimate of the average one hop traversal time for packets
+   *  and should include queuing delays, interrupt processing times and transfer times.
+   */
+  Time m_nodeTraversalTime;
+  Time m_netTraversalTime;             ///< Estimate of the average net traversal time.
+  Time m_pathDiscoveryTime;            ///< Estimate of maximum time needed to find route in network.
+  Time m_myRouteTimeout;               ///< Value of lifetime field in RREP generating by this node.
+  /**
+   * Every HelloInterval the node checks whether it has sent a broadcast  within the last HelloInterval.
+   * If it has not, it MAY broadcast a  Hello message
+   */
+  Time m_helloInterval;
+  uint32_t m_allowedHelloLoss;         ///< Number of hello messages which may be loss for valid link
+  /**
+   * DeletePeriod is intended to provide an upper bound on the time for which an upstream node A
+   * can have a neighbor B as an active next hop for destination D, while B has invalidated the route to D.
+   */
+  Time m_deletePeriod;
+  Time m_nextHopWait;                  ///< Period of our waiting for the neighbour's RREP_ACK
+  Time m_blackListTimeout;             ///< Time for which the node is put into the blacklist
+  uint32_t m_maxQueueLen;              ///< The maximum number of packets that we allow a routing protocol to buffer.
+  Time m_maxQueueTime;                 ///< The maximum period of time that a routing protocol is allowed to buffer a packet for.
+  bool m_destinationOnly;              ///< Indicates only the destination may respond to this RREQ.
+  bool m_gratuitousReply;              ///< Indicates whether a gratuitous RREP should be unicast to the node originated route discovery.
+  bool m_enableHello;                  ///< Indicates whether a hello messages enable
+  bool m_enableBroadcast;              ///< Indicates whether a a broadcast data packets forwarding enable
+  //\}
+
+  /// IP protocol
+  Ptr<Ipv4> m_ipv4;
+  /// Raw unicast socket per each IP interface, map socket -> iface address (IP + mask)
+  std::map< Ptr<Socket>, Ipv4InterfaceAddress > m_socketAddresses;
+  /// Raw subnet directed broadcast socket per each IP interface, map socket -> iface address (IP + mask)
+  std::map< Ptr<Socket>, Ipv4InterfaceAddress > m_socketSubnetBroadcastAddresses;
+  /// Loopback device used to defer RREQ until packet will be fully formed
+  Ptr<NetDevice> m_lo;
+
+  /// Routing table
+  RoutingTable m_routingTable;
+  /// A "drop-front" queue used by the routing layer to buffer packets to which it does not have a route.
+  RequestQueue m_queue;
+  /// Broadcast ID
+  uint32_t m_requestId;
+  /// Request sequence number
+  uint32_t m_seqNo;
+  /// Handle duplicated RREQ
+  IdCache m_rreqIdCache;
+  /// Handle duplicated broadcast/multicast packets
+  DuplicatePacketDetection m_dpd;
+  /// Handle neighbors
+  Neighbors m_nb;
+  /// Number of RREQs used for RREQ rate control
+  uint16_t m_rreqCount;
+  /// Number of RERRs used for RERR rate control
+  uint16_t m_rerrCount;
+
+private:
+  /// Start protocol operation
+  void Start ();
+  /**
+   * Queue packet and send route request
+   *
+   * \param p the packet to route
+   * \param header the IP header
+   * \param ucb the UnicastForwardCallback function
+   * \param ecb the ErrorCallback function
+   */ 
+  void DeferredRouteOutput (Ptr<const Packet> p, const Ipv4Header & header, UnicastForwardCallback ucb, ErrorCallback ecb);
+  /**
+   * If route exists and is valid, forward packet.
+   *
+   * \param p the packet to route
+   * \param header the IP header
+   * \param ucb the UnicastForwardCallback function
+   * \param ecb the ErrorCallback function
+   * \returns true if forwarded
+   */ 
+  bool Forwarding (Ptr<const Packet> p, const Ipv4Header & header, UnicastForwardCallback ucb, ErrorCallback ecb);
+  /**
+   * Repeated attempts by a source node at route discovery for a single destination
+   * use the expanding ring search technique.
+   * \param dst the destination IP address
+   */
+  void ScheduleRreqRetry (Ipv4Address dst);
+  /**
+   * Set lifetime field in routing table entry to the maximum of existing lifetime and lt, if the entry exists
+   * \param addr - destination address
+   * \param lt - proposed time for lifetime field in routing table entry for destination with address addr.
+   * \return true if route to destination address addr exist
+   */
+  bool UpdateRouteLifeTime (Ipv4Address addr, Time lt);
+  /**
+   * Set lifetime field in routing table entry to the maximum of existing lifetime and lt, if the entry exists
+   * and update the expire time of all paths of that entry
+   * \param addr - destination address
+   * \param lt - proposed time for lifetime field in routing table entry for destination with address addr.
+   * \return true if route to destination address addr exist
+   */
+  bool UpdatePathsLifeTime (Ipv4Address addr, Time lt);
+  /**
+   * Update neighbor record.
+   * \param receiver is supposed to be my interface
+   * \param sender is supposed to be IP address of my neighbor.
+   */
+  void UpdateRouteToNeighbor (Ipv4Address sender, Ipv4Address receiver);
+  /**
+   * Test whether the provided address is assigned to an interface on this node
+   * \param src the source IP address
+   * \returns true if the IP address is the node's IP address
+   */
+  bool IsMyOwnAddress (Ipv4Address src);
+  /**
+   * Find unicast socket with local interface address iface
+   *
+   * \param iface the interface
+   * \returns the socket associated with the interface
+   */
+  Ptr<Socket> FindSocketWithInterfaceAddress (Ipv4InterfaceAddress iface) const;
+  /**
+   * Find subnet directed broadcast socket with local interface address iface
+   *
+   * \param iface the interface
+   * \returns the socket associated with the interface
+   */
+  Ptr<Socket> FindSubnetBroadcastSocketWithInterfaceAddress (Ipv4InterfaceAddress iface) const;
+  /**
+   * Process hello message
+   * 
+   * \param rrepHeader RREP message header
+   * \param receiverIfaceAddr receiver interface IP address
+   */
+  void ProcessHello (RrepHeader const & rrepHeader, Ipv4Address receiverIfaceAddr);
+  /**
+   * Create loopback route for given header
+   *
+   * \param header the IP header
+   * \param oif the output interface net device
+   * \returns the route
+   */
+  Ptr<Ipv4Route> LoopbackRoute (const Ipv4Header & header, Ptr<NetDevice> oif) const;
+
+  ///\name Receive control packets
+  //\{
+  /**
+   * Receive and process control packet
+   * \param socket input socket
+   */
+  void RecvAomdv (Ptr<Socket> socket);
+  /**
+   * Receive RREQ
+   * \param p packet
+   * \param receiver receiver address
+   * \param src sender address
+   */
+  void RecvRequest (Ptr<Packet> p, Ipv4Address receiver, Ipv4Address src);
+  /**
+   * Receive RREP
+   * \param p packet
+   * \param my destination address
+   * \param src sender address
+   */
+  void RecvReply (Ptr<Packet> p, Ipv4Address my, Ipv4Address src);
+  /**
+   * Receive RREP_ACK
+   * \param neighbor neighbor address
+   */
+  void RecvReplyAck (Ipv4Address neighbor);
+  /**
+   * Receive RERR
+   * \param p packet
+   * \param src sender address
+   */
+  /// Receive  from node with address src
+  void RecvError (Ptr<Packet> p, Ipv4Address src);
+  //\}
+
+  ///\name Send
+  //\{
+  /** Forward packet from route request queue
+   * \param dst destination address
+   * \param route route to use
+   */
+  void SendPacketFromQueue (Ipv4Address dst, Ptr<Ipv4Route> route);
+  /// Send hello
+  void SendHello ();
+  /** Send RREQ
+   * \param dst destination address
+   */
+  void SendRequest (Ipv4Address dst);
+  /** Send RREP (AOMDV: per-path, carries the first hop back to the origin)
+   * \param rreqHeader route request header
+   * \param toOrigin routing table entry to originator
+   * \param firstHop the RREQ's first hop from the originator
+   */
+  void SendReply (RreqHeader const & rreqHeader, RoutingTableEntry & toOrigin, Ipv4Address firstHop);
+  /** Send RREP by intermediate node
+   * \param toDst routing table entry to destination
+   * \param toOrigin routing table entry to originator
+   * \param gratRep indicates whether a gratuitous RREP should be unicast to destination
+   */
+  void SendReplyByIntermediateNode (RoutingTableEntry & toDst, RoutingTableEntry & toOrigin, bool gratRep, Time expire,
+                                    Ipv4Address firstHop, uint32_t requestId);
+  /** Send RREP_ACK
+   * \param neighbor neighbor address
+   */
+  void SendReplyAck (Ipv4Address neighbor);
+  /** Initiate RERR
+   * \param nextHop next hop address
+   */
+  void SendRerrWhenBreaksLinkToNextHop (Ipv4Address nextHop);
+  /** Forward RERR
+   * \param packet packet
+   * \param precursors list of addresses of the visited nodes
+   */
+  void SendRerrMessage (Ptr<Packet> packet,  std::vector<Ipv4Address> precursors);
+  /**
+   * Send RERR message when no route to forward input packet. Unicast if there is reverse route to originating node, broadcast otherwise.
+   * \param dst - destination node IP address
+   * \param dstSeqNo - destination node sequence number
+   * \param origin - originating node IP address
+   */
+  void SendRerrWhenNoRouteToForward (Ipv4Address dst, uint32_t dstSeqNo, Ipv4Address origin);
+  /// @}
+
+  /**
+   * Send packet to destination scoket
+   * \param socket - destination node socket
+   * \param packet - packet to send
+   * \param destination - destination node IP address
+   */
+  void SendTo (Ptr<Socket> socket, Ptr<Packet> packet, Ipv4Address destination);
+
+  /// Hello timer
+  Timer m_htimer;
+  /// Schedule next send of hello message
+  void HelloTimerExpire ();
+  /// RREQ rate limit timer
+  Timer m_rreqRateLimitTimer;
+  /// Reset RREQ count and schedule RREQ rate limit timer with delay 1 sec.
+  void RreqRateLimitTimerExpire ();
+  /// RERR rate limit timer
+  Timer m_rerrRateLimitTimer;
+  /// Reset RERR count and schedule RERR rate limit timer with delay 1 sec.
+  void RerrRateLimitTimerExpire ();
+  /// Map IP address + RREQ timer.
+  std::map<Ipv4Address, Timer> m_addressReqTimer;
+  /**
+   * Handle route discovery process
+   * \param dst the destination IP address
+   */
+  void RouteRequestTimerExpire (Ipv4Address dst);
+  /**
+   * Mark link to neighbor node as unidirectional for blacklistTimeout
+   *
+   * \param neighbor the IP address of the neightbor node
+   * \param blacklistTimeout the black list timeout time
+   */
+  void AckTimerExpire (Ipv4Address neighbor, Time blacklistTimeout);
+
+  /// Provides uniform random variables.
+  Ptr<UniformRandomVariable> m_uniformRandomVariable;
+  /// Keep track of the last bcast time
+  Time m_lastBcastTime;
+  /// AOMDV Code
+  int32_t m_MaxPaths;
+  int32_t m_PrimAltPathLengthDiff;
+
+};
+
+} //namespace aomdv
+} //namespace ns3
+
+#endif /* AOMDVROUTINGPROTOCOL_H */

--- a/ns3/aomdv/model/aomdv-rqueue.cc
+++ b/ns3/aomdv/model/aomdv-rqueue.cc
@@ -1,0 +1,171 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#include "aomdv-rqueue.h"
+#include <algorithm>
+#include <functional>
+#include "ns3/ipv4-route.h"
+#include "ns3/socket.h"
+#include "ns3/log.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("AomdvRequestQueue");
+
+namespace aomdv {
+uint32_t
+RequestQueue::GetSize ()
+{
+  Purge ();
+  return m_queue.size ();
+}
+
+bool
+RequestQueue::Enqueue (QueueEntry & entry)
+{
+  Purge ();
+  for (std::vector<QueueEntry>::const_iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if ((i->GetPacket ()->GetUid () == entry.GetPacket ()->GetUid ())
+          && (i->GetIpv4Header ().GetDestination ()
+              == entry.GetIpv4Header ().GetDestination ()))
+        {
+          return false;
+        }
+    }
+  entry.SetExpireTime (m_queueTimeout);
+  if (m_queue.size () == m_maxLen)
+    {
+      Drop (m_queue.front (), "Drop the most aged packet"); // Drop the most aged packet
+      m_queue.erase (m_queue.begin ());
+    }
+  m_queue.push_back (entry);
+  return true;
+}
+
+void
+RequestQueue::DropPacketWithDst (Ipv4Address dst)
+{
+  NS_LOG_FUNCTION (this << dst);
+  Purge ();
+  for (std::vector<QueueEntry>::iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if (i->GetIpv4Header ().GetDestination () == dst)
+        {
+          Drop (*i, "DropPacketWithDst ");
+        }
+    }
+  auto new_end = std::remove_if (m_queue.begin (), m_queue.end (),
+                                 [&](const QueueEntry& en) { return en.GetIpv4Header ().GetDestination () == dst; });
+  m_queue.erase (new_end, m_queue.end ());
+}
+
+bool
+RequestQueue::Dequeue (Ipv4Address dst, QueueEntry & entry)
+{
+  Purge ();
+  for (std::vector<QueueEntry>::iterator i = m_queue.begin (); i != m_queue.end (); ++i)
+    {
+      if (i->GetIpv4Header ().GetDestination () == dst)
+        {
+          entry = *i;
+          m_queue.erase (i);
+          return true;
+        }
+    }
+  return false;
+}
+
+bool
+RequestQueue::Find (Ipv4Address dst)
+{
+  for (std::vector<QueueEntry>::const_iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if (i->GetIpv4Header ().GetDestination () == dst)
+        {
+          return true;
+        }
+    }
+  return false;
+}
+
+/**
+ * \brief IsExpired structure
+ */
+struct IsExpired
+{
+  bool
+  /**
+   * Check if the entry is expired
+   *
+   * \param e QueueEntry entry
+   * \return true if expired, false otherwise
+   */
+  operator() (QueueEntry const & e) const
+  {
+    return (e.GetExpireTime () < Seconds (0));
+  }
+};
+
+void
+RequestQueue::Purge ()
+{
+  IsExpired pred;
+  for (std::vector<QueueEntry>::iterator i = m_queue.begin (); i
+       != m_queue.end (); ++i)
+    {
+      if (pred (*i))
+        {
+          Drop (*i, "Drop outdated packet ");
+        }
+    }
+  m_queue.erase (std::remove_if (m_queue.begin (), m_queue.end (), pred),
+                 m_queue.end ());
+}
+
+void
+RequestQueue::Drop (QueueEntry en, std::string reason)
+{
+  NS_LOG_LOGIC (reason << en.GetPacket ()->GetUid () << " " << en.GetIpv4Header ().GetDestination ());
+  en.GetErrorCallback () (en.GetPacket (), en.GetIpv4Header (),
+                          Socket::ERROR_NOROUTETOHOST);
+  return;
+}
+
+}  // namespace aomdv
+}  // namespace ns3

--- a/ns3/aomdv/model/aomdv-rqueue.h
+++ b/ns3/aomdv/model/aomdv-rqueue.h
@@ -1,0 +1,288 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#ifndef AOMDV_RQUEUE_H
+#define AOMDV_RQUEUE_H
+
+#include <vector>
+#include "ns3/ipv4-routing-protocol.h"
+#include "ns3/simulator.h"
+
+
+namespace ns3 {
+namespace aomdv {
+
+/**
+ * \ingroup aomdv
+ * \brief AOMDV Queue Entry
+ */
+class QueueEntry
+{
+public:
+  /// IPv4 routing unicast forward callback typedef
+  typedef Ipv4RoutingProtocol::UnicastForwardCallback UnicastForwardCallback;
+  /// IPv4 routing error callback typedef
+  typedef Ipv4RoutingProtocol::ErrorCallback ErrorCallback;
+  /**
+   * constructor
+   *
+   * \param pa the packet to add to the queue
+   * \param h the Ipv4Header
+   * \param ucb the UnicastForwardCallback function
+   * \param ecb the ErrorCallback function
+   * \param exp the expiration time
+   */
+  QueueEntry (Ptr<const Packet> pa = 0, Ipv4Header const & h = Ipv4Header (),
+              UnicastForwardCallback ucb = UnicastForwardCallback (),
+              ErrorCallback ecb = ErrorCallback (), Time exp = Simulator::Now ())
+    : m_packet (pa),
+      m_header (h),
+      m_ucb (ucb),
+      m_ecb (ecb),
+      m_expire (exp + Simulator::Now ())
+  {
+  }
+
+  /**
+   * \brief Compare queue entries
+   * \param o QueueEntry to compare
+   * \return true if equal
+   */
+  bool operator== (QueueEntry const & o) const
+  {
+    return ((m_packet == o.m_packet) && (m_header.GetDestination () == o.m_header.GetDestination ()) && (m_expire == o.m_expire));
+  }
+
+  // Fields
+  /**
+   * Get unicast forward callback
+   * \returns unicast callback
+   */
+  UnicastForwardCallback GetUnicastForwardCallback () const
+  {
+    return m_ucb;
+  }
+  /**
+   * Set unicast forward callback
+   * \param ucb The unicast callback
+   */
+  void SetUnicastForwardCallback (UnicastForwardCallback ucb)
+  {
+    m_ucb = ucb;
+  }
+  /**
+   * Get error callback
+   * \returns the error callback
+   */
+  ErrorCallback GetErrorCallback () const
+  {
+    return m_ecb;
+  }
+  /**
+   * Set error callback
+   * \param ecb The error callback
+   */
+  void SetErrorCallback (ErrorCallback ecb)
+  {
+    m_ecb = ecb;
+  }
+  /**
+   * Get packet from entry
+   * \returns the packet
+   */
+  Ptr<const Packet> GetPacket () const
+  {
+    return m_packet;
+  }
+  /**
+   * Set packet in entry
+   * \param p The packet
+   */
+  void SetPacket (Ptr<const Packet> p)
+  {
+    m_packet = p;
+  }
+  /**
+   * Get IPv4 header
+   * \returns the IPv4 header
+   */
+  Ipv4Header GetIpv4Header () const
+  {
+    return m_header;
+  }
+  /**
+   * Set IPv4 header
+   * \param h the IPv4 header
+   */
+  void SetIpv4Header (Ipv4Header h)
+  {
+    m_header = h;
+  }
+  /**
+   * Set expire time
+   * \param exp The expiration time
+   */
+  void SetExpireTime (Time exp)
+  {
+    m_expire = exp + Simulator::Now ();
+  }
+  /**
+   * Get expire time
+   * \returns the expiration time
+   */
+  Time GetExpireTime () const
+  {
+    return m_expire - Simulator::Now ();
+  }
+
+private:
+  /// Data packet
+  Ptr<const Packet> m_packet;
+  /// IP header
+  Ipv4Header m_header;
+  /// Unicast forward callback
+  UnicastForwardCallback m_ucb;
+  /// Error callback
+  ErrorCallback m_ecb;
+  /// Expire time for queue entry
+  Time m_expire;
+};
+/**
+ * \ingroup aomdv
+ * \brief AOMDV route request queue
+ *
+ * Since AOMDV is an on demand routing we queue requests while looking for route.
+ */
+class RequestQueue
+{
+public:
+  /**
+   * constructor
+   *
+   * \param maxLen the maximum length
+   * \param routeToQueueTimeout the route to queue timeout
+   */
+  RequestQueue (uint32_t maxLen, Time routeToQueueTimeout)
+    : m_maxLen (maxLen),
+      m_queueTimeout (routeToQueueTimeout)
+  {
+  }
+  /**
+   * Push entry in queue, if there is no entry with the same packet and destination address in queue.
+   * \param entry the queue entry
+   * \returns true if the entry is queued
+   */
+  bool Enqueue (QueueEntry & entry);
+  /**
+   * Return first found (the earliest) entry for given destination
+   * 
+   * \param dst the destination IP address
+   * \param entry the queue entry
+   * \returns true if the entry is dequeued
+   */
+  bool Dequeue (Ipv4Address dst, QueueEntry & entry);
+  /**
+   * Remove all packets with destination IP address dst
+   * \param dst the destination IP address
+   */
+  void DropPacketWithDst (Ipv4Address dst);
+  /**
+   * Finds whether a packet with destination dst exists in the queue
+   * 
+   * \param dst the destination IP address
+   * \returns true if an entry with the IP address is found
+   */
+  bool Find (Ipv4Address dst);
+  /**
+   * \returns the number of entries
+   */
+  uint32_t GetSize ();
+
+  // Fields
+  /**
+   * Get maximum queue length
+   * \returns the maximum queue length
+   */
+  uint32_t GetMaxQueueLen () const
+  {
+    return m_maxLen;
+  }
+  /**
+   * Set maximum queue length
+   * \param len The maximum queue length
+   */
+  void SetMaxQueueLen (uint32_t len)
+  {
+    m_maxLen = len;
+  }
+  /**
+   * Get queue timeout
+   * \returns the queue timeout
+   */
+  Time GetQueueTimeout () const
+  {
+    return m_queueTimeout;
+  }
+  /**
+   * Set queue timeout
+   * \param t The queue timeout
+   */
+  void SetQueueTimeout (Time t)
+  {
+    m_queueTimeout = t;
+  }
+
+private:
+  /// The queue
+  std::vector<QueueEntry> m_queue;
+  /// Remove all expired entries
+  void Purge ();
+  /**
+   * Notify that packet is dropped from queue by timeout
+   * \param en the queue entry to drop
+   * \param reason the reason to drop the entry
+   */
+  void Drop (QueueEntry en, std::string reason);
+  /// The maximum number of packets that we allow a routing protocol to buffer.
+  uint32_t m_maxLen;
+  /// The maximum period of time that a routing protocol is allowed to buffer a packet for, seconds.
+  Time m_queueTimeout;
+};
+
+
+}  // namespace aomdv
+}  // namespace ns3
+
+#endif /* AOMDV_RQUEUE_H */

--- a/ns3/aomdv/model/aomdv-rtable.cc
+++ b/ns3/aomdv/model/aomdv-rtable.cc
@@ -1,0 +1,811 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+
+#include "aomdv-rtable.h"
+#include <algorithm>
+#include <iomanip>
+#include "ns3/simulator.h"
+#include "ns3/log.h"
+#include <iostream>
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("AomdvRoutingTable");
+
+namespace aomdv {
+
+/*
+ The Routing Table
+ */
+
+RoutingTableEntry::Path::Path (Ptr<NetDevice> dev, Ipv4Address dst, Ipv4Address nextHop, uint16_t hopCount,
+                               Time expireTime, Ipv4Address lastHop, Ipv4InterfaceAddress iface)
+  : m_hopCount (hopCount),
+    m_expire (expireTime + Simulator::Now ()),
+    m_lastHop (lastHop),
+    m_iface (iface),
+    m_ts (Simulator::Now ()),
+    m_pathError (false)
+{
+  m_ipv4Route = Create<Ipv4Route> ();
+  m_ipv4Route->SetDestination (dst);
+  m_ipv4Route->SetGateway (nextHop);
+  m_ipv4Route->SetSource (m_iface.GetLocal ());
+  m_ipv4Route->SetOutputDevice (dev);
+}
+
+void
+RoutingTableEntry::Path::Print (Ptr<OutputStreamWrapper> stream, Time::Unit unit /* = Time::S */) const
+{
+  std::ostream* os = stream->GetStream ();
+  *os << m_ipv4Route->GetGateway ()
+      << "\t" << m_iface.GetLocal () ;
+  *os << "\t";
+  *os << std::setiosflags (std::ios::fixed) << 
+  std::setiosflags (std::ios::left) << std::setprecision (2) <<
+  std::setw (14) << (m_expire - Simulator::Now ()).As (unit);
+  *os << "\t" << m_hopCount << "\n";
+}
+
+  /*
+ The Routing Table Entry
+ */
+
+RoutingTableEntry::RoutingTableEntry (Ipv4Address dst, bool vSeqNo, uint32_t seqNo, Time lifetime) :
+  m_ackTimer (Timer::CANCEL_ON_DESTROY),
+  // Vendoring fix: the fork's ctor accepted dst but never stored it, leaving
+  // m_dst default-initialized — which breaks the destination-keyed routing
+  // table and every Path's Ipv4Route destination. See ns3/aomdv/README.md.
+  m_dst (dst),
+  m_validSeqNo (vSeqNo), m_seqNo (seqNo),
+  m_lifeTime (lifetime + Simulator::Now ()), m_flag (VALID), m_reqCount (0), 
+  m_blackListState (false), m_blackListTimeout (Simulator::Now ()),
+  m_advertisedHopCount (INFINITY2), m_highestSeqnoHeard (0),
+  m_lastHopCount (INFINITY2), 
+  m_numPaths (0), m_error (false)
+{
+}
+
+RoutingTableEntry::~RoutingTableEntry ()
+{
+}
+
+/* 
+Our contribution 
+*/
+void 
+RoutingTableEntry::PrintPaths() 
+{
+  for (std::vector<Path>::const_iterator i = m_pathList.begin(); i != m_pathList.end(); ++i) 
+    {
+      std::cout<<i->GetNextHop ()<<" "<<i->m_hopCount<<" "<<i->m_lastHop;  
+    }
+}
+
+struct RoutingTableEntry::Path* 
+RoutingTableEntry::PathInsert (Ptr<NetDevice> dev, Ipv4Address nextHop, uint16_t hopCount, 
+                               Time expireTime, Ipv4Address lastHop, Ipv4InterfaceAddress iface)
+{
+  Path path(dev, m_dst, nextHop, hopCount, expireTime, lastHop, iface);
+  m_pathList.push_back (path);
+  m_numPaths += 1;     //TODO
+  // Vendoring fix (#296): the fork returned &path — the address of the local
+  // copy, dead the moment PathInsert returns, so every caller that kept the
+  // result (RecvRequest/RecvReply) wrote through a dangling stack pointer.
+  // GCC proves it (-Wreturn-local-addr) and ASan would report
+  // stack-use-after-return. Return the element actually stored in the list;
+  // ns-2 AOMDV, which this port follows, returned the inserted path itself.
+  return &m_pathList.back ();
+}
+
+struct RoutingTableEntry::Path* 
+RoutingTableEntry::PathLookup (Ipv4Address id) 
+{
+  NS_LOG_FUNCTION (this << id);
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+    {
+      if (i->m_ipv4Route->GetGateway () == id)
+        {
+          NS_LOG_LOGIC ("Path " << id << " found");
+          Path *path = &(*i);
+          return path;
+        }
+    }
+  NS_LOG_LOGIC ("Path " << id << " not found");
+  return NULL;
+}
+
+
+struct RoutingTableEntry::Path* 
+RoutingTableEntry::PathLookupDisjoint (Ipv4Address nh, Ipv4Address lh) 
+{
+  NS_LOG_FUNCTION (this << nh << lh);
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+    {
+      if (i->m_ipv4Route->GetGateway () == nh && i->m_lastHop == lh)
+        {
+          NS_LOG_LOGIC ("Disjoint Path " << nh << lh << " found");
+          Path *path = &(*i);
+          return path;
+        }
+    }
+  NS_LOG_LOGIC ("Disjoint Path " << nh << lh <<" not found");
+  return NULL;
+}
+
+bool 
+RoutingTableEntry::PathNewDisjoint (Ipv4Address nh, Ipv4Address lh) 
+{
+  NS_LOG_FUNCTION (this << nh << lh);
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+      if (i->m_ipv4Route->GetGateway () == nh || i->m_lastHop == lh)
+      {
+        NS_LOG_LOGIC ("Disjoint New Path " << nh << lh << " found");
+        return false;
+      }
+  }
+  NS_LOG_LOGIC ("Disjoint New Path " << nh << lh <<" not found");
+  return true;
+}
+
+struct RoutingTableEntry::Path* 
+RoutingTableEntry::PathLookupLastHop (Ipv4Address id) 
+{
+  NS_LOG_FUNCTION (this << id);
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+      if (i->m_lastHop == id)
+      {
+        NS_LOG_LOGIC ("Path " << id << " found");
+        Path *path = &(*i);
+        return path;
+      }
+  }
+  NS_LOG_LOGIC ("Path " << id << " not found");
+  return NULL;
+}
+
+//TODO
+void 
+RoutingTableEntry::PathDelete (Ipv4Address id)
+{
+  NS_LOG_FUNCTION (this << id);
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+    if (i->m_ipv4Route->GetGateway () == id)
+    {
+      NS_LOG_LOGIC ("Path " << id << " found");
+      m_pathList.erase (i);
+      m_numPaths -= 1;   //TODO
+    }
+  }
+}
+
+void 
+RoutingTableEntry::DeletePathFromInterface (Ipv4InterfaceAddress iface)
+{
+  for (std::vector<Path>::iterator j = m_pathList.begin (); j!= m_pathList.end (); ++j)
+    {
+      if (j->GetInterface () == iface)
+        {
+          std::vector<Path>::iterator tmp = j;
+          m_pathList.erase (tmp);
+        }
+    }
+}
+
+void 
+RoutingTableEntry::PathAllDelete (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_pathList.clear (); 
+  m_numPaths = 0;
+}
+
+void 
+RoutingTableEntry::PathDeleteLongest (void)
+{
+  Path *path = NULL;
+  std::vector<Path>::iterator j;
+  uint16_t maxHopCount = 0;
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+    if (i->m_hopCount > maxHopCount)
+    {
+      //assert (i->hopcount != INFINITY2); //TODO
+      path = &(*i);
+      j = i;
+      maxHopCount = i->m_hopCount;
+    }
+  }
+  if (path)
+  {
+    m_pathList.erase(j);
+    m_numPaths -= 1;
+  }
+}
+
+bool 
+RoutingTableEntry::PathEmpty (void) const
+{
+  return m_pathList.empty ();
+}
+
+struct RoutingTableEntry::Path * 
+RoutingTableEntry::PathFind (void) 
+{
+  // Vendoring fix (#296): the fork dereferenced begin() unconditionally, so on
+  // a pathless entry (SendRequest's IN_SEARCH placeholder is added with no
+  // path) this returned &*end() — UB, and in practice a null Path* that the
+  // ~30 `PathFind ()->` call sites then dereferenced. ns-2 AOMDV's
+  // path_find(), which this port follows, returns NULL on an empty list.
+  if (m_pathList.empty ())
+    {
+      return NULL;
+    }
+  Path *path = &m_pathList.front ();
+  return path;
+}
+
+struct RoutingTableEntry::Path* 
+RoutingTableEntry::PathFindMinHop (void)
+{
+  Path *path = NULL;
+  uint16_t minHopCount = 0xffff;
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+    if (i->m_hopCount < minHopCount)
+    {
+      path = &(*i);
+      minHopCount = i->m_hopCount;
+    }
+  }
+  return path;
+}
+
+uint16_t 
+RoutingTableEntry::PathGetMaxHopCount (void)
+{
+  uint16_t maxHopCount = 0;
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+    if (i->m_hopCount > maxHopCount)
+    {
+      maxHopCount = i->m_hopCount;
+    }
+  }
+  if(maxHopCount == 0) 
+    {  
+      return INFINITY2;
+    }
+  else 
+    {
+      return maxHopCount;
+    }
+} 
+
+uint16_t 
+RoutingTableEntry::PathGetMinHopCount (void)
+{
+  uint16_t minHopCount = INFINITY2;
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+    if (i->m_hopCount < minHopCount)
+    {
+      minHopCount = i->m_hopCount;
+    }
+  }
+  return minHopCount;
+}  
+
+Time 
+RoutingTableEntry::PathGetMaxExpirationTime (void)
+{
+  Time maxExpireTime = Time ();
+  for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+  {
+    if (i->m_expire > maxExpireTime)
+    {
+      maxExpireTime = i->m_expire;
+    }
+  }
+  return maxExpireTime;
+} 
+
+void 
+RoutingTableEntry::PathPurge (void)
+{
+  Time now = Simulator::Now ();
+  bool cond;
+  do
+    {
+      cond = false;
+      for (std::vector<Path>::iterator i = m_pathList.begin (); i!= m_pathList.end (); ++i)
+        {
+          if (i->m_expire < now)
+            {
+              cond = true;
+              m_pathList.erase(i);
+              m_numPaths -= 1;
+              break;
+            }
+        }
+    } while(cond);
+}
+
+bool
+RoutingTableEntry::InsertPrecursor (Ipv4Address id)
+{
+  NS_LOG_FUNCTION (this << id);
+  if (!LookupPrecursor (id))
+    {
+      m_precursorList.push_back (id);
+      return true;
+    }
+  else
+    {
+      return false;
+    }
+}
+
+bool
+RoutingTableEntry::LookupPrecursor (Ipv4Address id)
+{
+  NS_LOG_FUNCTION (this << id);
+  for (std::vector<Ipv4Address>::const_iterator i = m_precursorList.begin (); i
+       != m_precursorList.end (); ++i)
+    {
+      if (*i == id)
+        {
+          NS_LOG_LOGIC ("Precursor " << id << " found");
+          return true;
+        }
+    }
+  NS_LOG_LOGIC ("Precursor " << id << " not found");
+  return false;
+}
+
+bool
+RoutingTableEntry::DeletePrecursor (Ipv4Address id)
+{
+  NS_LOG_FUNCTION (this << id);
+  std::vector<Ipv4Address>::iterator i = std::remove (m_precursorList.begin (),
+                                                      m_precursorList.end (), id);
+  if (i == m_precursorList.end ())
+    {
+      NS_LOG_LOGIC ("Precursor " << id << " not found");
+      return false;
+    }
+  else
+    {
+      NS_LOG_LOGIC ("Precursor " << id << " found");
+      m_precursorList.erase (i, m_precursorList.end ());
+    }
+  return true;
+}
+
+void
+RoutingTableEntry::DeleteAllPrecursors ()
+{
+  NS_LOG_FUNCTION (this);
+  m_precursorList.clear ();
+}
+
+bool
+RoutingTableEntry::IsPrecursorListEmpty () const
+{
+  return m_precursorList.empty ();
+}
+
+void
+RoutingTableEntry::GetPrecursors (std::vector<Ipv4Address> & prec) const
+{
+  NS_LOG_FUNCTION (this);
+  if (IsPrecursorListEmpty ())
+    {
+      return;
+    }
+  for (std::vector<Ipv4Address>::const_iterator i = m_precursorList.begin (); i
+       != m_precursorList.end (); ++i)
+    {
+      bool result = true;
+      for (std::vector<Ipv4Address>::const_iterator j = prec.begin (); j
+           != prec.end (); ++j)
+        {
+          if (*j == *i)
+            {
+              result = false;
+            }
+        }
+      if (result)
+        {
+          prec.push_back (*i);
+        }
+    }
+}
+
+void
+RoutingTableEntry::GetPaths (std::vector<Path> & paths) const
+{
+  NS_LOG_FUNCTION (this);
+  if (PathEmpty ())
+    return;
+  for (std::vector<Path>::const_iterator i = m_pathList.begin (); i
+       != m_pathList.end (); ++i)
+    {
+      bool result = true;
+      for (std::vector<Path>::const_iterator j = paths.begin (); j
+           != paths.end (); ++j)
+        {
+          if (*j == *i)
+            result = false;
+        }
+      if (result)
+        paths.push_back (*i);
+    }
+}
+
+void
+RoutingTableEntry::Invalidate (Time badLinkLifetime)
+{
+  NS_LOG_FUNCTION (this << badLinkLifetime.As (Time::S));
+  if (m_flag == INVALID)
+    {
+      return;
+    }
+  m_flag = INVALID;
+  m_reqCount = 0;
+  m_lifeTime = badLinkLifetime + Simulator::Now ();
+}
+
+void
+RoutingTableEntry::Print (Ptr<OutputStreamWrapper> stream, Time::Unit unit /* = Time::S */) const
+{
+  std::ostream* os = stream->GetStream ();
+  *os << m_dst << "\t";
+  switch (m_flag)
+    {
+    case VALID:
+      {
+        *os << "UP";
+        break;
+      }
+    case INVALID:
+      {
+        *os << "DOWN";
+        break;
+      }
+    case IN_SEARCH:
+      {
+        *os << "IN_SEARCH";
+        break;
+      }
+    }
+  for (std::vector<Path>::const_iterator i = m_pathList.begin (); i != m_pathList.end (); ++i)
+    {
+      i->Print (stream, unit);
+      *os << "\n\t\t\t\t";
+    }
+  *stream->GetStream () << "\n";
+}
+
+/*
+ The Routing Table
+ */
+
+RoutingTable::RoutingTable (Time t)
+  : m_badLinkLifetime (t)
+{
+}
+
+bool
+RoutingTable::LookupRoute (Ipv4Address id, RoutingTableEntry & rt)
+{
+  NS_LOG_FUNCTION (this << id);
+  Purge ();
+  if (m_ipv4AddressEntry.empty ())
+    {
+      NS_LOG_LOGIC ("Route to " << id << " not found; m_ipv4AddressEntry is empty");
+      return false;
+    }
+  std::map<Ipv4Address, RoutingTableEntry>::const_iterator i =
+    m_ipv4AddressEntry.find (id);
+  if (i == m_ipv4AddressEntry.end ())
+    {
+      NS_LOG_LOGIC ("Route to " << id << " not found");
+      return false;
+    }
+  rt = i->second;
+  NS_LOG_LOGIC ("Route to " << id << " found");
+  return true;
+}
+
+bool
+RoutingTable::LookupValidRoute (Ipv4Address id, RoutingTableEntry & rt)
+{
+  NS_LOG_FUNCTION (this << id);
+  if (!LookupRoute (id, rt))
+    {
+      NS_LOG_LOGIC ("Route to " << id << " not found");
+      return false;
+    }
+  NS_LOG_LOGIC ("Route to " << id << " flag is " << ((rt.GetFlag () == VALID) ? "valid" : "not valid"));
+  return (rt.GetFlag () == VALID);
+}
+
+bool
+RoutingTable::DeleteRoute (Ipv4Address dst)
+{
+  NS_LOG_FUNCTION (this << dst);
+  Purge ();
+  if (m_ipv4AddressEntry.erase (dst) != 0)
+    {
+      NS_LOG_LOGIC ("Route deletion to " << dst << " successful");
+      return true;
+    }
+  NS_LOG_LOGIC ("Route deletion to " << dst << " not successful");
+  return false;
+}
+
+bool
+RoutingTable::AddRoute (RoutingTableEntry & rt)
+{
+  NS_LOG_FUNCTION (this);
+  Purge ();
+  if (rt.GetFlag () != IN_SEARCH)
+    {
+      rt.SetRreqCnt (0);
+    }
+  std::pair<std::map<Ipv4Address, RoutingTableEntry>::iterator, bool> result =
+    m_ipv4AddressEntry.insert (std::make_pair (rt.GetDestination (), rt));
+  return result.second;
+}
+
+bool
+RoutingTable::Update (RoutingTableEntry & rt)
+{
+  NS_LOG_FUNCTION (this);
+  std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+    m_ipv4AddressEntry.find (rt.GetDestination ());
+  if (i == m_ipv4AddressEntry.end ())
+    {
+      NS_LOG_LOGIC ("Route update to " << rt.GetDestination () << " fails; not found");
+      return false;
+    }
+  i->second = rt;
+  if (i->second.GetFlag () != IN_SEARCH)
+    {
+      NS_LOG_LOGIC ("Route update to " << rt.GetDestination () << " set RreqCnt to 0");
+      i->second.SetRreqCnt (0);
+    }
+  return true;
+}
+
+bool
+RoutingTable::SetEntryState (Ipv4Address id, RouteFlags state)
+{
+  NS_LOG_FUNCTION (this);
+  std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+    m_ipv4AddressEntry.find (id);
+  if (i == m_ipv4AddressEntry.end ())
+    {
+      NS_LOG_LOGIC ("Route set entry state to " << id << " fails; not found");
+      return false;
+    }
+  i->second.SetFlag (state);
+  i->second.SetRreqCnt (0);
+  NS_LOG_LOGIC ("Route set entry state to " << id << ": new state is " << state);
+  return true;
+}
+
+void
+RoutingTable::GetListOfDestinationWithNextHop (Ipv4Address nextHop, std::map<Ipv4Address, uint32_t> & unreachable )
+{
+  NS_LOG_FUNCTION (this);
+  Purge ();
+  unreachable.clear ();
+  for (std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+         m_ipv4AddressEntry.begin (); i != m_ipv4AddressEntry.end (); ++i)
+    {
+      RoutingTableEntry::Path *p = i->second.PathLookup (nextHop);
+      if (p != NULL)
+        {  
+          NS_LOG_LOGIC ("Unreachable insert " << i->first << " " << i->second.GetSeqNo ());
+          unreachable.insert (std::make_pair (i->first, i->second.GetSeqNo ()));
+        }
+    }
+}
+
+void
+RoutingTable::InvalidateRoutesWithDst (const std::map<Ipv4Address, uint32_t> & unreachable)
+{
+  NS_LOG_FUNCTION (this);
+  Purge ();
+  for (std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+         m_ipv4AddressEntry.begin (); i != m_ipv4AddressEntry.end (); ++i)
+    {
+      for (std::map<Ipv4Address, uint32_t>::const_iterator j =
+             unreachable.begin (); j != unreachable.end (); ++j)
+        {
+          if ((i->first == j->first) && (i->second.GetFlag () == VALID))
+            {
+              NS_LOG_LOGIC ("Invalidate route with destination address " << i->first);
+              i->second.Invalidate (m_badLinkLifetime);
+            }
+        }
+    }
+}
+
+void
+RoutingTable::DeleteAllRoutesFromInterface (Ipv4InterfaceAddress iface)
+{
+  NS_LOG_FUNCTION (this);
+  if (m_ipv4AddressEntry.empty ())
+    {
+      return;
+    }
+  for (std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+         m_ipv4AddressEntry.begin (); i != m_ipv4AddressEntry.end (); ++i)
+    {
+      i->second.DeletePathFromInterface (iface);
+    }
+}
+
+void
+RoutingTable::Purge ()
+{
+  NS_LOG_FUNCTION (this);
+  if (m_ipv4AddressEntry.empty ())
+    {
+      return;
+    }
+  for (std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+         m_ipv4AddressEntry.begin (); i != m_ipv4AddressEntry.end (); )
+    {
+      if (i->second.GetLifeTime () < Seconds (0))
+        {
+          if (i->second.GetFlag () == INVALID)
+            {
+              std::map<Ipv4Address, RoutingTableEntry>::iterator tmp = i;
+              ++i;
+              m_ipv4AddressEntry.erase (tmp);
+            }
+          else if (i->second.GetFlag () == VALID)
+            {
+              NS_LOG_LOGIC ("Invalidate route with destination address " << i->first);
+              i->second.Invalidate (m_badLinkLifetime);
+              ++i;
+            }
+          else
+            {
+              ++i;
+            }
+        }
+      else
+        {
+          ++i;
+        }
+    }
+}
+
+void
+RoutingTable::Purge (std::map<Ipv4Address, RoutingTableEntry> &table) const
+{
+  NS_LOG_FUNCTION (this);
+  if (table.empty ())
+    {
+      return;
+    }
+  for (std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+         table.begin (); i != table.end (); )
+    {
+      if (i->second.GetLifeTime () < Seconds (0))
+        {
+          if (i->second.GetFlag () == INVALID)
+            {
+              std::map<Ipv4Address, RoutingTableEntry>::iterator tmp = i;
+              ++i;
+              table.erase (tmp);
+            }
+          else if (i->second.GetFlag () == VALID)
+            {
+              NS_LOG_LOGIC ("Invalidate route with destination address " << i->first);
+              i->second.Invalidate (m_badLinkLifetime);
+              ++i;
+            }
+          else
+            {
+              ++i;
+            }
+        }
+      else
+        {
+          ++i;
+        }
+    }
+}
+
+//contribution
+bool 
+RoutingTable::HasActiveRoutes () 
+{
+  for (std::map<Ipv4Address, RoutingTableEntry>::const_iterator i =
+         m_ipv4AddressEntry.begin (); i != m_ipv4AddressEntry.end (); ++i)
+    {
+      if(i->second.GetFlag () == VALID)
+        {
+          return true;
+        }
+    }
+    return false;
+}
+
+bool
+RoutingTable::MarkLinkAsUnidirectional (Ipv4Address neighbor, Time blacklistTimeout)
+{
+  NS_LOG_FUNCTION (this << neighbor << blacklistTimeout.As (Time::S));
+  std::map<Ipv4Address, RoutingTableEntry>::iterator i =
+    m_ipv4AddressEntry.find (neighbor);
+  if (i == m_ipv4AddressEntry.end ())
+    {
+      NS_LOG_LOGIC ("Mark link unidirectional to  " << neighbor << " fails; not found");
+      return false;
+    }
+  i->second.SetUnidirectional (true);
+  i->second.SetBlacklistTimeout (blacklistTimeout);
+  i->second.SetRreqCnt (0);
+  NS_LOG_LOGIC ("Set link to " << neighbor << " to unidirectional");
+  return true;
+}
+
+void
+RoutingTable::Print (Ptr<OutputStreamWrapper> stream, Time::Unit unit /* = Time::S */) const
+{
+  std::map<Ipv4Address, RoutingTableEntry> table = m_ipv4AddressEntry;
+  Purge (table);
+  *stream->GetStream () << "\nAOMDV Routing table\n"
+                        << "Destination\tFlag\tGateway\t\tInterface\tExpire\t\tHops\n";
+  for (std::map<Ipv4Address, RoutingTableEntry>::const_iterator i =
+         table.begin (); i != table.end (); ++i)
+    {
+      i->second.Print (stream, unit);
+    }
+  *stream->GetStream () << "\n";
+}
+
+}
+}

--- a/ns3/aomdv/model/aomdv-rtable.h
+++ b/ns3/aomdv/model/aomdv-rtable.h
@@ -1,0 +1,434 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#ifndef AOMDV_RTABLE_H
+#define AOMDV_RTABLE_H
+
+#include <stdint.h>
+#include <cassert>
+#include <map>
+#include <sys/types.h>
+#include "ns3/ipv4.h"
+#include "ns3/ipv4-route.h"
+#include "ns3/timer.h"
+#include "ns3/net-device.h"
+#include "ns3/output-stream-wrapper.h"
+#include <vector>
+
+#define INFINITY2 0xff
+
+namespace ns3 {
+namespace aomdv {
+
+/**
+ * \ingroup aomdv
+ * \brief Route record states
+ */
+enum RouteFlags
+{
+  VALID = 0,          //!< VALID
+  INVALID = 1,        //!< INVALID
+  IN_SEARCH = 2,      //!< IN_SEARCH
+};
+
+
+/**
+ * \ingroup aomdv
+ * \brief Routing table entry
+ */
+class RoutingTableEntry
+{
+public:
+  /**
+   * constructor (AOMDV: per-path data lives in Path; the entry keeps only
+   * destination-level state)
+   *
+   * \param dst the destination IP address
+   * \param vSeqNo verify sequence number flag
+   * \param seqNo the sequence number
+   * \param lifetime the lifetime of the entry
+   */
+  RoutingTableEntry (Ipv4Address dst = Ipv4Address (), bool vSeqNo = false, uint32_t seqNo = 0,
+                     Time lifetime = Simulator::Now ());
+
+  ~RoutingTableEntry ();
+
+  /// Path - contribution
+
+
+  struct Path
+  {  
+    /** Ip route, include
+     *   - destination address
+     *   - source address
+     *   - next hop address (gateway)
+     *   - output device
+     */
+    Ptr<Ipv4Route> m_ipv4Route;
+    uint16_t m_hopCount;   // hopcount through this nexthop
+    Time m_expire;     // expiration timeout
+    Ipv4Address m_lastHop;    // lasthop address
+    /// Output interface address
+    Ipv4InterfaceAddress m_iface;
+    Time m_ts;         // time when we saw this nexthop
+    // CHANGE
+    bool m_pathError;
+
+    Path (Ptr<NetDevice> dev, Ipv4Address dst, Ipv4Address nextHop, uint16_t hopCount, Time expireTime, 
+          Ipv4Address lastHop, Ipv4InterfaceAddress iface);
+
+    Ptr<Ipv4Route> GetRoute () const { return m_ipv4Route; }
+    void SetRoute (Ptr<Ipv4Route> r) { m_ipv4Route = r; }
+    void SetNextHop (Ipv4Address nextHop) { m_ipv4Route->SetGateway (nextHop); }
+    Ipv4Address GetNextHop () const { return m_ipv4Route->GetGateway (); }
+    void SetLastHop (Ipv4Address lastHop) { m_lastHop = lastHop; }
+    Ipv4Address GetLastHop () const { return m_lastHop; }
+    void SetOutputDevice (Ptr<NetDevice> dev) { m_ipv4Route->SetOutputDevice (dev); }
+    Ptr<NetDevice> GetOutputDevice () const { return m_ipv4Route->GetOutputDevice (); }
+    void SetHopCount (uint16_t hop) { m_hopCount = hop; }
+    uint16_t GetHopCount () const { return m_hopCount; }
+    Ipv4InterfaceAddress GetInterface () const { return m_iface; }
+    void SetInterface (Ipv4InterfaceAddress iface) { m_iface = iface; }
+    void SetExpire (Time et) { m_expire = et + Simulator::Now (); }
+    Time GetExpire () const { return m_expire - Simulator::Now (); }
+  
+    void Print (Ptr<OutputStreamWrapper> stream, Time::Unit unit = Time::S) const;
+
+    friend bool operator == (Path const &a, Path const &b);
+  };
+
+  /// Path functions - contribution
+  void PrintPaths ();
+  struct Path* PathInsert (Ptr<NetDevice> dev, Ipv4Address nextHop, uint16_t hopCount, 
+                           Time expireTime, Ipv4Address lastHop, Ipv4InterfaceAddress iface);
+  struct Path* PathLookup (Ipv4Address id);
+  struct Path* PathLookupDisjoint (Ipv4Address nh, Ipv4Address lh);
+  bool PathNewDisjoint (Ipv4Address nh, Ipv4Address lh);
+  struct Path* PathLookupLastHop (Ipv4Address id);
+  void PathDelete (Ipv4Address id);
+  void DeletePathFromInterface (Ipv4InterfaceAddress iface);
+  void PathAllDelete (void);                  // delete all paths
+  void PathDeleteLongest (void);          // delete longest path
+  bool PathEmpty (void) const;                   // is the path list empty?
+  struct Path * PathFind (void);            // find the path that we got first
+  struct Path* PathFindMinHop (void);            // find the shortest path
+  uint16_t PathGetMaxHopCount (void);  
+  uint16_t PathGetMinHopCount (void);  
+  Time PathGetMaxExpirationTime (void); 
+  void PathPurge (void);
+
+
+
+  ///\name Precursors management
+  //\{
+  /**
+   * Insert precursor in precursor list if it doesn't yet exist in the list
+   * \param id precursor address
+   * \return true on success
+   */
+  bool InsertPrecursor (Ipv4Address id);
+  /**
+   * Lookup precursor by address
+   * \param id precursor address
+   * \return true on success
+   */
+  bool LookupPrecursor (Ipv4Address id);
+  /**
+   * \brief Delete precursor
+   * \param id precursor address
+   * \return true on success
+   */
+  bool DeletePrecursor (Ipv4Address id);
+  /// Delete all precursors
+  void DeleteAllPrecursors ();
+  /**
+   * Check that precursor list is empty
+   * \return true if precursor list is empty
+   */
+  bool IsPrecursorListEmpty () const;
+  /**
+   * Inserts precursors in output parameter prec if they do not yet exist in vector
+   * \param prec vector of precursor addresses
+   */
+  void GetPrecursors (std::vector<Ipv4Address> & prec) const;
+  //\}
+
+  /**
+   * Mark entry as "down" (i.e. disable it)
+   * \param badLinkLifetime duration to keep entry marked as invalid
+   */
+  void Invalidate (Time badLinkLifetime);
+
+  /**
+   * Copy the entry's paths into \p paths (AOMDV)
+   * \param paths filled with a copy of the path list
+   */
+  void GetPaths (std::vector<Path> & paths) const;
+  // Fields
+  Ipv4Address GetDestination () const { return m_dst; }
+  void SetValidSeqNo (bool s) { m_validSeqNo = s; }
+  bool GetValidSeqNo () const { return m_validSeqNo; }
+  void SetSeqNo (uint32_t sn) { m_seqNo = sn; }
+  uint32_t GetSeqNo () const { return m_seqNo; }
+  void SetLifeTime (Time lt) { m_lifeTime = lt + Simulator::Now (); }
+  Time GetLifeTime () const { return m_lifeTime - Simulator::Now (); }
+  void SetFlag (RouteFlags flag) { m_flag = flag; }
+  RouteFlags GetFlag () const { return m_flag; }
+  void SetRreqCnt (uint8_t n) { m_reqCount = n; }
+  uint8_t GetRreqCnt () const { return m_reqCount; }
+  void IncrementRreqCnt () { m_reqCount++; }
+  void SetUnidirectional (bool u) { m_blackListState = u; }
+  bool IsUnidirectional () const { return m_blackListState; }
+  void SetBlacklistTimeout (Time t) { m_blackListTimeout = t; }
+  Time GetBlacklistTimeout () const { return m_blackListTimeout; }
+  // AOMDV multipath bookkeeping (Marina & Das: advertised hop count,
+  // highest sequence number heard, path-count bound)
+  void SetAdvertisedHopCount (uint32_t ahc ) { m_advertisedHopCount = ahc; }
+  uint32_t GetAdvertisedHopCount () const { return m_advertisedHopCount; }
+  void SetHighestSequenceNumberHeard (uint32_t hsh ) { m_highestSeqnoHeard = hsh; }
+  uint32_t GetHighestSequenceNumberHeard () const { return m_highestSeqnoHeard; }
+  void SetLastHopCount (uint32_t lhc ) { m_lastHopCount = lhc; }
+  uint32_t GetLastHopCount () const { return m_lastHopCount; }
+  void SetNumberofPaths (uint32_t np ) { m_numPaths = np; }
+  uint32_t GetNumberofPaths () const { return m_numPaths; }
+  void SetError (bool e) { m_error = e; }
+  bool IsError () const { return m_error; }
+
+  /// RREP_ACK timer
+  Timer m_ackTimer;
+  //\}
+
+  /**
+   * \brief Compare destination address
+   * \param dst IP address to compare
+   * \return true if equal
+   */
+  bool operator== (Ipv4Address const  dst) const
+  {
+    return (m_dst == dst);
+  }
+  /**
+   * Print packet to trace file
+   * \param stream The output stream
+   * \param unit The time unit to use (default Time::S)
+   */
+  void Print (Ptr<OutputStreamWrapper> stream, Time::Unit unit = Time::S) const;
+
+private:
+  //Destination IP Address
+  Ipv4Address m_dst;
+  /// Valid Destination Sequence Number flag
+  bool m_validSeqNo;
+  /// Destination Sequence Number, if m_validSeqNo = true
+  uint32_t m_seqNo;
+  /// Hop Count (number of hops needed to reach destination)
+  //uint16_t m_hops;
+  /**
+  * \brief Expiration or deletion time of the route
+  *	Lifetime field in the routing table plays dual role:
+  *	for an active route it is the expiration time, and for an invalid route
+  *	it is the deletion time.
+  */
+  Time m_lifeTime;
+  /// Routing flags: valid, invalid or in search
+  RouteFlags m_flag;
+
+  /// List of precursors
+  std::vector<Ipv4Address> m_precursorList;
+  /// List of Paths - contribution
+  std::vector<Path> m_pathList;
+  /// When I can send another request
+  Time m_routeRequestTimout;
+  /// Number of route requests
+  uint8_t m_reqCount;
+  /// Indicate if this entry is in "blacklist"
+  bool m_blackListState;
+  /// Time for which the node is put into the blacklist
+  Time m_blackListTimeout;
+
+  //AOMDV
+  uint16_t  m_advertisedHopCount;
+  uint32_t  m_highestSeqnoHeard;
+  uint32_t  m_lastHopCount;  
+  int  m_numPaths;
+  bool  m_error;
+};
+
+
+/**
+ * \ingroup aomdv
+ * \brief The Routing table used by AOMDV protocol
+ */
+class RoutingTable
+{
+public:
+  /**
+   * constructor
+   * \param t the routing table entry lifetime
+   */
+  RoutingTable (Time t);
+  ///\name Handle lifetime of invalid route
+  //\{
+  /**
+   * Get the lifetime of a bad link
+   *
+   * \return the lifetime of a bad link
+   */
+  Time GetBadLinkLifetime () const
+  {
+    return m_badLinkLifetime;
+  }
+  /**
+   * Set the lifetime of a bad link
+   *
+   * \param t the lifetime of a bad link
+   */
+  void SetBadLinkLifetime (Time t)
+  {
+    m_badLinkLifetime = t;
+  }
+  //\}
+  /**
+   * Add routing table entry if it doesn't yet exist in routing table
+   * \param r routing table entry
+   * \return true in success
+   */
+  bool AddRoute (RoutingTableEntry & r);
+  /**
+   * Delete routing table entry with destination address dst, if it exists.
+   * \param dst destination address
+   * \return true on success
+   */
+  bool DeleteRoute (Ipv4Address dst);
+  /**
+   * Lookup routing table entry with destination address dst
+   * \param dst destination address
+   * \param rt entry with destination address dst, if exists
+   * \return true on success
+   */
+  //Contribution
+  void                 rt_dumptable();
+  bool                 rt_has_active_route();
+
+  bool LookupRoute (Ipv4Address dst, RoutingTableEntry & rt);
+  /**
+   * Lookup route in VALID state
+   * \param dst destination address
+   * \param rt entry with destination address dst, if exists
+   * \return true on success
+   */
+  bool LookupValidRoute (Ipv4Address dst, RoutingTableEntry & rt);
+  /**
+   * Update routing table
+   * \param rt entry with destination address dst, if exists
+   * \return true on success
+   */
+  bool Update (RoutingTableEntry & rt);
+  /**
+   * Set routing table entry flags
+   * \param dst destination address
+   * \param state the routing flags
+   * \return true on success
+   */
+  bool SetEntryState (Ipv4Address dst, RouteFlags state);
+  /**
+   * Lookup routing entries with next hop Address dst and not empty list of precursors.
+   *
+   * \param nextHop the next hop IP address
+   * \param unreachable
+   */
+  void GetListOfDestinationWithNextHop (Ipv4Address nextHop, std::map<Ipv4Address, uint32_t> & unreachable);
+  /**
+   *   Update routing entries with this destination as follows:
+   *  1. The destination sequence number of this routing entry, if it
+   *     exists and is valid, is incremented.
+   *  2. The entry is invalidated by marking the route entry as invalid
+   *  3. The Lifetime field is updated to current time plus DELETE_PERIOD.
+   *  \param unreachable routes to invalidate
+   */
+  void InvalidateRoutesWithDst (std::map<Ipv4Address, uint32_t> const & unreachable);
+  /**
+   * Delete all route from interface with address iface
+   * \param iface the interface IP address
+   */
+  void DeleteAllRoutesFromInterface (Ipv4InterfaceAddress iface);
+  /// Delete all entries from routing table
+  void Clear ()
+  {
+    m_ipv4AddressEntry.clear ();
+  }
+  /// Delete all outdated entries and invalidate valid entry if Lifetime is expired
+  void Purge ();
+
+  bool HasActiveRoutes();
+  /** Mark entry as unidirectional (e.g. add this neighbor to "blacklist" for blacklistTimeout period)
+   * \param neighbor - neighbor address link to which assumed to be unidirectional
+   * \param blacklistTimeout - time for which the neighboring node is put into the blacklist
+   * \return true on success
+   */
+  bool MarkLinkAsUnidirectional (Ipv4Address neighbor, Time blacklistTimeout);
+  /**
+   * Print routing table
+   * \param stream the output stream
+   * \param unit The time unit to use (default Time::S)
+   */
+  void Print (Ptr<OutputStreamWrapper> stream, Time::Unit unit = Time::S) const;
+
+private:
+  /// The routing table
+  std::map<Ipv4Address, RoutingTableEntry> m_ipv4AddressEntry;
+  /// Deletion time for invalid routes
+  Time m_badLinkLifetime;
+  /**
+   * const version of Purge, for use by Print() method
+   * \param table the routing table entry to purge
+   */
+  void Purge (std::map<Ipv4Address, RoutingTableEntry> &table) const;
+};
+
+/**
+ * \brief Path equality (AOMDV)
+ */
+inline bool operator == (const RoutingTableEntry::Path &a, const RoutingTableEntry::Path &b)
+{
+  return (a.m_ipv4Route == b.m_ipv4Route && a.m_hopCount == b.m_hopCount &&
+          a.m_expire == b.m_expire && a.m_lastHop == b.m_lastHop && a.m_iface == b.m_iface
+          && a.m_ts == b.m_ts && a.m_pathError == b.m_pathError);
+}
+
+}  // namespace aomdv
+}  // namespace ns3
+
+#endif /* AOMDV_RTABLE_H */

--- a/ns3/aomdv/test/aomdv-id-cache-test-suite.cc
+++ b/ns3/aomdv/test/aomdv-id-cache-test-suite.cc
@@ -1,0 +1,144 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Vendored for AntHocNet (#296, baseline port): stock ns-3.36 src/aodv rebased
+ * with the AOMDV delta from
+ * https://github.com/CharithaS/Implementation-of-AOMDV-Routing-Protocol-in-ns-3
+ * (commit 54594e24daf7688bdcdb6a696bf821a08fd2d06a, GPLv2). See
+ * ns3/aomdv/README.md for full provenance and the list of adaptations.
+ */
+/*
+ * Copyright (c) 2009 IITP RAS
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Based on
+ *      NS-2 AOMDV model developed by the CMU/MONARCH group and optimized and
+ *      tuned by Samir Das and Mahesh Marina, University of Cincinnati;
+ *
+ *      AOMDV-UU implementation by Erik Nordström of Uppsala University
+ *      http://core.it.uu.se/core/index.php/AOMDV-UU
+ *
+ * Authors: Elena Buchatskaia <borovkovaes@iitp.ru>
+ *          Pavel Boyko <boyko@iitp.ru>
+ */
+#include "ns3/aomdv-id-cache.h"
+#include "ns3/test.h"
+
+// TestSuite/TestCase enums became scoped (enum class) in ns-3.42 and the
+// unscoped aliases were removed in ns-3.47. AOMDV_NS3_SCOPED_TEST_ENUMS is
+// defined by the module's CMakeLists for ns-3 >= 3.42 (same pattern as the
+// anthocnet module's ANTHOCNET_NS3_SCOPED_TEST_ENUMS).
+#ifdef AOMDV_NS3_SCOPED_TEST_ENUMS
+#define AOMDV_TEST_TYPE_UNIT TestSuite::Type::UNIT
+#define AOMDV_TEST_QUICK     TestCase::Duration::QUICK
+#else
+#define AOMDV_TEST_TYPE_UNIT UNIT
+#define AOMDV_TEST_QUICK     TestCase::QUICK
+#endif
+
+namespace ns3 {
+namespace aomdv {
+
+/**
+ * \ingroup aomdv
+ * \defgroup aomdv-test AOMDV module tests
+ */
+
+
+/**
+ * \ingroup aomdv-test
+ * \ingroup tests
+ *
+ * \brief Unit test for id cache
+ */
+class IdCacheTest : public TestCase
+{
+public:
+  IdCacheTest () : TestCase ("Id Cache"),
+                   cache (Seconds (10))
+  {
+  }
+  virtual void DoRun ();
+
+private:
+  /// Timeout test function #1
+  void CheckTimeout1 ();
+  /// Timeout test function #2
+  void CheckTimeout2 ();
+  /// Timeout test function #3
+  void CheckTimeout3 ();
+
+  /// ID cache
+  IdCache cache;
+};
+
+void
+IdCacheTest::DoRun ()
+{
+  NS_TEST_EXPECT_MSG_EQ (cache.GetLifeTime (), Seconds (10), "Lifetime");
+  NS_TEST_EXPECT_MSG_EQ (cache.IsDuplicate (Ipv4Address ("1.2.3.4"), 3), false, "Unknown ID & address");
+  NS_TEST_EXPECT_MSG_EQ (cache.IsDuplicate (Ipv4Address ("1.2.3.4"), 4), false, "Unknown ID");
+  NS_TEST_EXPECT_MSG_EQ (cache.IsDuplicate (Ipv4Address ("4.3.2.1"), 3), false, "Unknown address");
+  NS_TEST_EXPECT_MSG_EQ (cache.IsDuplicate (Ipv4Address ("1.2.3.4"), 3), true, "Known address & ID");
+  cache.SetLifetime (Seconds (15));
+  NS_TEST_EXPECT_MSG_EQ (cache.GetLifeTime (), Seconds (15), "New lifetime");
+  cache.IsDuplicate (Ipv4Address ("1.1.1.1"), 4);
+  cache.IsDuplicate (Ipv4Address ("1.1.1.1"), 4);
+  cache.IsDuplicate (Ipv4Address ("2.2.2.2"), 5);
+  cache.IsDuplicate (Ipv4Address ("3.3.3.3"), 6);
+  NS_TEST_EXPECT_MSG_EQ (cache.GetSize (), 6, "trivial");
+
+  Simulator::Schedule (Seconds (5), &IdCacheTest::CheckTimeout1, this);
+  Simulator::Schedule (Seconds (11), &IdCacheTest::CheckTimeout2, this);
+  Simulator::Schedule (Seconds (30), &IdCacheTest::CheckTimeout3, this);
+  Simulator::Run ();
+  Simulator::Destroy ();
+}
+
+void
+IdCacheTest::CheckTimeout1 ()
+{
+  NS_TEST_EXPECT_MSG_EQ (cache.GetSize (), 6, "Nothing expire");
+}
+
+void
+IdCacheTest::CheckTimeout2 ()
+{
+  NS_TEST_EXPECT_MSG_EQ (cache.GetSize (), 3, "3 records left");
+}
+
+void
+IdCacheTest::CheckTimeout3 ()
+{
+  NS_TEST_EXPECT_MSG_EQ (cache.GetSize (), 0, "All records expire");
+}
+
+/**
+ * \ingroup aomdv-test
+ * \ingroup tests
+ *
+ * \brief Id Cache Test Suite
+ */
+class IdCacheTestSuite : public TestSuite
+{
+public:
+  IdCacheTestSuite () : TestSuite ("aomdv-routing-id-cache", AOMDV_TEST_TYPE_UNIT)
+  {
+    AddTestCase (new IdCacheTest, AOMDV_TEST_QUICK);
+  }
+} g_idCacheTestSuite; ///< the test suite
+
+}  // namespace aomdv
+}  // namespace ns3

--- a/ns3/examples/CMakeLists.txt
+++ b/ns3/examples/CMakeLists.txt
@@ -40,6 +40,9 @@ build_lib_example(
     # just makes the direct dependency explicit.
     ${libenergy}
     ${libaodv}
+    # aomdv (#296): the vendored multipath baseline, installed to contrib/
+    # alongside anthocnet by `make install-ns3` (see ../aomdv/README.md).
+    ${libaomdv}
     ${libolsr}
     ${libdsdv}
     # #296: the vendored GPSR baseline module (contrib/gpsr, installed by the

--- a/ns3/examples/anthocnet-compare.cc
+++ b/ns3/examples/anthocnet-compare.cc
@@ -68,6 +68,9 @@
 
 
 #include "ns3/aodv-module.h"
+// #296: the vendored AOMDV baseline module (contrib/aomdv, installed together
+// with anthocnet by `make install-ns3`).
+#include "ns3/aomdv-module.h"
 #include "ns3/olsr-module.h"
 #include "ns3/dsdv-module.h"
 // #296: the vendored GPSR baseline (contrib/gpsr). Geographic — position
@@ -1338,6 +1341,7 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     InternetStackHelper internet;
     AntHocNetHelper ahnHelper;
     AodvHelper aodvHelper;
+    AomdvHelper aomdvHelper;
     OlsrHelper olsrHelper;
     DsdvHelper dsdvHelper;
     GpsrHelper gpsrHelper;
@@ -1345,6 +1349,11 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
         internet.SetRoutingHelper(ahnHelper);
     } else if (proto == "aodv") {
         internet.SetRoutingHelper(aodvHelper);
+    } else if (proto == "aomdv") {
+        // #296: vendored multipath baseline. Not in the default protocol list —
+        // it joins campaign dispatches explicitly (phase 3); the harness
+        // attaches to it exactly what it attaches to the other baselines.
+        internet.SetRoutingHelper(aomdvHelper);
     } else if (proto == "olsr") {
         internet.SetRoutingHelper(olsrHelper);
     } else if (proto == "dsdv") {
@@ -1378,6 +1387,9 @@ Result RunOne(const std::string& proto, const Params& P, uint32_t seed) {
     } else if (proto == "aodv") {
         TakeStreams(stream, streamBase, aodvHelper.AssignStreams(nodes, stream),
                     "aodv routing");
+    } else if (proto == "aomdv") {
+        TakeStreams(stream, streamBase, aomdvHelper.AssignStreams(nodes, stream),
+                    "aomdv routing");
     } else if (proto == "olsr") {
         TakeStreams(stream, streamBase, olsrHelper.AssignStreams(nodes, stream),
                     "olsr routing");

--- a/ns3/tools/run-comparison.sh
+++ b/ns3/tools/run-comparison.sh
@@ -14,7 +14,7 @@
 #
 # The ns-3 tree must have been configured with:
 #   ./ns3 configure --enable-examples \
-#     --enable-modules='anthocnet;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
+#     --enable-modules='anthocnet;aomdv;wifi;mobility;applications;aodv;olsr;dsdv;flow-monitor;point-to-point'
 
 set -euo pipefail
 


### PR DESCRIPTION
## Read this first: the arm builds, it does not route multi-hop

This lands the vendored AOMDV module as a **build-matrix citizen only**. A smoke run added as a sanity check found it delivers **PDR 0.0 % with 86 % of drops attributed to "route"** (25 nodes / 300 m / 4 flows / 40 s, ns-3.48), against **16 % PDR / 0.09 % route drops for stock `aodv` on the identical scenario**. On a trivial 5-node / 100 m field it does deliver (PDR 10 %, `hopsMean=1.00`) — one-hop discovery works, **multi-hop discovery does not**.

**The arm must not be scheduled into a campaign in this state.** `ns3/aomdv/README.md` gains a "Runtime status" section saying exactly that, and the acceptance criterion (directional agreement with Marina & Das 2001) stays unmet and unmeasured.

Per the [campaign plan](../blob/main/docs/benchmarks/v1.5.0-campaign.md), the AOMDV spike's "deliverable may well be a written infeasibility verdict" — this PR is that verdict plus the code and the reproduction, not a working baseline.

## Why land it rather than drop it

The module compiles clean across the whole matrix, is off by default, and carries full provenance; landing it makes the failure reproducible and the next audit cheap. Dropping it would discard ~7.5k lines of vendored-and-fixed code and the diagnosis of *why* it fails.

## What was found (six defects beyond the three the spike named)

Two were compiler-proved UB that would have failed the ASan leg:
- `-Wreturn-local-addr`: `PathInsert` returned `&path`, a dead local — every caller wrote through a dangling stack address.
- `-Wnonnull` (`'this' pointer is null`): `RecvReply` compared where its sibling in `RecvRequest` assigns.

Four more were hard aborts/segfaults found by actually running the arm:
- `NS_ABORT_MSG_UNLESS (rt.GetRreqCnt () > 0, ...)` — `SendRequest`'s fresh entry never set the hop count (stock passes `/*hop=*/ ttl` to a ctor the fork's entry lacks).
- `cannot add the same kind of tag twice … ns3::SocketIpTtlTag` — five sockets set the `IpTtl` attribute where stock 3.36 calls `SetIpRecvTtl (true)`.
- `SIGSEGV Path::GetNextHop (this=0x0)` — `PathFind ()` dereferenced `begin ()` on an empty list.
- `SIGSEGV RecvRequest` — the fresh-reverse-route branch left `toOrigin` default-constructed and pathless.

**Likely root cause of the remaining gap**, consistent with README defects 2/4/9: the fork's value-semantics translation of ns-2's *pointer-aliased* routing table — every `Path*` from a `RoutingTableEntry` aliases whichever copy produced it, and a mutation only persists if `m_routingTable.Update ()` follows on that same copy. The sites fixed are the ones a run reached; the rest of the RREQ/RREP paths are unaudited.

This also corrects the record: the earlier README's implication that the three original spike fixes made the port routable was **not true**.

## Matrix hardening (the three classes GPSR hit on the same matrix, pre-empted)

- **19 `Ptr`-vs-0 rewrites** in `aomdv-routing-protocol.cc` (ns-3.37+ removed the safe-bool idiom). Integer/raw-pointer sites deliberately untouched (`erase (dst) != 0`, `m_prefixSize != 0`, `entry != 0` on a raw `ArpCache::Entry *`, etc.).
- **2 `__has_include("ns3/wifi-mpdu.h")` gates** in `aomdv-routing-protocol.h` (`ROUTEINPUT_BYVALUE`, `WIFI_QUEUE_ITEM`), matching `gpsr.h` — header gates can't rely on CMake-scoped defines, which is what broke GPSR's 3.36 build. Probe verified to discriminate (absent in 3.36, present in 3.48). `.cc`/test gates left as-is since they compile inside the module.
- **17 SPDX headers** fixed; `check-headers.py` 17 → 0 problems over 113 files.

## Verification

- Local builds **clean on both matrix extremes, zero errors and zero warnings**: ns-3.36 (735 targets) and ns-3.48 — `libns3.*-aomdv`, `libns3.*-gpsr`, and `anthocnet-compare` all link in both.
- `aomdv-id-cache-test-suite.cc` hand-compiled under both enum regimes (CI's example/test filter skips it).
- `ruff check .` and `check-headers.py` green.
- Harness: `--protocols=...,aomdv`, off by default; existing four-protocol runs and their RNG streams untouched. Coexists with the `gpsr` arm merged in #412.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_