### PR TITLE
fix(bench): stop the #230 diversity gate crying wolf, and frame the baseline set (#296)

### DIFF
--- a/.claude/skills/benchmark-results/SKILL.md
+++ b/.claude/skills/benchmark-results/SKILL.md
@@ -225,6 +225,48 @@ inputs predating route-quality instrumentation), and — with `--anchor` — the
 `ns3/tools/anchors.yml` (never duplicated). A `results` FAIL is a #51-class
 harness regression: fix the harness before trusting any number from that run.
 
+#### Path diversity is read as excess over the in-run churn floor (#230)
+
+`path_div_used` counts distinct next hops that carried data for one
+destination inside one `pathWindowS` window. A protocol that installs one route
+per destination can only exceed 1.0 by having that route *replaced* inside the
+window, so **whatever `aodv`/`olsr`/`dsdv` read above 1.0 is that scenario's
+churn floor**, measured in-run by three protocols at once. `results` therefore
+prints, once per cell (not once per protocol):
+
+- floor ≤ 1.10 → `ok: … path diversity readable — anthocnet 1.229 vs
+  single-path floor 1.133 (aodv) at windowS=2: excess +0.096`. That excess is
+  the only quotable diversity claim.
+- floor > 1.10 at a window above 2 s → one **WARN**: the diversity columns are
+  churn-dominated and unquotable, with the floor, the protocol that set it and
+  AntHocNet's excess in the message.
+- AntHocNet at or below a *clean* floor → **WARN**: no concurrent spreading in
+  a cell able to show it.
+- a single-path baseline above 1.50 at a churn-free window (≤ 2 s), or any
+  arithmetic break (diversity < 1, above its own maximum, zero at non-zero PDR,
+  entropy above log2(max)) → **FAIL**, unchanged: those are broken
+  instrumentation, not a mis-set threshold.
+
+The absolute `> 1.10 ⇒ FAIL` rule this replaces was **not** calibratable. The
+#230 sweeps show the floor is a function of the scenario knobs — olsr/aodv read
+1.000/1.000 at `windowS=2`, 1.116/1.109 at 4, 1.198/1.190 at 6, 1.322/1.311 at
+10, and 1.133 at `windowS=2` once the rate is raised to 8 pkt/s — while
+`windowS ≤ 2` at paper traffic pins *every* protocol, AntHocNet included, at
+~1.00 by sample starvation. No constant is both satisfiable and informative.
+Worse, the rule passed the row least worth trusting: across the 14 cells of the
+v1.5.0 campaign AntHocNet reads **below** the single-path floor every time
+(excess −0.061 to −0.144), so the threshold failed the three controls and
+cleared the arm they were controlling.
+
+And the excess never invalidates a cell: `divUsed` is accumulated in its own
+(node, dest, window) map off the WifiMac `AckedMpdu` trace
+(`anthocnet-compare.cc` `CountAckedDataHop`), while PDR/delay/delay99/
+throughput/NRL/jitter come from FlowMonitor and the energy columns from the
+energy model. A churn-inflated diversity figure cannot move a published number,
+so it is a WARN about three columns, not a FAIL about the cell. It was a FAIL
+for 14 consecutive campaign cells, every one of which was correctly waved
+through — which is how a gate stops being read.
+
 ### Testing the gate itself (`test_scenario_check.py`)
 
 ```bash

--- a/.claude/skills/benchmark-results/scenario_check.py
+++ b/.claude/skills/benchmark-results/scenario_check.py
@@ -61,7 +61,32 @@ HOLD_CEILING_MS = 5000.0
 # is the diversity *window* counting route replacement as concurrent multipath —
 # it calibrates the window, and it is the only external check on whether an
 # AntHocNet diversity figure means anything.
+#
+# That excess is NOT correctable by moving this number, and the rule is
+# deliberately no longer a FAIL. Two measured facts decide it:
+#
+#   - The floor is a function of the scenario knobs, not a constant. The #230
+#     window sweep at 900 s (paper knobs, one binary, one seed) reads
+#     olsr/aodv 1.000/1.000 at windowS=2, 1.116/1.109 at 4, 1.198/1.190 at 6,
+#     1.322/1.311 at 10; the dedicated 8 pkt/s cell reads aodv 1.133 at
+#     windowS=2. So it also rises with offered rate, and no absolute threshold
+#     is simultaneously satisfiable (windowS<=2 pins every protocol, AntHocNet
+#     included, at ~1.00 — the sample-starvation floor) and informative.
+#   - The excess never invalidates a cell. divUsed is accumulated in its own
+#     (node, dest, window) map off the WifiMac AckedMpdu trace
+#     (anthocnet-compare.cc CountAckedDataHop / FlushDiversityWindow); PDR,
+#     delay, delay99, throughput, NRL and jitter come from FlowMonitor and the
+#     energy columns from the energy model. A churn-inflated divUsed cannot
+#     move a single published number.
+#
+# So a contaminated floor makes exactly the diversity columns unquotable and is
+# reported once per cell as a WARN naming the floor, not as three per-row FAILs
+# that condemn the whole cell (14/14 campaign cells FAILed on nothing else, and
+# every one was waved through — the cry-wolf failure SKILL.md warns about).
+# The readable quantity is AntHocNet's EXCESS over the in-run floor, so that is
+# what gets printed whether the cell is contaminated or clean.
 SINGLE_PATH_PROTOS = ("aodv", "olsr", "dsdv")
+MULTI_PATH_PROTO = "anthocnet"
 SINGLE_PATH_DIV_MAX = 1.10
 # The dedicated diversity-measurement cell (#230, run 30650903707): window
 # <= DIV_CELL_WINDOW_S is the calibrated churn-free window, where a raised
@@ -832,6 +857,80 @@ def check_reinj(path):
                                "#386 books disagree (#386)")
 
 
+def _fnum(row, key):
+    try:
+        return float(row.get(key))
+    except (TypeError, ValueError):
+        return None
+
+
+def check_path_diversity(rows):
+    """#230: read path diversity as excess over the in-run single-path floor.
+
+    `path_div_used` counts distinct next hops that carried data for a
+    destination inside one `pathWindowS` window. A protocol that installs one
+    route per destination can only exceed 1.0 by having that route *replaced*
+    inside the window, so whatever the baselines read above 1.0 is the churn
+    floor of that scenario — measured, in-run, by three protocols at once. The
+    only claim the metric can support is AntHocNet's excess over that floor,
+    and that is what this prints; the absolute value is uninterpretable on its
+    own (see the sweep in the SINGLE_PATH_DIV_MAX comment).
+
+    One report per cell, not per row. Contamination is a property of the
+    window, so three baselines breaching one threshold is one finding stated
+    three times, and it was the whole content of 14/14 campaign FAILs.
+
+    Rows are grouped by `where` — one saved cell is one group; a campaign CSV
+    groups per scenario, which is the level the floor is a constant at.
+    Inputs without diversity columns, and cells with no single-path row to
+    measure a floor against, produce nothing.
+    """
+    groups = {}
+    for r in rows:
+        div = _fnum(r, "div")
+        if div is None:
+            continue
+        groups.setdefault(r["where"], []).append((r["proto"], div, r))
+    for where, grp in groups.items():
+        floors = [(d, p) for p, d, _ in grp if p in SINGLE_PATH_PROTOS]
+        if not floors:
+            continue
+        floor, floor_proto = max(floors)
+        multi = next((d for p, d, _ in grp if p == MULTI_PATH_PROTO), None)
+        windows = [w for w in (_fnum(r, "div_window") for _, _, r in grp)
+                   if w is not None]
+        window = max(windows) if windows else None
+        churn_free = window is not None and window <= DIV_CELL_WINDOW_S
+        excess = None if multi is None else multi - floor
+        reading = ("no anthocnet row in this cell" if excess is None else
+                   f"anthocnet {multi} = {excess:+.3f} vs the floor")
+        wtxt = "unknown" if window is None else f"{window:g}"
+        if not churn_free and floor > SINGLE_PATH_DIV_MAX:
+            report("WARN", f"{where}: path diversity is churn-dominated — the "
+                           f"single-path floor is {floor} ({floor_proto}) at "
+                           f"windowS={wtxt}, i.e. route replacement inside the "
+                           f"window is being counted as concurrent multipath; "
+                           f"{reading}. Do not quote path_div_*/"
+                           f"path_entropy_bits from this cell. Nothing else is "
+                           f"affected: PDR/delay/NRL/jitter come from "
+                           f"FlowMonitor, not from the diversity window (#230)")
+        elif excess is None:
+            print(f"ok: {where}: single-path diversity floor {floor} "
+                  f"({floor_proto}) at windowS={wtxt} — churn-free")
+        elif excess > 0.0:
+            print(f"ok: {where}: path diversity readable — anthocnet {multi} "
+                  f"vs single-path floor {floor} ({floor_proto}) at "
+                  f"windowS={wtxt}: excess {excess:+.3f}")
+        else:
+            report("WARN", f"{where}: anthocnet path diversity {multi} does "
+                           f"not exceed the single-path floor {floor} "
+                           f"({floor_proto}) at windowS={wtxt} (excess "
+                           f"{excess:+.3f}) — the multipath protocol shows no "
+                           f"concurrent spreading the baselines do not also "
+                           f"show, in a cell where the floor is clean enough "
+                           f"to say so (#230)")
+
+
 def cmd_results(a):
     floor = anchor_floor(a.anchor) if a.anchor else None
     n = 0
@@ -839,7 +938,9 @@ def cmd_results(a):
         check_provenance(path)
         check_drop_identity(path)
         check_reinj(path)
-        for r in parse_results(path):
+        rows = list(parse_results(path))
+        check_path_diversity(rows)
+        for r in rows:
             n += 1
             tag = f"{r['where']}/{r['proto']}"
 
@@ -1083,19 +1184,9 @@ def cmd_results(a):
                                    "is not churn-free at this offered rate, "
                                    "so the diversity cell is unreadable "
                                    "(#230)")
-                elif (r["proto"] in SINGLE_PATH_PROTOS
-                        and (div_window is None
-                             or div_window > DIV_CELL_WINDOW_S)
-                        and div > SINGLE_PATH_DIV_MAX):
-                    report("FAIL", f"{tag}: path diversity {div} > "
-                                   f"{SINGLE_PATH_DIV_MAX} for a single-path "
-                                   "protocol — path_div_window_s is longer than "
-                                   "the route lifetime, so route replacement is "
-                                   "being counted as concurrent multipath; "
-                                   "diversity is only readable from the "
-                                   "dedicated cell (cbrBps=4096, "
-                                   "pathWindowS=2), as excess over the "
-                                   "single-path floor (#230)")
+                # A churn-inflated single-path reading is not judged per row:
+                # it is a property of the cell and is read against the other
+                # protocols measured beside it, in check_path_diversity().
             if div_max is not None and div is not None and div_max and div_max < div:
                 report("FAIL", f"{tag}: max path diversity {div_max} < mean "
                                f"path diversity {div}")

--- a/.claude/skills/benchmark-results/test_scenario_check.py
+++ b/.claude/skills/benchmark-results/test_scenario_check.py
@@ -179,16 +179,21 @@ def _runs_floor_quiet():
 
 # --- #230 path diversity -----------------------------------------------------
 
-@case("#230 single-path baseline above 1.10 FAILs")
+@case("#230 single-path floor above 1.10 WARNs — and does not FAIL the cell")
 def _div_fires():
-    # olsr / heavy-load, the worst real reading of the campaign.
+    # olsr / heavy-load, the worst real reading of the campaign. It must still
+    # be said out loud (the diversity columns are unquotable), but it must not
+    # condemn the cell: divUsed is accumulated off the WifiMac AckedMpdu trace
+    # and cannot move a FlowMonitor number. 14 consecutive campaign cells
+    # FAILed on exactly this and nothing else, and all 14 were waved through.
     levels, out = run_results(protocol="olsr", path_div_used="1.428")
-    expect("FAIL" in levels, "div-fires", f"no FAIL for olsr div 1.428\n{out}")
-    expect("single-path protocol" in out, "div-fires",
-           f"FAIL did not name the cause\n{out}")
+    expect(levels == ["WARN"], "div-fires",
+           f"expected exactly one WARN for olsr div 1.428, got {levels}\n{out}")
+    expect("churn-dominated" in out and "1.428" in out, "div-fires",
+           f"WARN did not name the mechanism and the floor\n{out}")
 
 
-@case("#230 single-path baseline at 1.004 passes")
+@case("#230 single-path floor at 1.004 passes")
 def _div_quiet_baseline():
     # olsr / sparse-static — the churn-free control, the one row that already
     # reads correctly. If the threshold ever creeps below this the calibration
@@ -199,7 +204,8 @@ def _div_quiet_baseline():
 
 @case("#230 rule does not apply to anthocnet")
 def _div_quiet_anthocnet():
-    # AntHocNet is *supposed* to exceed 1; flagging it would invert the rule.
+    # AntHocNet is *supposed* to exceed 1, and with no single-path row beside
+    # it there is no floor to read it against, so there is nothing to say.
     levels, out = run_results(protocol="anthocnet", path_div_used="1.512")
     expect(levels == [], "div-anthocnet", f"fired on anthocnet\n{out}")
 
@@ -595,22 +601,33 @@ def run_cell(text, prov=True):
         os.unlink(path)
 
 
-@case("cell: real run 30379320885 FAILs on its own out-of-band baselines")
+@case("cell: real run 30379320885 WARNs once on its churn-dominated floor")
 def _cell_real():
+    # Every baseline here is out of band (aodv 1.112, olsr 1.117 at windowS=4)
+    # and AntHocNet reads *below* both (1.104). That is one finding about the
+    # window, not three about three protocols, and it invalidates nothing but
+    # the diversity columns — so: no FAIL, one WARN, naming the floor and the
+    # excess that is the only readable quantity.
     levels, out = run_cell(CELL)
-    expect(levels.count("FAIL") == 2, "cell-real",
-           f"expected exactly the aodv+olsr diversity FAILs, got {levels}\n{out}")
-    expect("aodv: path diversity 1.112" in out and
-           "olsr: path diversity 1.117" in out, "cell-real",
-           f"wrong rows flagged\n{out}")
+    expect("FAIL" not in levels, "cell-real",
+           f"a churn-dominated floor must not FAIL the cell, got {levels}\n{out}")
+    expect(out.count("churn-dominated") == 1, "cell-real",
+           f"expected exactly one diversity WARN\n{out}")
+    expect("1.117 (olsr)" in out and "anthocnet 1.104 = -0.013" in out,
+           "cell-real", f"WARN did not carry floor and excess\n{out}")
 
 
-@case("cell: impossible divUsed on a '# paths' line fires (the 9.999 probe)")
+@case("cell: impossible divUsed on a '# paths' line still FAILs (9.999 probe)")
 def _cell_div_fires():
-    _levels, out = run_cell(CELL.replace("aodv divUsed=1.112",
+    # The instrument-broken half of the rule stays a FAIL: 9.999 mean distinct
+    # next hops against a measured maximum of 2.5 is arithmetically impossible,
+    # so no threshold judgement is involved.
+    levels, out = run_cell(CELL.replace("aodv divUsed=1.112",
                                         "aodv divUsed=9.999"))
-    expect("path diversity 9.999" in out, "cell-div",
-           f"planted divUsed=9.999 not flagged\n{out}")
+    expect("FAIL" in levels, "cell-div",
+           f"planted divUsed=9.999 did not FAIL, got {levels}\n{out}")
+    expect("max path diversity 2.5 < mean path diversity 9.999" in out,
+           "cell-div", f"FAIL did not name the broken invariant\n{out}")
 
 
 # --- #308 phase 2 step 4: pending-queue hold on the ##HOLD## rows -------------
@@ -821,9 +838,25 @@ DIVCELL = """\
 
 @case("#230 diversity cell: baseline above 1.10 at windowS<=2 stays quiet")
 def _divcell_floor_allowed():
-    _levels, out = run_cell(DIVCELL)
-    expect("path diversity" not in out, "divcell-quiet",
-           f"absolute 1.10 rule fired inside the diversity cell\n{out}")
+    levels, out = run_cell(DIVCELL)
+    expect(levels == [], "divcell-quiet",
+           f"the readable diversity cell must be quiet, got {levels}\n{out}")
+    expect("path diversity readable" in out and "excess +0.096" in out,
+           "divcell-quiet",
+           f"the one readable diversity claim was not printed\n{out}")
+
+
+@case("#230 diversity cell: anthocnet at the floor WARNs — no spreading")
+def _divcell_no_separation():
+    # The other half of the same reading. If the multipath protocol matches the
+    # churn floor in a cell clean enough to measure one, the defining claim
+    # fails — and that is worth saying precisely because this cell can say it.
+    levels, out = run_cell(DIVCELL.replace("anthocnet divUsed=1.229",
+                                           "anthocnet divUsed=1.133"))
+    expect(levels == ["WARN"], "divcell-nosep",
+           f"expected one WARN for a zero excess, got {levels}\n{out}")
+    expect("does not exceed the single-path floor" in out, "divcell-nosep",
+           f"WARN did not name the finding\n{out}")
 
 
 @case("#230 diversity cell: baseline above the 1.50 sanity ceiling fires")
@@ -832,6 +865,52 @@ def _divcell_sanity_fires():
                                             "aodv divUsed=1.633"))
     expect("not churn-free at this offered rate" in out, "divcell-sanity",
            f"planted 1.633 above the sanity ceiling not flagged\n{out}")
+
+
+# --- the shape the v1.5.0 campaign actually produced (#230) ------------------
+# grid-v150/rwp-tworay, one of the 14 cells (6 grid re-baseline + 8 phase-2)
+# that every returned `verdict: FAIL` on the diversity rule and nothing else,
+# and that were every one waved through as "known #230, non-blocking". All four
+# protocols, windowS=10, drop identity closing to within 0.07 pp, energy and
+# reordering sane: the cell is publication-grade on every metric the campaign
+# publishes, and the only thing wrong with it is a metric no document quotes.
+# It is the regression fixture for over-firing — if this cell ever FAILs again,
+# the gate has gone back to crying wolf.
+GRIDCELL = """\
+##BENCH## anthocnet 92.6 29.3 420.8 6.11 34.92 46.15 1.8 301.7 40.674
+##BENCH## aodv 85.9 42.4 584.6 5.67 64.64 67.01 3.5 inf 34.056
+##BENCH## olsr 90.6 7.4 23.2 5.83 4.02 10.89 1.1 inf 10.431
+##BENCH## dsdv 85.0 15.2 419.8 5.61 23.01 26.72 1.4 inf 15.744
+# paths anthocnet divUsed=1.275 divMax=4.9 entropyBits=0.221 windowS=10.0 hopsMean=1.97 hopsMax=13.4
+# paths aodv divUsed=1.346 divMax=5.0 entropyBits=0.259 windowS=10.0 hopsMean=1.75 hopsMax=16.9
+# paths olsr divUsed=1.326 divMax=5.0 entropyBits=0.243 windowS=10.0 hopsMean=1.53 hopsMax=9.7
+# paths dsdv divUsed=1.169 divMax=3.8 entropyBits=0.141 windowS=10.0 hopsMean=1.55 hopsMax=6.0
+# drops anthocnet pdr=92.59 route=5.45 queue=0.00 mac=0.18 chan=1.76 ttl=0.03 sum=100.01 other=0.00 [route: setup=0.00 reconv=5.30 repair=0.14]
+# drops aodv pdr=85.93 route=3.02 queue=0.01 mac=8.50 chan=2.45 ttl=0.02 sum=99.93 other=0.00 [route: setup=- reconv=- repair=-]
+# drops olsr pdr=90.59 route=0.09 queue=0.00 mac=7.55 chan=1.76 ttl=0.01 sum=100.00 other=0.00 [route: setup=- reconv=- repair=-]
+# drops dsdv pdr=84.99 route=0.00 queue=0.00 mac=12.36 chan=2.65 ttl=0.00 sum=100.00 other=0.00 [route: setup=- reconv=- repair=-]
+"""
+
+
+@case("#230 a real v1.5.0 campaign cell WARNs once and exits 0")
+def _gridcell_quiet():
+    levels, out = run_cell(GRIDCELL)
+    expect(levels == ["WARN"], "gridcell",
+           f"the 14-cell campaign shape must be one WARN, got {levels}\n{out}")
+    expect("1.346 (aodv)" in out and "anthocnet 1.275 = -0.071" in out,
+           "gridcell", f"WARN did not carry floor and excess\n{out}")
+
+
+@case("#230 the same cell with a real defect still FAILs loudly")
+def _gridcell_defect_fires():
+    # dsdv losing 12.36 pp at the MAC retry limit, unaccounted: the #229 class
+    # where the identity breaks and the numbers genuinely cannot be trusted.
+    # Demoting diversity to WARN must not have demoted this with it.
+    levels, out = run_cell(GRIDCELL.replace("mac=12.36 chan=2.65", "mac=0.00 chan=2.65"))
+    expect("FAIL" in levels, "gridcell-defect",
+           f"a broken drop identity must still FAIL, got {levels}\n{out}")
+    expect("drop causes" in out, "gridcell-defect",
+           f"FAIL did not name the identity\n{out}")
 
 
 # --- #259 satellite (isl-grid) input: CSV schema + human mode + rules --------

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,8 @@ golden rules, where-to-look), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 |---|---|
 | [benchmarks.md](benchmarks.md) | Results index: per-merge taxonomy table + links to every scenario/sweep page. |
 | [benchmarks/metrics.md](benchmarks/metrics.md) | What PDR, delay99, NRL etc. mean, and their caveats. |
-| [benchmarks/methodology.md](benchmarks/methodology.md) | Reproduce commands (local and CI dispatch), build profiles, validation anchors, determinism gate. |
+| [benchmarks/methodology.md](benchmarks/methodology.md) | Reproduce commands (local and CI dispatch), build profiles, validation anchors, determinism gate, and what each baseline arm is for. |
+| [benchmarks/modern-baseline-survey.md](benchmarks/modern-baseline-survey.md) | Dated survey of ns-3 support for Babel / BATMAN-adv / OLSRv2, and the decision it drove. |
 | [benchmarks/README.md](benchmarks/README.md) | How the figures/tables are generated and regenerated. |
 | [benchmarks/satellite/isl-grid.md](benchmarks/satellite/isl-grid.md) | The satellite/ISL suite: harness, analytic anchors, dispatch. |
 | [benchmarks/grid.md](benchmarks/grid.md) | The mobility × channel grid and its scoped ranking-stability statement. |

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -1,7 +1,8 @@
 # Benchmark methodology
 
 How the numbers are produced: how to reproduce a run, the scenario taxonomy and
-sweeps the harness drives, the ns-3 build profile they run under, and the
+sweeps the harness drives, [what each baseline arm is for](#baselines-what-each-arm-is-for-296)
+and what its provenance is worth, the ns-3 build profile they run under, and the
 validation anchors that gate publishing them. Part of the
 [benchmark index](../benchmarks.md); the metric definitions are in
 [metrics.md](metrics.md).
@@ -150,7 +151,282 @@ PDR / mean+99th-percentile delay / NRL vs. the swept parameter:
 - **[scale](sweeps/scale.md)** (Fig. 3): terrain ×f, nodes ×f² (50→200 nodes).
 
 Unlike the paper (AODV only), every baseline (AODV/OLSR/DSDV) is run on identical
-realisations, so the classification covers all of them.
+realisations, so the classification covers all of them. What each of those arms
+is *for* — and which comparisons the baseline set does and does not support — is
+[the next section](#baselines-what-each-arm-is-for-296).
+
+## Baselines: what each arm is for ([#296](https://github.com/danieljoppi/AntHocNet/issues/296))
+
+The arms in this harness are not all the same kind of thing, and reading them as
+one undifferentiated "comparison set" gets the conclusions wrong in both
+directions. Three of them exist to show that this implementation reproduces a
+published result; one exists to check the protocol against a class of competitor
+the original work never faced; one will exist to bound what any protocol could
+achieve; one was attempted and is a documented gap. Provenance differs the same
+way — stock upstream code, third-party code this project repaired, and code
+written here — and each provenance carries its own quality risk.
+
+| arm | category | provenance | measurement status |
+|---|---|---|---|
+| `anthocnet` | subject under test | this repo (`core/` + `ns3/`) | measured everywhere |
+| `aodv`, `olsr`, `dsdv` | **replication anchors** | stock ns-3 modules, never vendored | the published corpus |
+| `gpsr` | **competitive frontier** | vendored third-party port, repaired here ([#412](https://github.com/danieljoppi/AntHocNet/pull/412)) | builds + ASan green; **unmeasured** until [campaign phase 3](v1.5.0-campaign.md#phase-3--the-oracle-control) |
+| oracle | **upper bound** | to be written here ([#415](https://github.com/danieljoppi/AntHocNet/issues/415)) | in progress |
+| `aomdv` | **attempted → documented gap** | vendored third-party port, repaired here ([#414](https://github.com/danieljoppi/AntHocNet/pull/414)) | builds on all five ns-3 versions; **does not route multi-hop** |
+| RL / DRL baseline | **deferred by design** | — | out of scope until [#293](https://github.com/danieljoppi/AntHocNet/issues/293) + [#295](https://github.com/danieljoppi/AntHocNet/issues/295) land |
+| Babel · BATMAN-adv · OLSRv2 | **decided against, for now** | — | [surveyed and declined](#modern-deployed-baseline--decided-not-skipped-item-4) |
+
+### Replication anchors — AODV / OLSR / DSDV
+
+**What they are for: fidelity, not competition.** The repo's canonical reference
+[1] (Di Caro, Ducatelle & Gambardella, PPSN VIII 2004; see
+[`docs/publications/`](../publications/README.md)) evaluated AntHocNet in Qualnet
+against **AODV with local route repair, and nothing else**. AODV is therefore the
+only arm that literally replicates the original comparison. OLSR and DSDV are
+this project's additions, chosen to cover the proactive link-state and proactive
+distance-vector classes that [1] §2 names as the alternatives to AODV's reactive
+class. A claim that this implementation reproduces the published AntHocNet
+result can only be made against the protocols the publication used — that is the
+whole job of these three arms.
+
+**Provenance: stock ns-3, deliberately untouched.** `src/aodv`, `src/olsr` and
+`src/dsdv` come from the prebuilt simulator image; nothing in this repository
+vendors, patches or wraps them. That is a reproducibility choice: nobody has to
+trust *our* port of a baseline, and anyone with the same image tag gets the same
+baseline code.
+
+**Quality risk.** Two kinds, and the second is the larger one.
+
+1. *Stock is well-tested, but stock is not the protocol on paper.* ns-3's OLSR
+   implements RFC 3626 and its own documentation states it "is *not* compliant
+   with OLSR Version 2 (RFC 7181) or any of the Version 2 extensions"; its scope
+   list further records that it does not respond to interface up/down
+   notifications and, unlike the NS-2 model it was ported from, "does not yet
+   support MAC layer feedback as described in RFC 3626" — a mechanism this
+   project's own protocol uses (ADR-0008's second detector). ns-3's DSDV sheds
+   packets from its routing queue with no observable signal at all, which this
+   harness had to reason around before its drop-conservation check could mean
+   anything ([#229](https://github.com/danieljoppi/AntHocNet/issues/229); see the
+   `ns3/examples/anthocnet-compare.cc` conservation block). Baselines inherit
+   their simulator's model gaps, and those gaps are not symmetric across arms.
+2. *They are the comparison set of 2004–2005, and 2026 reviewers increasingly
+   read them as strawmen.* That criticism is correct and is not answered by
+   adding seeds or confidence intervals to the same three arms. It is answered —
+   partially — by the categories below, and where it is **not** answered the gap
+   is stated in [the threat to validity](#the-resulting-threat-to-validity)
+   rather than papered over. These arms stay because the fidelity story requires
+   them, not because they are evidence of competitiveness.
+
+### Competitive frontier — GPSR
+
+**What it is for.** Geographic/greedy forwarding is the dominant baseline class
+in FANET and DRL routing papers, and the closest competitor class for the
+satellite/ISL suite (the grid-greedy family, [#296](https://github.com/danieljoppi/AntHocNet/issues/296)'s
+second premise). It is the one arm here that AntHocNet's own literature never
+faced.
+
+**Provenance.** Vendored from
+[`dwosion/ns3.29-with-gpsr`](https://github.com/dwosion/ns3.29-with-gpsr) at
+commit `15241ef`, itself the ns-3.29 refresh of António Fonseca's 2011–12 port;
+GPLv2 verified end to end. Ported here to the ns-3.36–3.48 matrix with the three
+faults the spike named fixed: the dead `TxErrHeader` trace re-pointed at
+`DroppedMpdu`, per-call RNG objects replaced by an `AssignStreams`-pinned member
+(the [#352](https://github.com/danieljoppi/AntHocNet/issues/352) requirement),
+and the position-header layering reordered to `IP|UDP|GPSR` so FlowMonitor
+classifies data flows correctly. Full detail and per-file port notes:
+[`ns3/gpsr/README.md`](../../ns3/gpsr/README.md).
+
+**Quality risk — this is a repaired third-party port, not a reference
+implementation.**
+
+- There is no upstream to diff against and no independent validation of the
+  numbers it will produce. Its acceptance evidence has to be its own measured
+  behaviour in phase 3, not its pedigree. [#414](https://github.com/danieljoppi/AntHocNet/pull/414)
+  is the standing reminder of what "it builds" is worth.
+- [PA-GPSR](https://github.com/CSVNetLab/PA-GPSR) (IEEE Access 2019) fixed real
+  bugs in this lineage, but publishes no licence anywhere and so was not copied
+  from — not one line. Where this port needed the same fix it was re-derived
+  from the paper. **Defects PA-GPSR found that this port did not independently
+  encounter may still be present.**
+- The arm is configured *favourably to itself*: position knowledge comes from a
+  GOD location service reading each node's `MobilityModel` directly — perfect,
+  instantaneous, zero-overhead location. Real GPSR pays for a location service
+  in both traffic and staleness. A GPSR result here is therefore an **upper
+  bound on GPSR**, and a GPSR win reads as "geographic routing *with free
+  location information* beats us", not "GPSR beats us".
+
+### Upper bound — the oracle control ([#415](https://github.com/danieljoppi/AntHocNet/issues/415))
+
+Global-knowledge Dijkstra over the ground-truth topology, replayed as an
+`Ipv4RoutingProtocol`. **Not a protocol — a control**, and the only arm that can
+answer "how much of the gap between AntHocNet and perfect is protocol overhead?"
+In progress; it is [phase 3](v1.5.0-campaign.md#phase-3--the-oracle-control) of
+the v1.5.0 campaign.
+
+**What it will be exact for.** On the `range` disk model adjacency is crisp, so
+the path it takes *is* the shortest path; it emits no control traffic (NRL
+exactly 0, an assertable property rather than an expectation) and performs no
+discovery, so its delay is queueing plus propagation only.
+
+**What it will not be exact for**, stated now so no reader over-reads it later:
+
+- **Fading channels have no crisp adjacency.** Under `nakagami` — and at the
+  margin under `tworay` — link existence is a probabilistic event, so "the
+  ground-truth graph" needs a stated rule and remains an approximation whichever
+  rule is chosen. #415 requires that rule to be documented rather than silently
+  assumed.
+- **It bounds routing, not delivery.** It runs on the same MAC/PHY as every
+  other arm, so contention and collision losses remain. An oracle PDR below
+  100 % is expected and is not a defect.
+- **Shortest-path is not the throughput optimum.** Under congestion a
+  load-spreading multipath protocol can beat a shortest-hop oracle. The oracle
+  upper-bounds *path quality by hop count*, which is why #415's falsifiable
+  assertions are "hop count ≤ every other arm" generally, and "PDR ≥ every other
+  arm" only on a static lossless topology.
+- Consequently the AntHocNet-to-oracle gap is an **upper bound on how much of
+  the shortfall is protocol overhead** — it does not decompose that shortfall
+  into discovery cost, suboptimal path choice and reconvergence loss.
+
+### Attempted and documented as a gap — AOMDV (multipath)
+
+AntHocNet is a multipath protocol (`enableMultipath`, default on). The standard
+classical multipath on-demand baseline is **AOMDV** (Marina & Das, 2001), and a
+reviewer is entitled to ask why a multipath protocol is not compared against
+one. The honest answer, with its evidence:
+
+- **AOMDV is not in stock ns-3** — `src/aomdv` is absent from `ns-3-dev`
+  (probed 2026-08-13; see the
+  [availability survey](modern-baseline-survey.md#what-stock-ns-3-ships)).
+- **The best available third-party port was vendored and repaired here**
+  ([#414](https://github.com/danieljoppi/AntHocNet/pull/414)): stock ns-3.36
+  `src/aodv` rebased with the AOMDV delta from the CharithaS fork, licence
+  verified GPLv2, cross-version gated for the whole CI matrix, with **nine
+  defects in the fork fixed** — two of them compiler-proved undefined behaviour,
+  four of them hard aborts or segfaults found only by *running* the arm.
+- **It compiles clean — zero errors, zero warnings — on all five ns-3 versions,
+  and it does not route.** On 25 nodes / 300 m / 4 flows / 40 s (ns-3.48, single
+  run) it delivers **0.0 % PDR with 86 % of drops charged to "route"**, against
+  **16.0 % PDR / 0.09 % route drops for stock `aodv` on the identical
+  scenario**. On a trivial 5-node / 100 m field it *does* deliver (PDR 10 %,
+  `hopsMean = 1.00`). One-hop discovery works; multi-hop discovery does not.
+- **The likely cause is diagnosed, not guessed**: the fork's value-semantics
+  translation of ns-2's *pointer-aliased* routing table. In ns-2 a `Path*`
+  obtained from a route entry aliases the live entry; in the fork it aliases
+  whichever *copy* produced it, so a mutation survives only if an
+  `m_routingTable.Update()` follows on that same copy. The sites fixed are
+  exactly those a run reached; the remaining RREQ/RREP paths are unaudited for
+  the same pattern. Finishing it is an open-ended protocol-level audit of a
+  vendored fork, not port mechanics.
+- **The arm therefore ships as a build-matrix citizen only** — off by default,
+  with a "Runtime status" section in
+  [`ns3/aomdv/README.md`](../../ns3/aomdv/README.md) that says so, and it must
+  not be scheduled into a campaign in this state. It was landed rather than
+  dropped so the failure stays reproducible and the next audit starts from the
+  diagnosis instead of from scratch.
+
+**Publishing its numbers is not an alternative.** 0 % PDR is not the finding
+"AOMDV performs poorly"; it is the finding "this port does not route". Reporting
+it as a protocol result would be a fabricated comparison, and would be the more
+damaging outcome precisely because the number looks like a measurement.
+
+The paragraph this produces, in the form the paper will use it:
+
+> Our baseline set contains no multipath on-demand protocol. AOMDV, the standard
+> such baseline, has no implementation in ns-3: the protocol is absent upstream,
+> and the only available third-party port — which we vendored, hardened across
+> five ns-3 releases and repaired to the point of compiling cleanly — fails to
+> establish multi-hop routes at all, delivering 0 % of offered traffic against
+> 16 % for stock AODV on an identical scenario while one-hop delivery works. We
+> traced the failure to the port's value-semantics translation of the original
+> ns-2 implementation's pointer-aliased routing table, and judged completing the
+> audit out of scope for this work. Rather than publish numbers from a baseline
+> we know to be broken, we state the gap: AntHocNet's multipath behaviour is
+> evaluated against single-path reactive and proactive baselines and a
+> geographic one, and any claim about its multipath advantage is relative to
+> those, not to a multipath competitor.
+
+### Deferred by design — the RL / DRL baseline
+
+An ACO-versus-RL comparison under one rigorous harness is uncommon and would be
+publishable ([#296](https://github.com/danieljoppi/AntHocNet/issues/296)'s third
+premise). It is nonetheless **out of scope until the statistics
+([#293](https://github.com/danieljoppi/AntHocNet/issues/293)) and realism
+([#295](https://github.com/danieljoppi/AntHocNet/issues/295)) epics land**, and
+the reason is not effort but validity: a learned baseline evaluated on the
+topologies, densities and speeds it trained on leaks, and a leaked comparison
+produces a number that survives review and is wrong — the generalisation of the
+Trustee critique (ACM CCS 2022). A leaky RL arm would be worse than no RL arm,
+because it would make a claim rather than leave a gap.
+
+What has to be true before it starts: multi-seed confidence intervals and paired
+tests in place (so a difference can be *called* rather than eyeballed), and the
+realism axes in place (so there are held-out scenario families to hold out).
+
+### Modern deployed baseline — decided, not skipped (item 4)
+
+Testbed-era mesh comparisons centre on OLSR vs BATMAN-adv vs Babel; OLSRv2 is
+RFC 7181 and Babel is RFC 8966. The epic's acceptance bar for this item is
+*deciding deliberately and recording why*, and the full survey — per protocol,
+with sources, probe dates and the questions it could not answer — is
+[**modern-baseline-survey.md**](modern-baseline-survey.md).
+
+| candidate | ns-3 availability (2026-08-13) | verdict |
+|---|---|---|
+| **Babel** (RFC 8966) | Not upstream; no upstream MR or issue; one 2022 TUM seminar-paper implementation with **no located public code** | no candidate arm exists |
+| **BATMAN-adv** | Not upstream; the ns-3 wiki's 2020 batman-adv project is paused/incomplete; the only port ([BATSEN](https://github.com/npowell3/BATSEN)) is ns-3.25, last commit **2018-05-11**, and implements the *pre-adv 2008 daemon*, a different protocol. batman-adv itself is layer 2 and so is not an `Ipv4RoutingProtocol` at all | wrong protocol, wrong layer, unmaintained |
+| **OLSRv2** (RFC 7181) | Not upstream (ns-3's `olsr` documents itself as RFC 3626 and explicitly not RFC 7181). A complete-looking ~7.3k-line `olsrv2` + ~1.9k-line `nhdp` pair exists on an ns-3.43 **archival** NIST branch, GPLv2, with `AssignStreams` | the near miss — real code, no maintainer |
+| *(found by the survey)* **802.11s HWMP** | **In stock ns-3** (`src/mesh`), maintained, mac80211-compatible message formats — and deployed in the Linux kernel | not a drop-in: layer-2 install path, IP-layer overhead counters would read zero, and the model omits path maintenance |
+
+**Decision: write the threat-to-validity paragraph, do not write the code — and
+record the trigger that reverses it.** The reasoning, in the order that decided
+it: nothing available today is both maintained and buildable on this matrix;
+[#414](https://github.com/danieljoppi/AntHocNet/pull/414) is direct, recent
+evidence that a third-party port which compiles is not a baseline that works,
+and a *subtly* broken modern arm would be worse than an absent one; and upstream
+ns-3 has an open draft `manet` module (MR
+[!2887](https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2887), 2026-06-03)
+whose stated plan includes **an OLSRv2 model and a B.A.T.M.A.N. model**, so
+adopting an archival port now would take on maximum maintenance at the moment it
+is most likely to be superseded.
+
+That last point is the part that differs from the epic's expectation, and it
+changes the character of the decision: the answer is **not yet**, not
+**unavailable**. The survey's
+[reversal triggers](modern-baseline-survey.md#what-would-reverse-this-decision)
+are concrete and cheap to re-check — two directory probes and one API query — and
+are worth re-running before any campaign that will publish a baseline
+comparison.
+
+### The resulting threat to validity
+
+Stated once, plainly, so it can be quoted into a paper and weighed by a reader:
+
+> The comparison set is the one the original AntHocNet publications used
+> (2004–2005: AODV, extended here with OLSR and DSDV to cover the proactive
+> link-state and distance-vector classes), plus one geographic protocol. AODV,
+> OLSR and DSDV are stock ns-3 implementations, which makes them reproducible
+> but also inherits their documented model gaps. GPSR is a third-party port
+> vendored and repaired for this work, and it runs with a perfect location
+> service, so its numbers bound geographic routing from above rather than
+> reproducing a deployed system. **No modern deployed link-state or
+> distance-vector protocol — Babel, BATMAN-adv, OLSRv2 — is compared**, because
+> none had a maintained, buildable ns-3 implementation when this work was done
+> (surveyed August 2026). **No multipath protocol is compared**, because the
+> only available AOMDV port does not route. Results should therefore be read as
+> AntHocNet measured against the protocols its own literature compares against,
+> plus a geographic check and a global-knowledge upper bound — not as a
+> positioning against the current state of practice in deployed mesh routing.
+
+Each clause of that paragraph has a retirement condition, and they are tracked
+rather than assumed permanent:
+
+| clause | retired by |
+|---|---|
+| no modern deployed protocol | ns-3 MR [!2887](https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2887) merging with an OLSRv2 or B.A.T.M.A.N. model, or any other [reversal trigger](modern-baseline-survey.md#what-would-reverse-this-decision) |
+| no multipath protocol | the `Path*` aliasing audit in [`ns3/aomdv/README.md`](../../ns3/aomdv/README.md) being completed and the arm passing a multi-hop smoke run |
+| geographic arm is unvalidated | phase 3 measuring `gpsr` and its results being checked against published GPSR behaviour |
+| no upper bound | [#415](https://github.com/danieljoppi/AntHocNet/issues/415) landing the oracle control |
+| no learned baseline | [#293](https://github.com/danieljoppi/AntHocNet/issues/293) + [#295](https://github.com/danieljoppi/AntHocNet/issues/295) landing, then #296 item 5 |
 
 ## Mobility models (`--mobility`, [#61](https://github.com/danieljoppi/AntHocNet/issues/61))
 

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -1117,15 +1117,43 @@ not a blank column.
 >    floor 1.133), so the honest figure is AntHocNet − AODV in the same run
 >    (today: **+0.096 used-paths, +0.070 entropy bits**). No (rate, window)
 >    pair drives the floor to 1.0 while keeping the cells fed.
-> 3. `scenario_check.py` enforces the split: the absolute 1.10 single-path
->    bound applies whenever `path_div_window_s > 2`; at the cell's window it
->    relaxes to a 1.50 sanity ceiling (a baseline above that means the window
->    is not churn-free at the offered rate and the cell is unreadable).
+> 3. `scenario_check.py` reads rule 2 rather than an absolute bound. Per cell
+>    it measures the single-path floor *in that run* as the largest `divUsed`
+>    over aodv/olsr/dsdv, reports AntHocNet's excess over it once, and **WARNs**
+>    — it does not FAIL — when the floor is itself churn-dominated (> 1.10) or
+>    when AntHocNet fails to exceed a clean floor. The severity is deliberate:
+>    `divUsed` is accumulated off the WifiMac `AckedMpdu` trace into its own
+>    counter and shares no accumulator with any published metric, so a
+>    churn-inflated diversity figure cannot move PDR, delay, delay99, NRL or
+>    energy. What still FAILs: a baseline above 1.50 at a churn-free window,
+>    and every arithmetic invariant (`div < 1`, `div > divMax`, `div == 0` at
+>    non-zero PDR, `entropy > log2(divMax)`).
+>
+>    *An absolute threshold was tried and refuted.* The floor is a function of
+>    the scenario knobs, not a constant: aodv/olsr read 1.000/1.000 at
+>    `windowS=2`, 1.190/1.198 at 6 and 1.311/1.322 at 10, and 1.133 at
+>    `windowS=2` once the rate goes to 8 pkt/s. No constant is both satisfiable
+>    and informative — the old 1.10 rule FAILed the three control rows in
+>    **14 of 14** v1.5.0 campaign cells while passing the one row least worth
+>    trusting.
+>
+> **What the v1.5.0 campaign's 14 cells say (all `windowS=10`): no diversity
+> claim survives at the paper window, and the sign is the wrong way round.**
+> AntHocNet's excess over the in-run floor is **negative in 14/14 cells**,
+> −0.061 to −0.144 (anthocnet 1.236–1.306 against floors 1.339–1.405). A
+> multipath protocol scoring *below* three protocols that install one route per
+> destination is not a calibration problem; at this window the column is
+> measuring route churn, and the baselines simply churn more. This strengthens
+> the "not publishable" verdict above rather than softening it.
 >
 > The per-packet-pair concurrency counter remains the clean long-term
 > instrument that would retire the floor comparison; #230 keeps it as the
-> follow-up. `path_hops_*` and `jain_pkts` are unaffected by all of this and
-> readable from any cell.
+> follow-up. Its shape is now specific: count **interleaving** (a next-hop
+> sequence that returns to a previously-used hop, a→b→a) instead of distinct
+> hops per window. Route replacement is monotone and never returns, so that
+> counter has an a-priori control of exactly **0** for aodv/olsr/dsdv — the
+> falsifiable control `path_div_used` never had. `path_hops_*` and `jain_pkts`
+> are unaffected by all of this and readable from any cell.
 
 - **Reactive protocols read one hop high on route-discovery packets.** A
   protocol with no route yet bounces the packet through the loopback device to

--- a/docs/benchmarks/modern-baseline-survey.md
+++ b/docs/benchmarks/modern-baseline-survey.md
@@ -1,0 +1,339 @@
+# Modern deployed baselines — the ns-3 availability survey
+
+**The question:** the 2026 literature review behind
+[#296](https://github.com/danieljoppi/AntHocNet/issues/296) observed that
+testbed-era MANET comparisons centre on OLSR vs BATMAN-adv vs Babel, and that a
+comparison set of AODV/OLSR/DSDV alone increasingly reads as a strawman set.
+Item 4 of that epic asks whether one of those **modern deployed** protocols can
+join this harness, and sets the acceptance bar at *deciding deliberately and
+recording why*. This page is that record: the survey, its evidence, the
+decision, and the conditions that would reverse it.
+
+[← Benchmark index](../benchmarks.md) · [Methodology](methodology.md) ·
+[Baselines framing](methodology.md#baselines-what-each-arm-is-for-296) ·
+[Roadmap](../roadmap.md)
+
+> **Verdict (2026-08-13): write the threat-to-validity paragraph, do not write
+> the code — but the "why not" is *timing*, not absence.** No modern deployed
+> link-state or distance-vector protocol has a maintained, currently-building
+> ns-3 implementation today. But upstream ns-3 opened a draft `manet` module in
+> June 2026 whose stated plan includes **an OLSRv2 model and a B.A.T.M.A.N.
+> model**, and a complete-looking OLSRv2 module already exists on an *archival*
+> NIST research branch. So the decision carries an explicit
+> [revisit trigger](#what-would-reverse-this-decision) rather than a flat
+> "unavailable", and the threat-to-validity paragraph is written to be retired,
+> not defended.
+
+## Why the survey had to be honest rather than quick
+
+[#414](https://github.com/danieljoppi/AntHocNet/pull/414) is the reason this
+page exists in this form. The AOMDV spike vendored a third-party port, fixed
+nine defects in it, got it compiling **clean on all five ns-3 versions in the CI
+matrix** — and then measured **0 % PDR** against stock AODV's 16 % on an
+identical scenario. A port that compiles is not a baseline that works, and the
+distance between those two states was nine defects and a smoke run.
+
+That result sets the evidentiary bar for item 4. "Somebody published an ns-3
+module for it" is not evidence that an arm is feasible; the questions that
+matter are *who maintains it*, *against which ns-3 version*, *is it validated
+against anything*, and *what would this project have to repair before the
+number it produces could be published*. The sections below answer those
+questions per protocol, with the source for each answer.
+
+## Method, and what it could not check
+
+Checked on **2026-08-13**:
+
+- **Stock ns-3 content** — direct probes of module directories on the
+  `nsnam/ns-3-dev-git` GitHub mirror's `master` branch (a read-only mirror of
+  the canonical `gitlab.com/nsnam/ns-3-dev`), plus the module's own
+  documentation source (`src/<module>/doc/*.rst`).
+- **Upstream trajectory** — the ns-3 GitLab REST API, for merge requests and
+  issues matching each protocol name (all states).
+- **Third-party ports** — repository contents and commit history via GitHub.
+
+**What this could not check, stated because it bounds the verdict.** The ns-3
+web properties are unreachable from these sessions: `www.nsnam.org` (wiki,
+rendered model library), `apps.nsnam.org` (**the ns-3 App Store — the canonical
+index of contributed modules**), `dl.acm.org`, `net.in.tum.de` and
+`groups.google.com` all return an egress-proxy block. So:
+
+- The App Store catalogue was **not** browsed directly; its coverage here rests
+  on search results and on the absence of any upstream issue/MR pointing at such
+  a module. The same caveat was recorded in the
+  [original spike](https://github.com/danieljoppi/AntHocNet/issues/296#issuecomment-5245550798)
+  — *two minutes of human browsing would close it*, and that remains true.
+- Two papers below are cited from their metadata and from the ns-3 merge request
+  that references them, not from their full text.
+
+Everything else on this page was read from a primary source and is quoted or
+linked as such.
+
+## What stock ns-3 ships
+
+Probing `src/<module>/CMakeLists.txt` on `ns-3-dev` `master`:
+
+| module | present? | note |
+|---|---|---|
+| `aodv`, `olsr`, `dsdv`, `dsr` | ✅ | the classical set — this project's [replication anchors](methodology.md#replication-anchors--aodv--olsr--dsdv) are three of these |
+| `mesh` | ✅ | IEEE 802.11s: peering management + **HWMP**. See [below](#the-second-thing-the-epic-did-not-predict-80211s-hwmp-is-already-in-stock-ns-3) |
+| `babel`, `batman`, `batmand`, `olsrv2`, `nhdp` | ❌ (404) | no modern deployed L3 protocol |
+| `aomdv`, `gpsr` | ❌ (404) | why both are vendored here at all ([#414](https://github.com/danieljoppi/AntHocNet/pull/414), [#412](https://github.com/danieljoppi/AntHocNet/pull/412)) |
+
+And the ns-3 OLSR model's own documentation is explicit about its vintage:
+
+> The implementation is based on OLSR Version 1 (RFC 3626) and it is *not*
+> compliant with OLSR Version 2 (RFC 7181) or any of the Version 2 extensions.
+>
+> — [`src/olsr/doc/olsr.rst`](https://raw.githubusercontent.com/nsnam/ns-3-dev-git/master/src/olsr/doc/olsr.rst)
+
+That file's *Scope and Limitations* also records two gaps worth carrying into
+the [anchors' quality-risk statement](methodology.md#replication-anchors--aodv--olsr--dsdv):
+the model does not respond to interface up/down notifications, and — unlike the
+NS-2 original it was ported from — "does not yet support MAC layer feedback as
+described in RFC 3626".
+
+## Babel (RFC 8966)
+
+| question | answer | source |
+|---|---|---|
+| Upstream ns-3 module? | **No** — `src/babel` absent from `ns-3-dev` master | direct probe, 2026-08-13 |
+| Upstream work in progress? | **No** — zero merge requests and zero issues matching "babel" in the ns-3 GitLab project, any state | ns-3 GitLab API, 2026-08-13 |
+| Maintained contrib module? | **None found** | searches returned no repository |
+| Academic port? | **One paper**, no located code | von Ehren, Andre & Wiedner, *An Implementation of the Babel Routing Protocol for ns-3*, TUM Seminar IITM proceedings NET-2022-01-1 (2022), <https://www.net.in.tum.de/fileadmin/TUM/NET/NET-2022-01-1/NET-2022-01-1_15.pdf> |
+
+The paper describes a new `babel` module — example scenario, helper, protocol
+implementation, structured after ns-3's `olsr` — written because Babel had no
+prior ns-3 implementation. Its PDF host is egress-blocked from these sessions,
+so that description comes from the search index rather than from the text, and
+**no public repository for the implementation was located**. A single-author
+seminar-paper module with no released code, no maintainer and no stated ns-3
+version is not a candidate arm; it is a lead for someone with web access to
+follow up, and it is recorded here as such rather than as a negative result.
+
+Babel itself is not in doubt — RFC 8966 (2021), with two production
+implementations (`babeld`, the reference; and BIRD's). The gap is entirely on
+the simulator side.
+
+## BATMAN / batman-adv
+
+| question | answer | source |
+|---|---|---|
+| Upstream ns-3 module? | **No** — `src/batman`, `src/batmand` absent | direct probe, 2026-08-13 |
+| Upstream work in progress? | **No** open MR or issue matching "batman" | ns-3 GitLab API, 2026-08-13 — but see [`manet` module](#the-thing-the-epic-did-not-predict-upstream-ns-3-is-building-a-manet-module-now), whose plan names one |
+| Past ns-3 effort? | **NSOC 2020 project, targeted batman-adv for Freifunk, paused incomplete** | ns-3 wiki `NSOC2020Routing` (page itself egress-blocked; status read from the search summary — second-hand, flagged) |
+| Third-party port? | **BATSEN** (`npowell3/BATSEN`), ns-3.25, **last commit 2018-05-11**, 5 commits total | <https://github.com/npowell3/BATSEN> |
+
+Two facts disqualify BATSEN as a modern-deployed baseline even before its age is
+considered.
+
+**It is the wrong protocol.** Its own header states it is "based on the BATMAND
+module and modified for BATMAND-0.3.2", implementing
+`draft-openmesh-b-a-t-m-a-n-00` — the 2008 *daemon*-era BATMAN, two protocol
+generations before what is deployed. The Linux kernel's own documentation draws
+exactly this line:
+
+> Unlike the batman daemon, which exchanges information using UDP packets and
+> sets routing tables, batman-advanced operates on ISO/OSI Layer 2 only and uses
+> and routes (or better: bridges) Ethernet Frames.
+>
+> — [`Documentation/networking/batman-adv.rst`](https://raw.githubusercontent.com/torvalds/linux/master/Documentation/networking/batman-adv.rst)
+
+**And the deployed protocol is structurally incompatible with the harness's arm
+shape.** batman-adv is a layer-2 kernel module (`net/batman-adv`; its Kconfig builds the
+BATMAN V protocol — ELP + OGMv2 + a throughput metric — in by default alongside
+BATMAN IV), so it is not an `Ipv4RoutingProtocol` at all. Every arm in `anthocnet-compare` is installed
+through `InternetStackHelper::SetRoutingHelper`, and the overhead metrics
+(`nrl`, `nrl_bytes`) count routing-control traffic at the IP layer. A layer-2
+mesh protocol would need a different install path *and* a different overhead
+counting point, which means its overhead column would not be comparable with the
+other arms' — the exact failure mode the [metrics](metrics.md) page warns about
+for TCP.
+
+## OLSRv2 (RFC 7181) — the near miss
+
+This is the one that nearly changed the recommendation, and the detail is
+recorded because the next person to ask this question should start here.
+
+| question | answer | source |
+|---|---|---|
+| Upstream ns-3 module? | **No** — `src/olsrv2` absent from `ns-3-dev` master; the stock `olsr` model states it is not RFC 7181 compliant | direct probe + `olsr.rst`, 2026-08-13 |
+| Does an ns-3 OLSRv2 implementation exist at all? | **Yes** — `src/olsrv2` on `usnistgov/psc-ns3`, branch `icns3-2025-nhdp` | <https://github.com/usnistgov/psc-ns3/tree/icns3-2025-nhdp> |
+| Base ns-3 version | **ns-3.43** (inside this project's 3.36–3.48 matrix) | branch README |
+| Size | **~7,330 lines** across 9 model/helper files, plus a companion `src/nhdp` of **~1,915 lines** | line counts, 2026-08-13 |
+| Tests | **5 suites** declared: regression, hello-regression, TC-regression, header, routing-protocol, plus a bug-780 case | `src/olsrv2/CMakeLists.txt` |
+| Licence | **GPL-2.0-only**, headers inherited from ns-3's `olsr` (Ros / Carneiro) — matches this repo | `olsrv2-routing-protocol.h` |
+| `AssignStreams`? | **Yes** (`RoutingProtocol::AssignStreams`) — the [#352](https://github.com/danieljoppi/AntHocNet/issues/352) stream-pinning requirement is met | `olsrv2-routing-protocol.{h,cc}` |
+| Maintained? | **No.** The branch is *by its authors' own statement* archival | branch README |
+
+The README says it plainly:
+
+> This branch is intended to be archival only. Some updated version of NHDP is
+> likely to be contributed to ns-3-dev in the future.
+
+The branch exists to reproduce the figures of Black & Henderson, *A Neighborhood
+Discovery Protocol (NHDP) Model for ns-3*, Proceedings of the 2025 International
+Conference on ns-3 ([doi:10.1145/3747204.3747218](https://dl.acm.org/doi/10.1145/3747204.3747218);
+paywalled and egress-blocked here — cited from its metadata and from the ns-3
+merge request that references it). The branch was **last updated 2025-04-30**;
+`psc-ns3`'s own default branch was last updated **2024-01-10** and contains
+neither `nhdp` nor `olsrv2` (both probe 404 on `master`, `main`, `psc-dev` and
+`psc-ns3.43`).
+
+So this module is: complete-looking, correctly licensed, harness-compatible in
+the one respect that usually breaks ports (RNG stream pinning), and **not
+maintained by anyone**, on a branch its authors have labelled archival, with the
+protocol itself (as opposed to its NHDP substrate) not the subject of the paper
+the branch supports and therefore of unknown validation status. Adopting it
+would mean this project becomes the maintainer of a ~9,200-line RFC 7181
+implementation across five ns-3 versions — the AOMDV situation, at four times
+the size, with a *newer* base and better hygiene but the same structural
+position: a third-party research port with no upstream to diff against.
+
+## The thing the epic did not predict: upstream ns-3 is building a `manet` module now
+
+The epic's premise was that item 4's likely outcome is a threat-to-validity
+paragraph *because nothing exists*. The survey found something different: the
+gap is being closed upstream, in the open, right now.
+
+**MR !2887 — "Draft: manet: Add manet module and NHDP model"**
+(<https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2887>), author Tom
+Henderson, opened **2026-06-03**, last updated 2026-06-12, still **open and
+draft** as of 2026-08-13. It proposes a new `manet` module seeded with an RFC
+6130 NHDP model ("an evolution of the model described in" the ICNS3 2025 paper
+above), and states the plan for populating it:
+
+> - Move PacketBB from src/network/utils here
+> - Move `src/olsr`, `src/aodv`, `src/dsr`, `src/dsdv` here
+> - Add AODVv2 model from [this paper](https://dl.acm.org/doi/10.1145/3747204.3747219) here, when ready
+> - **Add an OLSRv2 model**
+> - **Add a B.A.T.M.A.N. model**
+
+**MR !2975 — "Draft: Proposed new RFC5444 (PacketBB) API"**
+(<https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2975>), same author, opened
+**2026-08-04** — nine days before this survey — reworks the RFC 5444 message
+encoding that NHDP and OLSRv2 both sit on. Its own description says it is "just
+an API proposal (no implementation yet)".
+
+Neither is merged. Both are drafts by a single ns-3 maintainer, on a track whose
+prior art (the 2025 NHDP paper) took a year to reach a draft MR. Nothing here is
+a schedule this project can plan a campaign around — but it is decisive for the
+*shape* of the decision: writing our own OLSRv2 or BATMAN arm now would be
+building, unmaintained and alone, the thing upstream intends to ship
+maintained. That is the worst possible time to start.
+
+## The second thing the epic did not predict: 802.11s HWMP is already in stock ns-3
+
+The epic named Babel, BATMAN-adv and OLSRv2. It did not name the one *deployed*
+mesh routing protocol that ns-3 already ships and maintains: **HWMP**, the
+Hybrid Wireless Mesh Protocol of IEEE 802.11s, in `src/mesh`.
+
+It has a real claim to the "modern deployed" slot. The Linux kernel implements
+802.11s including HWMP in `net/mac80211` (`mesh_hwmp.c`, originally open80211s,
+with copyright lines running to 2026), so it is deployed in every Linux mesh
+device; and ns-3's model is maintained upstream, was updated to the 802.11s-2012
+packet formats in ns-3.23, and claims "Linux kernel mac80211 layer compatible
+message formats" plus a custom Wireshark dissector
+([`src/mesh/doc/source/mesh-design.rst`](https://raw.githubusercontent.com/nsnam/ns-3-dev-git/master/src/mesh/doc/source/mesh-design.rst)).
+
+Three things stop it from being a drop-in arm, and they are the reasons it is
+recorded here rather than scheduled:
+
+1. **Wrong layer for this harness.** `MeshPointDevice` is a layer-2 net device
+   installed by `MeshHelper` at the device layer; it is not an
+   `Ipv4RoutingProtocol` and cannot be installed through the
+   `InternetStackHelper::SetRoutingHelper` path every existing arm uses. The
+   change is to the harness's topology construction, not to a `--protocols`
+   switch.
+2. **Its overhead is not counted where the other arms' overhead is counted.**
+   HWMP's PREQ/PREP/PERR are 802.11 management frames, not IP packets, so
+   `nrl` / `nrl_bytes` — IP-layer counters — would read **zero** for an HWMP arm
+   while it is in fact sending control traffic. A protocol whose overhead metric
+   is structurally zero is worse than no arm: it is a wrong number with a
+   plausible shape.
+3. **A known model gap that would bias the comparison against it.** The ns-3
+   model's own *Unsupported features* list includes "Path maintenance (sending
+   PREQ proactively before a path expires)", and the design doc spells out the
+   consequence: "active routes may time out and need to be rebuilt, causing
+   packet loss". Under mobility — precisely this project's regime — that gap
+   penalises HWMP for a model limitation rather than a protocol property.
+
+None of these is fatal; all three are work, and item (2) is measurement work of
+the kind [#229/#230](https://github.com/danieljoppi/AntHocNet/issues/229) taught
+this project to take seriously. It is the strongest candidate the survey found
+for a *future* modern arm, and it is written down here so the next attempt does
+not start from the epic's three-name list.
+
+## The decision
+
+**Write the paragraph, not the code — with a named trigger for revisiting.**
+
+Reasoning, in the order that decided it:
+
+1. **No option available today is both maintained and buildable on this matrix.**
+   Babel has no located code; BATMAN's only ns-3 artefact is a 2018, ns-3.25,
+   wrong-generation daemon port; OLSRv2's only implementation is archival by its
+   authors' own statement and depends on a second archival module.
+2. **The AOMDV evidence is direct and recent.** A vendored port that compiled
+   clean on five ns-3 versions still delivered 0 % PDR, and only a smoke run
+   distinguished "builds" from "routes"
+   ([#414](https://github.com/danieljoppi/AntHocNet/pull/414)). Every candidate
+   here is a third-party research port of the same species. Shipping a second
+   broken arm — or worse, one broken *subtly* enough to produce plausible
+   numbers — would damage the comparison more than the missing arm does.
+3. **Upstream intends to ship OLSRv2 and BATMAN models** (MR !2887). Adopting an
+   archival port now maximises the maintenance we take on at exactly the moment
+   it is most likely to be superseded.
+4. **The honest limitation is cheap and the reader can price it.** A stated
+   threat to validity costs a paragraph and lets a reviewer weight the results
+   correctly. A silently-broken modern arm costs the credibility of every number
+   on the page.
+
+The paragraph itself lives with the rest of the baseline framing, in
+[methodology.md](methodology.md#the-resulting-threat-to-validity).
+
+**What was explicitly *not* decided:** that a modern baseline is unnecessary. It
+is necessary, and its absence is the largest single weakness in this project's
+comparison set. This is a decision about *when*, made on evidence about *what
+exists*, and it is written to be overturned.
+
+## What would reverse this decision
+
+Any one of these, in decreasing order of likelihood:
+
+| trigger | what to do | how to check |
+|---|---|---|
+| **ns-3 MR !2887 merges** and a `manet` module lands with an OLSRv2 or B.A.T.M.A.N. model | Adopt it as an upstream module — the same standing as `aodv`/`olsr`/`dsdv`, no vendoring, no maintenance burden. This is the outcome this decision is waiting for. | <https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2887> |
+| **NHDP + OLSRv2 are contributed to `ns-3-dev`** by any route (the branch README says an updated NHDP "is likely to be contributed") | Same as above; OLSRv2 is the highest-value modern arm because it is the direct RFC 7181 successor to a protocol already in the comparison set, which makes the pairing a controlled contrast rather than a new axis. | probe `src/olsrv2` and `src/nhdp` on `ns-3-dev` master |
+| **A maintained contrib module appears in the ns-3 App Store** for any of the three | Evaluate to the [#414](https://github.com/danieljoppi/AntHocNet/pull/414) bar: build on all five matrix versions, `AssignStreams` present, and a **smoke run with non-zero multi-hop PDR before anything else** | <https://apps.nsnam.org/> — *not checkable from agent sessions; needs a human* |
+| **The harness grows layer-2 arm support** (device-layer install + a link-layer control-traffic counter) | 802.11s HWMP becomes the cheapest modern arm available, since the model is already in stock ns-3 and maintained | this repo |
+| **Someone releases the TUM Babel module** | Evaluate to the same bar; expect it to be a first-release research module, i.e. the AOMDV risk profile | search for a repository; the paper's authors are the contact |
+
+The cheap standing check is two probes and one API query — the commands are in
+[Method](#method-and-what-it-could-not-check) — and it is worth re-running at
+the start of any campaign that will publish a baseline comparison.
+
+## Sources
+
+| # | source | what it establishes |
+|---|---|---|
+| 1 | [`ns-3-dev-git/src/olsr/doc/olsr.rst`](https://raw.githubusercontent.com/nsnam/ns-3-dev-git/master/src/olsr/doc/olsr.rst) | ns-3's OLSR is RFC 3626, explicitly *not* RFC 7181; its scope/limitation list |
+| 2 | `ns-3-dev-git` `src/` module probes (2026-08-13) | no `babel`/`batman`/`batmand`/`olsrv2`/`nhdp`/`aomdv`/`gpsr` upstream; `aodv`/`olsr`/`dsdv`/`dsr`/`mesh` present |
+| 3 | [ns-3 GitLab MR !2887](https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2887) (opened 2026-06-03, draft) | upstream `manet` module + NHDP; plan names OLSRv2 and B.A.T.M.A.N. models |
+| 4 | [ns-3 GitLab MR !2975](https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2975) (opened 2026-08-04, draft) | RFC 5444 API rework — the encoding NHDP/OLSRv2 depend on; API proposal only |
+| 5 | [`usnistgov/psc-ns3` @ `icns3-2025-nhdp`](https://github.com/usnistgov/psc-ns3/tree/icns3-2025-nhdp) | an ns-3.43 OLSRv2 (~7.3k lines) + NHDP (~1.9k lines), GPL-2.0-only, `AssignStreams` present, branch "archival only", last updated 2025-04-30 |
+| 6 | Black & Henderson, *A Neighborhood Discovery Protocol (NHDP) Model for ns-3*, ICNS3 2025, [doi:10.1145/3747204.3747218](https://dl.acm.org/doi/10.1145/3747204.3747218) | the paper that branch supports (metadata only — paywalled and egress-blocked) |
+| 7 | [`npowell3/BATSEN`](https://github.com/npowell3/BATSEN) + its `batmand-routing-protocol.cc` header | ns-3.25 BATMAN port, `draft-openmesh-b-a-t-m-a-n-00` / BATMAND-0.3.2 lineage, last commit 2018-05-11 |
+| 8 | [Linux `Documentation/networking/batman-adv.rst`](https://raw.githubusercontent.com/torvalds/linux/master/Documentation/networking/batman-adv.rst) and [`net/batman-adv/Kconfig`](https://raw.githubusercontent.com/torvalds/linux/master/net/batman-adv/Kconfig) | batman-adv is layer 2 and distinct from the batman daemon; BATMAN V is the current generation |
+| 9 | [`ns-3-dev-git/src/mesh/doc/source/mesh-design.rst`](https://raw.githubusercontent.com/nsnam/ns-3-dev-git/master/src/mesh/doc/source/mesh-design.rst) | 802.11s HWMP in stock ns-3: supported features, mac80211-compatible formats, and the missing path maintenance |
+| 10 | [Linux `net/mac80211/mesh_hwmp.c`](https://raw.githubusercontent.com/torvalds/linux/master/net/mac80211/mesh_hwmp.c) | HWMP is deployed and maintained in the Linux kernel (copyright to 2026) |
+| 11 | von Ehren, Andre & Wiedner, *An Implementation of the Babel Routing Protocol for ns-3*, TUM NET-2022-01-1 (2022), <https://www.net.in.tum.de/fileadmin/TUM/NET/NET-2022-01-1/NET-2022-01-1_15.pdf> | the only located Babel-for-ns-3 work; no released code found (host egress-blocked) |
+| 12 | ns-3 GitLab issues/MR search for "babel", "batman" (2026-08-13) | zero upstream tickets for either |
+| 13 | ns-3 wiki `NSOC2020Routing` | a batman-adv-for-ns-3 project existed and is paused/incomplete (**second-hand**: page egress-blocked, read from search summary) |
+| 14 | [#414](https://github.com/danieljoppi/AntHocNet/pull/414) · [`ns3/aomdv/README.md`](../../ns3/aomdv/README.md) | the local evidence that a compiling third-party port is not a working arm |
+
+Refs [#296](https://github.com/danieljoppi/AntHocNet/issues/296)
+([item 4](https://github.com/danieljoppi/AntHocNet/issues/296#issuecomment-5275396168)),
+[#412](https://github.com/danieljoppi/AntHocNet/pull/412),
+[#414](https://github.com/danieljoppi/AntHocNet/pull/414),
+[#415](https://github.com/danieljoppi/AntHocNet/issues/415).


### PR DESCRIPTION
Two independent pieces of work that both close v1.5.0 loose ends. No protocol code changes.

## 1. The #230 path-diversity gate was training everyone to skim past FAIL

`scenario_check.py results` ran on **14 campaign cells** this session (6 grid re-baseline + 8 phase-2). **All 14 returned FAIL**, and every FAIL was the same three findings — `path_div_used` above 1.10 for aodv, olsr, dsdv. Zero anthocnet FAILs anywhere. Each time the response was "known #230, non-blocking, proceed." That is exactly what the skill's own guidance warns about: *a check that cries wolf gets ignored, and then it is not a gate.*

**Diagnosis — the metric is wrong, and the severity was wrong too.** The decisive number: **AntHocNet reads *below* the single-path floor in 14/14 cells** (excess −0.061 to −0.144; anthocnet 1.236–1.306 vs floors 1.339–1.405). A multipath protocol scoring under three protocols that install one route per destination is not a threshold problem — at `windowS=10` the column measures route churn, and the baselines churn more.

**An absolute threshold was tried and refuted**: the floor is a function of the knobs, not a constant — aodv/olsr read 1.000/1.000 at `windowS=2`, 1.190/1.198 at 6, 1.311/1.322 at 10, and 1.133 at `windowS=2` when the rate goes to 8 pkt/s. No constant is both satisfiable and informative.

**The fix**: per cell, measure the single-path floor *in that run* (max `divUsed` over the three baselines), report AntHocNet's excess over it **once**, and WARN — not FAIL — when the floor is churn-dominated or AntHocNet fails to clear a clean floor. The severity is justified by the code paths: `divUsed` accumulates off the WifiMac `AckedMpdu` trace into its own counter and shares no accumulator with FlowMonitor or the energy model, so a churn-inflated diversity figure cannot move a published number. Still FAILing: baseline > 1.50 at a churn-free window, and every arithmetic invariant.

**The validation that matters** — on the historical `30201145972` campaign CSV, 18 diversity FAILs become 6 WARNs and the **#229 drop-accounting FAIL (dense-small/dsdv, −11.46 pp) survives as the only FAIL**. The defect that proved this gate's worth still stops the run.

14 cells before → after: `FAIL (3f)` → `WARN (0f), exit 0`, each with its floor, floor-protocol and excess named. 83 test cases (+2 net, 6 rewritten), each rule with a fires case *and* a stays-quiet case.

**Follow-up instrument, now specified**: count **interleaving** (`a→b→a`) rather than distinct hops per window. Route replacement is monotone and never returns, so that counter has an a-priori control of exactly **0** for the single-path baselines — the falsifiable control `path_div_used` never had. Needs a CI dispatch to validate, so it is not in this PR.

## 2. #296 items 4 and 6 — the baselines framing and the modern-baseline decision

`methodology.md` gains **"Baselines: what each arm is for"** classifying every arm with provenance and quality risk: replication anchors (AODV/OLSR/DSDV — with the sharper point that **only AODV literally replicates** [1], which compared AODV-with-local-repair alone; OLSR/DSDV are this project's class-coverage additions), competitive frontier (GPSR — a repaired third-party port, and its GOD location service makes the arm an *upper bound on GPSR* rather than a deployed-GPSR result), upper bound (the oracle, #415), **attempted gap (AOMDV — with the paper-ready threat-to-validity prose #296's acceptance asked for)**, and deferred (RL, leakage-gated).

**Item 4 verdict: write the paragraph, not the code — because of timing, not absence.** The dated survey (new `modern-baseline-survey.md`) found two things that contradict the epic's premises:

- **Upstream ns-3 is closing this gap right now.** MR [!2887](https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/2887) creates a `manet` module seeded with NHDP and explicitly plans OLSRv2 and BATMAN models; MR !2975 reworks the RFC 5444 encoding both need. So the answer is "not yet, with a named trigger" — and it argues *against* porting the archival `usnistgov/psc-ns3` OLSRv2 branch now.
- **802.11s HWMP already ships stock** (`src/mesh`, maintained, deployed in the Linux kernel) — the epic's three-name list missed it. Not a drop-in (layer-2 install, so IP-layer NRL reads zero; the model omits path maintenance) but recorded as the cheapest future modern arm.

Babel: no ns-3 module, zero MRs/issues. BATMAN-adv: no module; the only port is `npowell3/BATSEN`, ns-3.25, last commit 2018, and it implements the pre-`adv` daemon draft — plus batman-adv is layer-2 by design, so not an `Ipv4RoutingProtocol`.

## Verification

`check-headers.py` 0 problems (113 files), `check-links.py` 0 problems (77 files), `test_scenario_check.py` **83 cases passed**, `ruff` clean. The third commit aligns `metrics.md`'s #230 resolution block with the new gate behaviour (it still described the removed 1.10 rule) and indexes the survey page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtKHtuMwTUY8uBBCJceDY)_